### PR TITLE
Frontend(gulp): Bind 'dev' and 'watch' task together.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,23 +61,14 @@ Follow this guide to setup your development machine.
     bower install
     ```
 
-8. To build static files(development) type
+8. Now to connect to dev server at http://127.0.0.1:8888 (for serving frontend)
 
     ```
-    gulp dev
+    gulp dev:runserver
     ```
 
-9. That's it, Now to connect to dev server at http://127.0.0.1:8888 (for serving frontend)
+9. That's it, Open web browser and hit the url `http://127.0.0.1:8888`.
 
-    ```
-    gulp connect
-    ```
-
-10. To check for static files change run gulp watch task in new terminal window
-
-    ```
-    gulp watch
-    ```
 
 ## Contribution guidelines
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,13 +49,13 @@ gulp.task('vendorjs', function() {
             .pipe(concat(chunkName + '.js'))
             //.on('error', swallowError)
             .pipe(gulp.dest("frontend/dist/vendors"))
-            .pipe(gulp.watch(paths).on('change', function (event){
-                if(event.type == 'deleted'){
+            .pipe(gulp.watch(paths).on('change', function(event) {
+                if (event.type == 'deleted') {
                     var filePathFromSrc = path.relative(path.resolve(paths), event.path);
                     var destFilePath = path.resolve('frontend/dist/vendors', filePathFromSrc);
                     del.sync(destFilePath);
-                    }
-                  }))
+                }
+            }))
     })
 
 });
@@ -79,20 +79,20 @@ gulp.task('vendorcss', function() {
             .pipe(concat(chunkName + '.css'))
             //.on('error', swallowError)
             .pipe(gulp.dest("frontend/dist/vendors"))
-            .pipe(gulp.watch(paths).on('change', function (event){
-                if(event.type == 'deleted'){
+            .pipe(gulp.watch(paths).on('change', function(event) {
+                if (event.type == 'deleted') {
                     var filePathFromSrc = path.relative(path.resolve(paths), event.path);
                     var destFilePath = path.resolve('frontend/dist/vendors', filePathFromSrc);
                     del.sync(destFilePath);
-                    }
-                  }))
+                }
+            }))
     })
 
 });
 
 // config for dev server
 gulp.task('configDev', function() {
-    gulp.src('frontend/src/js/config.json' , {base: 'frontend/src/js/'})
+    gulp.src('frontend/src/js/config.json', { base: 'frontend/src/js/' })
         .pipe(ngConfig('evalai-config', {
             environment: 'local'
         }))
@@ -237,74 +237,74 @@ gulp.task('clean', function() {
 gulp.task('watch', function() {
 
     // Watch .scss files
-    gulp.watch('frontend/src/css/**/*.scss', ['css']).on('change', function (event){
-    if(event.type == 'deleted'){
-        var filePathFromSrc = path.relative(path.resolve('frontend/src/css/'), event.path);
-        var destFilePath = path.resolve('frontend/dist/css', filePathFromSrc);
-        del.sync(destFilePath);
+    gulp.watch('frontend/src/css/**/*.scss', ['css']).on('change', function(event) {
+        if (event.type == 'deleted') {
+            var filePathFromSrc = path.relative(path.resolve('frontend/src/css/'), event.path);
+            var destFilePath = path.resolve('frontend/dist/css', filePathFromSrc);
+            del.sync(destFilePath);
         }
-     });
+    });
 
     // Watch .js files
-    gulp.watch('frontend/src/js/**/*.js', ['js']).on('change', function (event){
-      if(event.type == 'deleted'){
-          var filePathFromSrc = path.relative(path.resolve('frontend/src/js/'), event.path);
-          var destFilePath = path.resolve('frontend/dist/js', filePathFromSrc);
-          del.sync(destFilePath);
-          }
-        });
+    gulp.watch('frontend/src/js/**/*.js', ['js']).on('change', function(event) {
+        if (event.type == 'deleted') {
+            var filePathFromSrc = path.relative(path.resolve('frontend/src/js/'), event.path);
+            var destFilePath = path.resolve('frontend/dist/js', filePathFromSrc);
+            del.sync(destFilePath);
+        }
+    });
 
     // Watch html files
-    gulp.watch('frontend/src/views/**/*.html', ['html']).on('change', function (event){
-      if(event.type == 'deleted'){
-          var filePathFromSrc = path.relative(path.resolve('frontend/src/views/'), event.path);
-          var destFilePath = path.resolve('frontend/dist/views/web', filePathFromSrc);
-          del.sync(destFilePath);
-          }
-        });
+    gulp.watch('frontend/src/views/**/*.html', ['html']).on('change', function(event) {
+        if (event.type == 'deleted') {
+            var filePathFromSrc = path.relative(path.resolve('frontend/src/views/'), event.path);
+            var destFilePath = path.resolve('frontend/dist/views/web', filePathFromSrc);
+            del.sync(destFilePath);
+        }
+    });
 
     // Watch image files
-    gulp.watch('frontend/src/images/**/*', ['images']).on('change', function (event){
-      if(event.type == 'deleted'){
-          var filePathFromSrc = path.relative(path.resolve('frontend/src/images/'), event.path);
-          var destFilePath = path.resolve('frontend/dist/images', filePathFromSrc);
-          del.sync(destFilePath);
-          }
-        });
+    gulp.watch('frontend/src/images/**/*', ['images']).on('change', function(event) {
+        if (event.type == 'deleted') {
+            var filePathFromSrc = path.relative(path.resolve('frontend/src/images/'), event.path);
+            var destFilePath = path.resolve('frontend/dist/images', filePathFromSrc);
+            del.sync(destFilePath);
+        }
+    });
 
     // Watch config dev
-    gulp.watch('frontend/src/js/config.json', ['configDev']).on('change', function (event){
-      if(event.type == 'deleted'){
-          var filePathFromSrc = path.relative(path.resolve('frontend/src/js/'), event.path);
-          var destFilePath = path.resolve('frontend/dist/js', filePathFromSrc);
-          del.sync(destFilePath);
-          }
-        });
+    gulp.watch('frontend/src/js/config.json', ['configDev']).on('change', function(event) {
+        if (event.type == 'deleted') {
+            var filePathFromSrc = path.relative(path.resolve('frontend/src/js/'), event.path);
+            var destFilePath = path.resolve('frontend/dist/js', filePathFromSrc);
+            del.sync(destFilePath);
+        }
+    });
 
-    gulp.watch('bower_components/font-awesome/fonts/fontawesome-webfont.*', ['fonts']).on('change', function (event){
-      if(event.type == 'deleted'){
-          var filePathFromSrc = path.relative(path.resolve('bower_components/font-awesome/fonts/'), event.path);
-          var destFilePath = path.resolve('frontend/dist/fonts/', filePathFromSrc);
-          del.sync(destFilePath);
-          }
-        });
+    gulp.watch('bower_components/font-awesome/fonts/fontawesome-webfont.*', ['fonts']).on('change', function(event) {
+        if (event.type == 'deleted') {
+            var filePathFromSrc = path.relative(path.resolve('bower_components/font-awesome/fonts/'), event.path);
+            var destFilePath = path.resolve('frontend/dist/fonts/', filePathFromSrc);
+            del.sync(destFilePath);
+        }
+    });
 
-      gulp.watch('bower_components/materialize/fonts/**/*', ['fonts']).on('change', function (event){
-        if(event.type == 'deleted'){
+    gulp.watch('bower_components/materialize/fonts/**/*', ['fonts']).on('change', function(event) {
+        if (event.type == 'deleted') {
             var filePathFromSrc = path.relative(path.resolve('bower_components/materialize/fonts/'), event.path);
             var destFilePath = path.resolve('frontend/dist/fonts/', filePathFromSrc);
             del.sync(destFilePath);
-            }
-        });
+        }
+    });
 
 
-       gulp.watch('bower_components/font-awesome/css/font-awesome.css', ['fonts']).on('change', function (event){
-         if(event.type == 'deleted'){
+    gulp.watch('bower_components/font-awesome/css/font-awesome.css', ['fonts']).on('change', function(event) {
+        if (event.type == 'deleted') {
             var filePathFromSrc = path.relative(path.resolve('bower_components/font-awesome/css/'), event.path);
             var destFilePath = path.resolve('frontend/dist/css/', filePathFromSrc);
             del.sync(destFilePath);
-            }
-         });
+        }
+    });
 
     // Create LiveReload server
     livereload.listen();
@@ -315,7 +315,7 @@ gulp.task('watch', function() {
 });
 
 
-// connect to server
+// Start a server for serving frontend
 gulp.task('connect', function() {
     connect.server({
         root: 'frontend/',
@@ -338,4 +338,9 @@ gulp.task('dev', ['clean'], function() {
 // production task
 gulp.task('prod', ['clean'], function() {
     gulp.start('css', 'js', 'html', 'images', 'vendorjs', 'vendorcss', 'fonts', 'configProd');
+});
+
+// Runserver for development
+gulp.task('dev:runserver', ['dev'], function() {
+    gulp.start('connect', 'watch');
 });


### PR DESCRIPTION
Solution for issue #534 
# Before this PR
the process to serve frontend in development-
1. run `gulp dev` (To build static files).
2. run `gulp connect` (To start server at `127.0.0.1:8888`)
3. run `gulp watch` (To check for static files change and reload them into `dist/` )

# After this PR
1. run `gulp dev:runserver` (to run all three task in a single command in a single terminal) .

@deshraj @aka-jain @dexter1691 Please test this in your system as well before merging this PR. 