### PR TITLE
show meaninful error messsage when email verification not done

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -12,7 +12,7 @@ drfdocs==0.0.11
 pika==0.10.0
 pickleshare==0.7.4
 Pillow==3.4.2
-psycopg2==2.6.2
+psycopg2==2.7.3.1
 PyYaml==3.12
 proc==0.10.1
 rstr==2.2.5


### PR DESCRIPTION
 Fix #1413 : Now a meaningful error message is shown to inform the user about the email verification link in order to activate his account and able to proceed ahead.
![pr](https://user-images.githubusercontent.com/25207205/34070172-ace1579a-e286-11e7-9b14-8d1b017eb37d.png)



