### PR TITLE
Fixes #1364: Updated color scheme for pop up info notifications

### DIFF
--- a/frontend/src/css/modules/notification.scss
+++ b/frontend/src/css/modules/notification.scss
@@ -11,36 +11,52 @@
 .toast-message {
     font-size: 14px;
     a {
-        // color: #ffffff;
+        color: #ffffff;
         &:hover {
             // color: #cccccc;
             text-decoration: none;
         }
     }
     label {
-        // color: #ffffff
+       // color: #ffffff;
     }
 }
 
 .toast {
     word-break: initial;
     &.toast-success {
-        //     background-color: #51a351;
+        background-color: #74DB70;
+            &:hover {
+                background-color: #74DB70;
+            }
     }
+
     &.toast-error {
-        //     background-color: #bd362f;
+        background-color: #E43F3F;
+            &:hover {
+                background-color: #E43F3F;
+            }
     }
 
     &.toast-info {
-        //     background-color: #2f96b4;
+        background-color: #3B9EB9;
+            &:hover {
+                background-color: #3B9EB9;
+            }
     }
 
     &.toast-wait {
-        //     background-color: #2f96b4;
+        background-color: #5843A3;
+            &:hover {
+                background-color: #5843A3;
+            }
     }
 
     &.toast-warning {
-        //     background-color: #f89406;
+        background-color: #DF9C3E;
+            &:hover {
+                background-color: #DA8F27;
+            }
     }
 }
 


### PR DESCRIPTION
Fixes #1364 

- Updated the color scheme for pop-up notifications.
- Made slight changes in the colors to look more-like material design.

Screenshots:

![screen shot 2017-12-18 at 7 02 28 am](https://user-images.githubusercontent.com/22245418/34086404-8d287d16-e3c1-11e7-9c2b-3c6608071a8d.png)
![screen shot 2017-12-18 at 7 02 44 am](https://user-images.githubusercontent.com/22245418/34086406-8df5fe8a-e3c1-11e7-9304-cdfd07393c84.png)
![screen shot 2017-12-18 at 7 02 55 am](https://user-images.githubusercontent.com/22245418/34086408-8fcd7e9a-e3c1-11e7-970d-7bddc5ccdbdc.png)

