### PR TITLE
Frontend(js linting): Add js linting packages

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,9 @@ var gulp = require('gulp'),
     autoprefixer = require('gulp-autoprefixer'),
     cssnano = require('gulp-cssnano'),
     jshint = require('gulp-jshint'),
+    eslint = require('gulp-eslint'),
+    stylish = require('jshint-stylish'),
+    angularPlugin = require('eslint-plugin-angular'),
     gulp_if = require('gulp-if'),
     uglify = require('gulp-uglify'),
     imagemin = require('gulp-imagemin'),
@@ -208,7 +211,6 @@ gulp.task('inject', function() {
         .pipe(gulp.dest('./frontend/'));
 });
 
-
 // config for dev server
 gulp.task('configDev', function() {
     gulp.src('frontend/src/js/config.json', { base: 'frontend/src/js/' })
@@ -227,6 +229,16 @@ gulp.task('configProd', function() {
         .pipe(gulp.dest('frontend/dist/js'))
 });
 
+// js linting
+var lint_path = {
+    js: ['frontend/src/js/**/*.js', ]
+}
+
+gulp.task('lint', [], function() {
+    return gulp.src(lint_path.js)
+        .pipe(jshint())
+        .pipe(jshint.reporter('jshint-stylish'))
+});
 
 // cleaning build process- run clean before deploy and rebuild files again
 gulp.task('clean', function() {
@@ -349,5 +361,5 @@ gulp.task('prod', function(callback) {
 
 // Runserver for development
 gulp.task('dev:runserver', function(callback) {
-    runSequence('dev', 'connect', 'watch', callback);
+    runSequence('dev', 'lint', 'connect', 'watch', callback);
 });

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
     "gulp-connect": "^5.0.0",
     "gulp-cssnano": "^2.1.2",
     "gulp-debug": "^3.0.0",
+    "gulp-eslint": "^3.0.1",
     "gulp-html-minifier": "^0.1.8",
     "gulp-imagemin": "^3.0.3",
-    "gulp-jshint": "^2.0.2",
+    "gulp-jshint": "^2.0.4",
     "gulp-livereload": "^3.8.1",
     "gulp-notify": "^2.2.0",
     "gulp-prettyerror": "^1.1.1",
@@ -30,6 +31,7 @@
     "gulp-ruby-sass": "^2.1.0",
     "gulp-uglify": "^2.0.0",
     "jshint": "^2.9.4",
+    "jshint-stylish": "^2.2.1",
     "merge-stream": "^1.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Solution for #352 
* Integrated js linting task with gulp

## How to run
* `gulp dev:runserver`
or 
* `gulp lint`

It is integrated with gulp so on development when `gulp dev:runserver` runs then lint task will run and errors and warnings can be seen on the terminal.

Since there are too many minor errors so for now everything will work as it is even after showing errors and warnings but after fixing these errors i will rewrite runserver code so that server will not run until the linting errors remain.

@aka-jain @deshraj : Please review.