### PR TITLE
Fixes #879: IsChallengeCreator decorator in Challenge Phase detail API Endpoint.

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -331,7 +331,7 @@ def challenge_phase_list(request, challenge_pk):
 
 @throttle_classes([UserRateThrottle])
 @api_view(['GET', 'PUT', 'PATCH', 'DELETE'])
-@permission_classes((permissions.IsAuthenticatedOrReadOnly, HasVerifiedEmail))
+@permission_classes((permissions.IsAuthenticatedOrReadOnly, HasVerifiedEmail, IsChallengeCreator))
 @authentication_classes((ExpiringTokenAuthentication,))
 def challenge_phase_detail(request, challenge_pk, pk):
     try:

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -198,6 +198,54 @@ class GetParticularChallenge(BaseAPITestClass):
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_update_challenge_when_user_is_not_its_creator(self):
+        self.user1 = User.objects.create(
+            username='someuser1',
+            email="user1@test.com",
+            password='secret_psassword')
+
+        EmailAddress.objects.create(
+            user=self.user1,
+            email='user1@test.com',
+            primary=True,
+            verified=True)
+
+        self.client.force_authenticate(user=self.user1)
+
+        expected = {"detail": "Sorry, you are not allowed to perform this operation!"}
+
+        response = self.client.put(self.url, {'title': 'Rose Challenge', 'description': 'Version 2.0'})
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_update_challenge_when_user_is_its_creator(self):
+        new_title = 'Rose Challenge'
+        new_description = 'New description.'
+        expected = {
+            "id": self.challenge.pk,
+            "title": new_title,
+            "short_description": self.challenge.short_description,
+            "description": new_description,
+            "terms_and_conditions": self.challenge.terms_and_conditions,
+            "submission_guidelines": self.challenge.submission_guidelines,
+            "evaluation_details": self.challenge.evaluation_details,
+            "image": None,
+            "start_date": "{0}{1}".format(self.challenge.start_date.isoformat(), 'Z').replace("+00:00", ""),
+            "end_date": "{0}{1}".format(self.challenge.end_date.isoformat(), 'Z').replace("+00:00", ""),
+            "creator": {
+                "id": self.challenge.creator.pk,
+                "team_name": self.challenge.creator.team_name,
+                "created_by": self.challenge.creator.created_by.username
+            },
+            "published": self.challenge.published,
+            "enable_forum": self.challenge.enable_forum,
+            "anonymous_leaderboard": self.challenge.anonymous_leaderboard,
+            "is_active": True
+        }
+        response = self.client.put(self.url, {'title': new_title, 'description': new_description})
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     def test_particular_challenge_does_not_exist(self):
         self.url = reverse_lazy('challenges:get_challenge_detail',
                                 kwargs={'challenge_host_team_pk': self.challenge_host_team.pk,
@@ -1240,6 +1288,47 @@ class GetParticularChallengePhase(BaseChallengePhaseClass):
             "max_submissions": self.challenge_phase.max_submissions,
         }
         response = self.client.get(self.url, {})
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_update_challenge_phase_when_user_is_not_its_creator(self):
+        self.user1 = User.objects.create(
+            username='someuser1',
+            email="user1@test.com",
+            password='secret_psassword')
+
+        EmailAddress.objects.create(
+            user=self.user1,
+            email='user1@test.com',
+            primary=True,
+            verified=True)
+
+        self.client.force_authenticate(user=self.user1)
+
+        expected = {"detail": "Sorry, you are not allowed to perform this operation!"}
+
+        response = self.client.put(self.url, {'name': 'Rose Phase', 'description': 'New description.'})
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_update_challenge_phase_when_user_is_its_creator(self):
+        new_name = 'Rose Phase'
+        new_description = 'New description.'
+        expected = {
+            "id": self.challenge_phase.id,
+            "name": new_name,
+            "description": new_description,
+            "leaderboard_public": self.challenge_phase.leaderboard_public,
+            "start_date": "{0}{1}".format(self.challenge_phase.start_date.isoformat(), 'Z').replace("+00:00", ""),
+            "end_date": "{0}{1}".format(self.challenge_phase.end_date.isoformat(), 'Z').replace("+00:00", ""),
+            "challenge": self.challenge_phase.challenge.pk,
+            "is_public": self.challenge_phase.is_public,
+            "is_active": True,
+            "codename": "Phase Code Name",
+            "max_submissions_per_day": self.challenge_phase.max_submissions_per_day,
+            "max_submissions": self.challenge_phase.max_submissions,
+        }
+        response = self.client.put(self.url, {'name': new_name, 'description': new_description})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 


### PR DESCRIPTION
    * Add IsChallengeCreator decorator to challenge_phase_detail API.

    * Write tests for the following changes.

I've also added missing tests to challenge_detail end-point.

Fixes #879 