### PR TITLE
Challenges: Add permissions to allow unauthenticated users 

### DIFF
--- a/apps/accounts/permissions.py
+++ b/apps/accounts/permissions.py
@@ -11,7 +11,10 @@ class HasVerifiedEmail(permissions.BasePermission):
 
     def has_permission(self, request, view):
 
-        if EmailAddress.objects.filter(user=request.user, verified=True).exists():
+        if request.user.is_anonymous:
             return True
         else:
-            return False
+            if EmailAddress.objects.filter(user=request.user, verified=True).exists():
+                return True
+            else:
+                return False

--- a/apps/challenges/permissions.py
+++ b/apps/challenges/permissions.py
@@ -15,7 +15,7 @@ class IsChallengeCreator(permissions.BasePermission):
             return True
         elif request.method in ['DELETE', 'PATCH', 'PUT', 'POST']:
             try:
-                challenge = Challenge.objects.get(pk=request.parser_context['kwargs']['pk'])
+                challenge = Challenge.objects.get(pk=request.parser_context['kwargs']['challenge_pk'])
             except Challenge.DoesNotExist:
                 return False
 

--- a/apps/challenges/urls.py
+++ b/apps/challenges/urls.py
@@ -6,11 +6,11 @@ urlpatterns = [
 
     url(r'challenge_host_team/(?P<challenge_host_team_pk>[0-9]+)/challenge$', views.challenge_list,
         name='get_challenge_list'),
-    url(r'challenge_host_team/(?P<challenge_host_team_pk>[0-9]+)/challenge/(?P<pk>[0-9]+)$',
+    url(r'challenge_host_team/(?P<challenge_host_team_pk>[0-9]+)/challenge/(?P<challenge_pk>[0-9]+)$',
         views.challenge_detail, name='get_challenge_detail'),
     url(r'challenge/(?P<challenge_pk>[0-9]+)/participant_team/(?P<participant_team_pk>[0-9]+)',
         views.add_participant_team_to_challenge, name='add_participant_team_to_challenge'),
-    url(r'challenge/(?P<pk>[0-9]+)/disable',
+    url(r'challenge/(?P<challenge_pk>[0-9]+)/disable',
         views.disable_challenge, name='disable_challenge'),
     url(r'challenge/(?P<challenge_pk>[0-9]+)/challenge_phase$', views.challenge_phase_list,
         name='get_challenge_phase_list'),

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -60,7 +60,7 @@ def challenge_list(request, challenge_host_team_pk):
 @api_view(['GET', 'PUT', 'PATCH', 'DELETE'])
 @permission_classes((permissions.IsAuthenticated, HasVerifiedEmail, IsChallengeCreator))
 @authentication_classes((ExpiringTokenAuthentication,))
-def challenge_detail(request, challenge_host_team_pk, pk):
+def challenge_detail(request, challenge_host_team_pk, challenge_pk):
     try:
         challenge_host_team = ChallengeHostTeam.objects.get(pk=challenge_host_team_pk)
     except ChallengeHostTeam.DoesNotExist:
@@ -68,7 +68,7 @@ def challenge_detail(request, challenge_host_team_pk, pk):
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     try:
-        challenge = Challenge.objects.get(pk=pk)
+        challenge = Challenge.objects.get(pk=challenge_pk)
     except Challenge.DoesNotExist:
         response_data = {'error': 'Challenge does not exist'}
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
@@ -154,9 +154,9 @@ def add_participant_team_to_challenge(request, challenge_pk, participant_team_pk
 @api_view(['POST'])
 @permission_classes((permissions.IsAuthenticated, HasVerifiedEmail, IsChallengeCreator))
 @authentication_classes((ExpiringTokenAuthentication,))
-def disable_challenge(request, pk):
+def disable_challenge(request, challenge_pk):
     try:
-        challenge = Challenge.objects.get(pk=pk)
+        challenge = Challenge.objects.get(pk=challenge_pk)
     except Challenge.DoesNotExist:
         response_data = {'error': 'Challenge does not exist'}
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
@@ -253,7 +253,7 @@ def get_challenges_based_on_teams(request):
 
 @throttle_classes([UserRateThrottle])
 @api_view(['GET', 'POST'])
-@permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))
+@permission_classes((permissions.IsAuthenticatedOrReadOnly, HasVerifiedEmail, IsChallengeCreator))
 @authentication_classes((ExpiringTokenAuthentication,))
 def challenge_phase_list(request, challenge_pk):
     try:
@@ -281,7 +281,7 @@ def challenge_phase_list(request, challenge_pk):
 
 @throttle_classes([UserRateThrottle])
 @api_view(['GET', 'PUT', 'PATCH', 'DELETE'])
-@permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))
+@permission_classes((permissions.IsAuthenticatedOrReadOnly, HasVerifiedEmail))
 @authentication_classes((ExpiringTokenAuthentication,))
 def challenge_phase_detail(request, challenge_pk, pk):
     try:

--- a/settings/prod.py
+++ b/settings/prod.py
@@ -5,7 +5,7 @@ import raven
 
 DEBUG = False
 
-ALLOWED_HOSTS = ['evalapi.cloudcv.org', 'evalai.cloudcv.org', 'evalai.s3.amazonaws.com']
+ALLOWED_HOSTS = ['evalapi.cloudcv.org', 'evalai.cloudcv.org']
 
 # Database
 # https://docs.djangoproject.com/en/1.10.2/ref/settings/#databases
@@ -14,6 +14,7 @@ CORS_ORIGIN_ALLOW_ALL = False
 
 CORS_ORIGIN_WHITELIST = (
     'evalai.cloudcv.org',
+    'evalai.s3.amazonaws.com',
 )
 
 DATABASES = {

--- a/tests/unit/challenges/test_urls.py
+++ b/tests/unit/challenges/test_urls.py
@@ -47,7 +47,8 @@ class TestChallengeUrls(BaseAPITestClass):
         self.assertEqual(url, '/api/challenges/challenge_host_team/' + str(self.challenge_host_team.pk) + '/challenge')
 
         url = reverse_lazy('challenges:get_challenge_detail',
-                           kwargs={'challenge_host_team_pk': self.challenge_host_team.pk, 'pk': self.challenge.pk})
+                           kwargs={'challenge_host_team_pk': self.challenge_host_team.pk,
+                                   'challenge_pk': self.challenge.pk})
         self.assertEqual(url, '/api/challenges/challenge_host_team/' +
                          str(self.challenge_host_team.pk) + '/challenge/' + str(self.challenge.pk))
 
@@ -56,7 +57,7 @@ class TestChallengeUrls(BaseAPITestClass):
         self.assertEqual(url, '/api/challenges/challenge/' + str(self.challenge.pk) + '/participant_team/' +
                          str(self.participant_team.pk))
 
-        url = reverse_lazy('challenges:disable_challenge', kwargs={'pk': self.challenge.pk})
+        url = reverse_lazy('challenges:disable_challenge', kwargs={'challenge_pk': self.challenge.pk})
         self.assertEqual(url, '/api/challenges/challenge/' + str(self.challenge.pk) + '/disable')
 
         url = reverse_lazy('challenges:get_challenge_phase_list', kwargs={'challenge_pk': self.challenge.pk})

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -160,7 +160,7 @@ class GetParticularChallenge(BaseAPITestClass):
         super(GetParticularChallenge, self).setUp()
         self.url = reverse_lazy('challenges:get_challenge_detail',
                                 kwargs={'challenge_host_team_pk': self.challenge_host_team.pk,
-                                        'pk': self.challenge.pk})
+                                        'challenge_pk': self.challenge.pk})
 
     def test_get_particular_challenge(self):
         expected = {
@@ -191,7 +191,7 @@ class GetParticularChallenge(BaseAPITestClass):
     def test_particular_challenge_does_not_exist(self):
         self.url = reverse_lazy('challenges:get_challenge_detail',
                                 kwargs={'challenge_host_team_pk': self.challenge_host_team.pk,
-                                        'pk': self.challenge.pk + 1})
+                                        'challenge_pk': self.challenge.pk + 1})
         expected = {
             'error': 'Challenge does not exist'
         }
@@ -202,7 +202,7 @@ class GetParticularChallenge(BaseAPITestClass):
     def test_particular_challenge_host_team_for_challenge_does_not_exist(self):
         self.url = reverse_lazy('challenges:get_challenge_detail',
                                 kwargs={'challenge_host_team_pk': self.challenge_host_team.pk + 1,
-                                        'pk': self.challenge.pk})
+                                        'challenge_pk': self.challenge.pk})
         expected = {
             'error': 'ChallengeHostTeam does not exist'
         }
@@ -217,7 +217,7 @@ class UpdateParticularChallenge(BaseAPITestClass):
         super(UpdateParticularChallenge, self).setUp()
         self.url = reverse_lazy('challenges:get_challenge_detail',
                                 kwargs={'challenge_host_team_pk': self.challenge_host_team.pk,
-                                        'pk': self.challenge.pk})
+                                        'challenge_pk': self.challenge.pk})
 
         self.partial_update_challenge_title = 'Partial Update Test Challenge'
         self.update_challenge_title = 'Update Test Challenge'
@@ -293,7 +293,7 @@ class DeleteParticularChallenge(BaseAPITestClass):
         super(DeleteParticularChallenge, self).setUp()
         self.url = reverse_lazy('challenges:get_challenge_detail',
                                 kwargs={'challenge_host_team_pk': self.challenge_host_team.pk,
-                                        'pk': self.challenge.pk})
+                                        'challenge_pk': self.challenge.pk})
 
     def test_particular_challenge_delete(self):
         response = self.client.delete(self.url, {})
@@ -475,7 +475,7 @@ class DisableChallengeTest(BaseAPITestClass):
         )
 
         self.url = reverse_lazy('challenges:disable_challenge',
-                                kwargs={'pk': self.challenge.pk})
+                                kwargs={'challenge_pk': self.challenge.pk})
 
     def test_disable_a_challenge(self):
         response = self.client.post(self.url, {})
@@ -483,13 +483,13 @@ class DisableChallengeTest(BaseAPITestClass):
 
     def test_particular_challenge_for_disable_does_not_exist(self):
         self.url = reverse_lazy('challenges:disable_challenge',
-                                kwargs={'pk': self.challenge.pk + 2})
+                                kwargs={'challenge_pk': self.challenge.pk + 2})
         response = self.client.post(self.url, {})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_when_user_does_not_have_permission_to_disable_particular_challenge(self):
         self.url = reverse_lazy('challenges:disable_challenge',
-                                kwargs={'pk': self.challenge2.pk})
+                                kwargs={'challenge_pk': self.challenge2.pk})
         expected = {
             'error': 'Sorry, you are not allowed to perform this operation!'
         }
@@ -499,7 +499,7 @@ class DisableChallengeTest(BaseAPITestClass):
 
     def test_disable_challenge_when_user_is_not_creator(self):
         self.url = reverse_lazy('challenges:disable_challenge',
-                                kwargs={'pk': self.challenge2.pk})
+                                kwargs={'challenge_pk': self.challenge2.pk})
         # Now allot self.user as also a host of self.challenge_host_team1
         self.challenge_host = ChallengeHost.objects.create(
             user=self.user,


### PR DESCRIPTION
This fix allow the users to access some of the endpoints to get details related to Challenge using `SAFE_METHODS`