### PR TITLE
FIX #1266 : Creating Hyperlinks for Github and Twitter

### DIFF
--- a/frontend/src/views/web/partials/dashboard-footer.html
+++ b/frontend/src/views/web/partials/dashboard-footer.html
@@ -5,8 +5,8 @@
                 <h5 class="white-text">EvalAI</h5>
                 <p class="text-light-gray">Evaluating state of the art in AI</p>
                 <ul class="inline-list">
-                    <li><a class="text-light-gray" href="#!"><i class="fa fa-github"></i></a></li>
-                    <li><a class="text-light-gray" href="#!"><i class="fa fa-twitter"></i></a></li>
+                    <li><a class="text-light-gray" href="https://github.com/Cloud-CV/EvalAI" target="_blank"><i class="fa fa-github"></i></a></li>
+                    <li><a class="text-light-gray" href="https://twitter.com/project_cloudcv" target="_blank"><i class="fa fa-twitter"></i></a></li>
                 </ul>
             </div>
             <div class="col l4 offset-l0 s12">


### PR DESCRIPTION
Creating Hyperlinks for Github and Twitter for dashboard Footer (closes #1266 )  