### PR TITLE
Fix: Auth loader after sign out.

### DIFF
--- a/frontend/src/js/route-config/route-config.js
+++ b/frontend/src/js/route-config/route-config.js
@@ -573,6 +573,7 @@
             parameters.callback = {
                 onSuccess: function() {
                     utilities.resetStorage();
+                    $rootScope.isLoader = false;
                     $state.go("auth.login");
                     $rootScope.isAuth = false;
                     $rootScope.notify("info", "Successfully logged out!");


### PR DESCRIPTION
Fixed the loader on auth pages when user directs to login page after sign out.

Current Scenario: Login and click on sign out button, it will redirect to login page but with continuous loader.

@deshraj @RishabhJain2018 