### PR TITLE
Fixed the broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Follow this guide to setup your development machine.
 
 ## Contribution guidelines
 
-If you are interested in contributing to EvalAI, follow your [contribution guidelines](https://github.com/Cloud-CV/EvalAI/blob/development/CONTRIBUTING.md).
+If you are interested in contributing to EvalAI, follow your [contribution guidelines](https://github.com/Cloud-CV/EvalAI/blob/master/CONTRIBUTING.md).
 
 [git]: https://git-scm.com/downloads
 [virtualenv]: https://virtualenv.pypa.io/


### PR DESCRIPTION
Changed the link in [readme.md](https://github.com/Cloud-CV/EvalAI/blob/master/README.md) to  https://github.com/Cloud-CV/EvalAI/blob/master/CONTRIBUTING.md