### PR TITLE
Adding Sentry and File Logging for production.

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -215,6 +215,14 @@ LOGGING = {
             'class': 'logging.StreamHandler',
             'formatter': 'simple'
         },
+        'logfile': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': "/tmp/logfile",
+            'maxBytes': 50000,
+            'backupCount': 10,
+            'formatter': 'verbose'
+        },
         'mail_admins': {
             'level': 'ERROR',
             'class': 'django.utils.log.AdminEmailHandler',

--- a/settings/prod.py
+++ b/settings/prod.py
@@ -1,7 +1,7 @@
 from .common import *  # noqa: ignore=F405
 
 import os
-
+import raven
 
 DEBUG = False
 
@@ -27,7 +27,7 @@ DATADOG_API_KEY = os.environ.get('DATADOG_API_KEY')
 
 MIDDLEWARE += ['middleware.metrics.DatadogMiddleware', ]     # noqa
 
-INSTALLED_APPS += ('storages',)  # noqa
+INSTALLED_APPS += ('storages', 'raven.contrib.django.raven_compat')  # noqa
 
 AWS_STORAGE_BUCKET_NAME = "evalai"
 AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', '')
@@ -62,3 +62,21 @@ REST_FRAMEWORK_DOCS = {
 
 # Port number for the python-memcached cache backend.
 CACHES['default']['LOCATION'] = os.environ.get("LOCATION", "") # noqa: ignore=F405
+
+RAVEN_CONFIG = {
+    'dsn': os.environ.get('SENTRY_URL'),
+    # If you are using git, you can also automatically configure the
+    # release based on the git info.
+    'release': raven.fetch_git_sha(os.path.dirname(os.pardir)),
+}
+
+LOGGING['root'] = {                                     # noqa
+    'level': 'INFO',
+    'handlers': ['console', 'sentry', 'logfile'],
+}
+
+LOGGING['handlers']['sentry'] = {                       # noqa
+    'level': 'ERROR',
+    'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
+    'tags': {'custom-tag': 'x'},
+}


### PR DESCRIPTION
Log all debug data to a file because storage is cheap.
Log only errors on Sentry because only 10,000 event per month for free :(