### PR TITLE
Fix Travis build fail issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Some background: Last year, the [Visual Question Answering Challenge (VQA, 2016]
 Setting up EvalAI on your local machine is really easy.
 Follow this guide to setup your development machine.
 
-1. Install [python] 2.x (EvalAI only supports python2.x for now.), [git], [postgresql] version >= 9.4, [RabbitMQ] and [virtualenv], in your computer, if you don't have it already.
+1. Install [python] 2.x (EvalAI only supports python2.x for now.), [git], [postgresql] version >= 10.1, [RabbitMQ] and [virtualenv], in your computer, if you don't have it already.
 *If you are having trouble with postgresql on Windows check this link [postgresqlhelp].*
 
 2. Get the source code on your machine via git.

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,4 +1,4 @@
-asgi-redis==0.14.1
+asgi-redis==1.4.3
 commonmark==0.5.4
 django==1.10.2
 django-import-export==0.5.1

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,7 +1,5 @@
 asgi-redis==0.14.1
-channels==0.17.2
 commonmark==0.5.4
-daphne==0.15.0
 django==1.10.2
 django-import-export==0.5.1
 djangorestframework==3.5.2
@@ -12,7 +10,7 @@ drfdocs==0.0.11
 pika==0.10.0
 pickleshare==0.7.4
 Pillow==3.4.2
-psycopg2==2.6.2
+psycopg2==2.7.3.2
 PyYaml==3.12
 proc==0.10.1
 rstr==2.2.5

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -5,7 +5,7 @@ django-import-export==0.5.1
 djangorestframework==3.5.2
 djangorestframework-expiring-authtoken==0.1.4
 django-cors-headers==1.3.1
-django-rest-auth[with_social]
+django-rest-auth[with_social]==0.9.2
 drfdocs==0.0.11
 pika==0.10.0
 pickleshare==0.7.4


### PR DESCRIPTION
Includes the following fixes:

- Downgrade django-rest-auth to 0.9.2
- Update asgi-redis version
- Remove some extra dependencies that we are not using
- Update the psycopg2 version to be compatible with PostgreSQL 10.1