### PR TITLE
Show the team name

### DIFF
--- a/apps/hosts/models.py
+++ b/apps/hosts/models.py
@@ -17,6 +17,9 @@ class ChallengeHostTeam(TimeStampedModel):
     def __unicode__(self):
         return "%s: %s" % (self.team_name, self.created_by)
 
+    def __str__(self):
+        return "%s" % self.team_name
+
     class Meta:
         app_label = 'hosts'
         db_table = 'challenge_host_teams'


### PR DESCRIPTION
Currently in the Django admin, when we wish to select the ChallengeHostTeam, the admin interface shows us `ChallengeHostTeam object` instead of the team name. This can be confusing for users who are a part of multiple teams.

This PR fixes this issue.