### PR TITLE
Updated migration file to account for prior migration merge

### DIFF
--- a/apps/challenges/migrations/0019_added_leaderboard_data_table.py
+++ b/apps/challenges/migrations/0019_added_leaderboard_data_table.py
@@ -10,7 +10,7 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('jobs', '0004_submission_output'),
+        ('jobs', '0001_squashed_0005_upload_unique_random_filename'),
         ('challenges', '0018_added_challenge_phase_split_table'),
     ]
 


### PR DESCRIPTION
Fix for the missing migration error in `jobs` caused due to the migration merge.