### PR TITLE
Scripts: Bug fix for submission worker

### DIFF
--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -366,6 +366,15 @@ def run_submission(challenge_id, challenge_phase, submission_id, submission, use
     # after the execution is finished, set `status` to finished and hence `completed_at`
     if submission_output:
         submission.output = submission_output
+
+        # Save submission_result_file
+        submission_result = submission_output.get('submission_result', '')
+        submission.submission_result_file.save('submission_result.txt', ContentFile(submission_result))
+
+        # Save submission_metadata_file
+        submission_metadata = submission_output.get('submission_metadata', '')
+        submission.submission_metadata_file.save('submission_metadata.txt', ContentFile(submission_metadata))
+
     submission.save()
 
     stderr.close()
@@ -380,14 +389,6 @@ def run_submission(challenge_id, challenge_phase, submission_id, submission, use
     with open(stderr_file, 'r') as stderr:
         stderr_content = stderr.read()
         submission.stderr_file.save('stderr.txt', ContentFile(stderr_content))
-
-    # Save submission_result_file
-    submission_result = submission_output.get('submission_result', '')
-    submission.submission_result_file.save('submission_result.txt', ContentFile(submission_result))
-
-    # Save submission_metadata_file
-    submission_metadata = submission_output.get('submission_metadata', '')
-    submission.submission_metadata_file.save('submission_metadata.txt', ContentFile(submission_metadata))
 
     # delete the complete temp run directory
     shutil.rmtree(temp_run_dir)


### PR DESCRIPTION
Fixes the error when the submission fails. 

Throws the following traceback for a submission if the submission fails: 

```shell
(' [x] Received \'{"challenge_id": "1", "submission_id": 81, "phase_id": "1"}\'', <BasicProperties(['delivery_mode=2'])>, <Basic.Deliver(['consumer_tag=ctag1.cfcf4456ca1448d5b97cc2968d07fa30', 'delivery_tag=2', 'exchange=evalai_submissions', 'redelivered=True', 'routing_key=submission.*.*'])>)
Error in receiving message from submission queue with error 'NoneType' object has no attribute 'get'
Traceback (most recent call last):
  File "scripts/workers/submission_worker.py", line 431, in process_submission_callback
    process_submission_message(body)
  File "scripts/workers/submission_worker.py", line 410, in process_submission_message
    run_submission(challenge_id, challenge_phase, submission_id, submission_instance, user_annotation_file_path)
  File "scripts/workers/submission_worker.py", line 385, in run_submission
    submission_result = submission_output.get('submission_result', '')
AttributeError: 'NoneType' object has no attribute 'get'
```