### PR TITLE
 Settings: Setting default renderer to JSONRenderer in DRF backend.

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -163,7 +163,7 @@ REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {
         'anon': '100/minute',
         'user': '100/minute'
-    }
+    },
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
     )

--- a/settings/common.py
+++ b/settings/common.py
@@ -164,6 +164,9 @@ REST_FRAMEWORK = {
         'anon': '100/minute',
         'user': '100/minute'
     }
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+    )
 }
 
 # ALLAUTH SETTINGS


### PR DESCRIPTION
fixes #696 . @deshraj @TroJan Please review the PR.