### PR TITLE
Add Python 3 to the testing in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: python
 sudo: false
 python:
-  - '2.7'
+  - "2.7"
+  - "3.6"
+matrix:
+  allow_failures:
+    - python: "3.6"
 
 addons:
   postgresql: "9.4"


### PR DESCRIPTION
Helps to fix #1241 
This will help to spot issues which would hinder future migration to Django 2.
* https://docs.djangoproject.com/en/1.11/faq/install/#faq-python-version-support

Output:
* https://travis-ci.org/Cloud-CV/EvalAI/builds/276989987?utm_source=github_status&utm_medium=notification