### PR TITLE
Frontend: Fix base url in route-config

### DIFF
--- a/frontend/src/js/route-config/route-config.js
+++ b/frontend/src/js/route-config/route-config.js
@@ -7,7 +7,7 @@
         .module('evalai')
         .config(configure);
 
-    var baseUrl = "dist/views/";
+    var baseUrl = "dist/views";
 
     function configure($stateProvider, $urlRouterProvider, $locationProvider, $urlMatcherFactoryProvider) {
 


### PR DESCRIPTION
As for now templateurl is having extra `/` which is redundant
i.e. `templateUrl` for state `home` is `dist/views//web/landing.html` which should be `dist/views/web/landing.html` .
@aka-jain : Please review and merge this PR.