### PR TITLE
Challenges: upload_to path fixed for test_annotation field

### DIFF
--- a/apps/challenges/models.py
+++ b/apps/challenges/models.py
@@ -80,7 +80,7 @@ class ChallengePhase(TimeStampedModel):
         null=True, blank=True, verbose_name="End Date (UTC)")
     challenge = models.ForeignKey('Challenge')
     is_public = models.BooleanField(default=False)
-    test_annotation = models.FileField(upload_to="testAnnotations")
+    test_annotation = models.FileField(upload_to="test_annotations")
     max_submissions_per_day = models.PositiveIntegerField(default=100000)
     max_submissions = models.PositiveIntegerField(default=100000)
 


### PR DESCRIPTION
This PR corrects the mistake done in PR #373 where the path of `test_annotations` was modified. Undoing that in this PR. 