### PR TITLE
Add tests for __unicode__ function in models

### DIFF
--- a/tests/unit/challenges/test_models.py
+++ b/tests/unit/challenges/test_models.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 
@@ -8,7 +9,7 @@ from django.test import TestCase
 from django.contrib.auth.models import User
 from django.utils import timezone
 
-from challenges.models import Challenge, ChallengePhase
+from challenges.models import Challenge, ChallengePhase, ChallengePhaseSplit, DatasetSplit, Leaderboard
 from hosts.models import ChallengeHostTeam
 
 
@@ -96,6 +97,20 @@ class ChalengeTestCase(BaseTestCase):
                          self.challenge.get_end_date())
 
 
+class DatasetSplitTestCase(BaseTestCase):
+
+    def setUp(self):
+        super(DatasetSplitTestCase, self).setUp()
+        self.dataset_split = DatasetSplit.objects.create(
+            name="Name",
+            codename="Codename",
+        )
+
+    def test__str__(self):
+        self.assertEqual(self.dataset_split.name,
+                         self.dataset_split.__str__())
+
+
 class ChallengePhaseTestCase(BaseTestCase):
 
     def setUp(self):
@@ -142,3 +157,59 @@ class ChallengePhaseTestCase(BaseTestCase):
     def test_get_end_date(self):
         self.assertEqual(self.challenge_phase.end_date,
                          self.challenge_phase.get_end_date())
+
+
+class LeaderboardTestCase(BaseTestCase):
+
+    def setUp(self):
+        super(LeaderboardTestCase, self).setUp()
+        self.leaderboard = Leaderboard.objects.create(schema=json.dumps({"hello": "world"}))
+
+    def test__str__(self):
+        instance_id = str(self.leaderboard.id)
+        self.assertEqual(instance_id,
+                         self.leaderboard.__str__())
+
+
+class ChallengePhaseSplitTestCase(BaseTestCase):
+
+    def setUp(self):
+        super(ChallengePhaseSplitTestCase, self).setUp()
+        try:
+            os.makedirs('/tmp/evalai')
+        except OSError:
+            pass
+
+        with self.settings(MEDIA_ROOT='/tmp/evalai'):
+            self.challenge_phase = ChallengePhase.objects.create(
+                name='Challenge Phase',
+                description='Description for Challenge Phase',
+                leaderboard_public=False,
+                is_public=False,
+                start_date=timezone.now() - timedelta(days=2),
+                end_date=timezone.now() + timedelta(days=1),
+                challenge=self.challenge,
+                test_annotation=SimpleUploadedFile('test_sample_file.txt',
+                                                   'Dummy file content', content_type='text/plain')
+            )
+
+        self.dataset_split = DatasetSplit.objects.create(name="Test Dataset Split", codename="test-split")
+
+        self.leaderboard = Leaderboard.objects.create(schema=json.dumps({'hello': 'world'}))
+
+        self.challenge_phase_split = ChallengePhaseSplit.objects.create(
+                dataset_split=self.dataset_split,
+                challenge_phase=self.challenge_phase,
+                leaderboard=self.leaderboard,
+                visibility=ChallengePhaseSplit.PUBLIC
+            )
+
+    def tearDown(self):
+        shutil.rmtree('/tmp/evalai')
+
+    def test__str__(self):
+        challenge_phase_name = self.challenge_phase_split.challenge_phase.name
+        dataset_split_name = self.challenge_phase_split.dataset_split.name
+        string_to_compare = '{} : {}'.format(challenge_phase_name, dataset_split_name)
+        self.assertEqual(string_to_compare,
+                         self.challenge_phase_split.__str__())


### PR DESCRIPTION
tests for __unicode__ have been added for the following classes:
1. challenges.DatasetSplit
2. challenges.Leaderboard
3. challenges.ChallengePhaseSplit

In response to #1002, the last function, `LeaderboardData` needs `Submission` and other classes to be present. So ill do a PR for that class soon enough along with the rest of them.