### PR TITLE
Fix #1547: add support for sorting leaderboard column wise

### DIFF
--- a/apps/accounts/migrations/0001_initial.py
+++ b/apps/accounts/migrations/0001_initial.py
@@ -19,7 +19,8 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Affiliation',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
                 ('name', models.TextField()),
@@ -31,11 +32,14 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='UserAffliation',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
-                ('affiliation', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='accounts.Affiliation')),
-                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+                ('affiliation', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE, to='accounts.Affiliation')),
+                ('user', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'db_table': 'user_affiliation',
@@ -44,7 +48,8 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='UserStatus',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
                 ('name', models.CharField(max_length=30)),

--- a/apps/accounts/migrations/0002_profile.py
+++ b/apps/accounts/migrations/0002_profile.py
@@ -18,14 +18,17 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Profile',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
                 ('contact_number', models.CharField(max_length=10, null=True)),
                 ('affiliation', models.CharField(max_length=512)),
-                ('receive_participated_challenge_updates', models.BooleanField(default=False)),
+                ('receive_participated_challenge_updates',
+                 models.BooleanField(default=False)),
                 ('recieve_newsletter', models.BooleanField(default=False)),
-                ('user', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+                ('user', models.OneToOneField(
+                    on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'db_table': 'user_profile',

--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -9,6 +9,7 @@ from base.models import (TimeStampedModel,)
 
 
 class UserStatus(TimeStampedModel):
+
     """
     Model representing the status of a user being invited by
     other user to host/participate in a competition
@@ -34,6 +35,7 @@ class UserStatus(TimeStampedModel):
 
 
 class Profile(TimeStampedModel):
+
     """
     Model to store profile of a user
     """

--- a/apps/accounts/permissions.py
+++ b/apps/accounts/permissions.py
@@ -3,6 +3,7 @@ from rest_framework import permissions
 
 
 class HasVerifiedEmail(permissions.BasePermission):
+
     """
     Permission class for if the user has verified the email or not
     """

--- a/apps/accounts/serializers.py
+++ b/apps/accounts/serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 
 
 class UserDetailsSerializer(serializers.ModelSerializer):
+
     """
     Make username as a read_only field.
     """
@@ -14,6 +15,7 @@ class UserDetailsSerializer(serializers.ModelSerializer):
 
 
 class ProfileSerializer(UserDetailsSerializer):
+
     """
     Serializer to update the user profile.
     """
@@ -27,7 +29,8 @@ class ProfileSerializer(UserDetailsSerializer):
         profile_data = validated_data.pop('profile', {})
         affiliation = profile_data.get('affiliation')
 
-        instance = super(ProfileSerializer, self).update(instance, validated_data)
+        instance = super(ProfileSerializer, self).update(
+            instance, validated_data)
 
         profile = instance.profile
         if profile_data and affiliation:

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -5,7 +5,8 @@ from rest_framework import permissions, status
 from rest_framework.decorators import (api_view,
                                        authentication_classes,
                                        permission_classes,)
-from rest_framework_expiring_authtoken.authentication import (ExpiringTokenAuthentication,)
+from rest_framework_expiring_authtoken.authentication import (
+    ExpiringTokenAuthentication,)
 
 
 @api_view(['POST'])

--- a/apps/analytics/serializers.py
+++ b/apps/analytics/serializers.py
@@ -26,6 +26,8 @@ class LastSubmissionTimestamp(object):
 
 
 class LastSubmissionTimestampSerializer(serializers.Serializer):
-    last_submission_timestamp_in_challenge = serializers.DateTimeField(format=None)
-    last_submission_timestamp_in_challenge_phase = serializers.DateTimeField(format=None)
+    last_submission_timestamp_in_challenge = serializers.DateTimeField(
+        format=None)
+    last_submission_timestamp_in_challenge_phase = serializers.DateTimeField(
+        format=None)
     challenge_phase = serializers.IntegerField()

--- a/apps/analytics/views.py
+++ b/apps/analytics/views.py
@@ -8,7 +8,8 @@ from rest_framework.decorators import (api_view,
                                        permission_classes,
                                        throttle_classes,)
 from rest_framework.response import Response
-from rest_framework_expiring_authtoken.authentication import (ExpiringTokenAuthentication,)
+from rest_framework_expiring_authtoken.authentication import (
+    ExpiringTokenAuthentication,)
 from rest_framework.throttling import UserRateThrottle
 
 from accounts.permissions import HasVerifiedEmail
@@ -59,7 +60,8 @@ def get_participant_count(request, challenge_pk):
     """
     challenge = get_challenge_model(challenge_pk)
     participant_teams = challenge.participant_teams.all()
-    participant_count = Participant.objects.filter(team__in=participant_teams).count()
+    participant_count = Participant.objects.filter(
+        team__in=participant_teams).count()
     participant_count = ParticipantCount(participant_count)
     serializer = ParticipantCountSerializer(participant_count)
     return Response(serializer.data, status=status.HTTP_200_OK)
@@ -81,7 +83,8 @@ def get_submission_count(request, challenge_pk, duration):
 
     challenge = get_challenge_model(challenge_pk)
 
-    challenge_phase_ids = challenge.challengephase_set.all().values_list('id', flat=True)
+    challenge_phase_ids = challenge.challengephase_set.all().values_list(
+        'id', flat=True)
 
     q_params = {'challenge_phase__id__in': challenge_phase_ids}
     since_date = None
@@ -126,7 +129,8 @@ def get_challenge_phase_submission_analysis(request, challenge_pk, challenge_pha
     challenge_phase_submission_count = ChallengePhaseSubmissionCount(
         submission_count, participant_team_count, challenge_phase.pk)
     try:
-        serializer = ChallengePhaseSubmissionCountSerializer(challenge_phase_submission_count)
+        serializer = ChallengePhaseSubmissionCountSerializer(
+            challenge_phase_submission_count)
         response_data = serializer.data
         return Response(response_data, status=status.HTTP_200_OK)
     except:
@@ -148,10 +152,12 @@ def get_last_submission_time(request, challenge_pk, challenge_phase_pk, submissi
 
     # To get the last submission time by a user in a challenge phase.
     if submission_by == 'user':
-        last_submitted_at = Submission.objects.filter(created_by=request.user.pk,
+        last_submitted_at = Submission.objects.filter(
+            created_by=request.user.pk,
                                                       challenge_phase=challenge_phase,
                                                       challenge_phase__challenge=challenge)
-        last_submitted_at = last_submitted_at.order_by('-submitted_at')[0].created_at
+        last_submitted_at = last_submitted_at.order_by(
+            '-submitted_at')[0].created_at
         last_submitted_at = LastSubmissionDateTime(last_submitted_at)
         serializer = LastSubmissionDateTimeSerializer(last_submitted_at)
         return Response(serializer.data, status=status.HTTP_200_OK)
@@ -189,7 +195,8 @@ def get_last_submission_datetime_analysis(request, challenge_pk, challenge_phase
         last_submission_timestamp_in_challenge, last_submission_timestamp_in_challenge_phase, challenge_phase.pk)
 
     try:
-        serializer = LastSubmissionTimestampSerializer(last_submission_timestamp)
+        serializer = LastSubmissionTimestampSerializer(
+            last_submission_timestamp)
         response_data = serializer.data
         return Response(response_data, status=status.HTTP_200_OK)
     except:

--- a/apps/base/management/commands/seed.py
+++ b/apps/base/management/commands/seed.py
@@ -6,6 +6,7 @@ class Command(BaseCommand):
     help = "Seeds the database with random but sensible values."
 
     def handle(self, *args, **options):
-        self.stdout.write(self.style.SUCCESS('Starting the database seeder. Hang on...'))
+        self.stdout.write(
+            self.style.SUCCESS('Starting the database seeder. Hang on...'))
         call_command('runscript', 'seed', '--settings', 'settings.dev')
         self.stdout.write(self.style.SUCCESS('Database successfully seeded.'))

--- a/apps/base/models.py
+++ b/apps/base/models.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class TimeStampedModel(models.Model):
+
     """
     An abstract base class model that provides self-managed `created_at` and
     `modified_at` fields.
@@ -37,6 +38,7 @@ def create_post_model_field(sender, instance, field_name, **kwargs):
     When any model field value changes, it is used to log the change.
     """
     if getattr(instance, '_original_{}'.format(field_name)) is False:
-        logger.info('{} for {} is added first time !'.format(field_name, instance.pk))
+        logger.info(
+            '{} for {} is added first time !'.format(field_name, instance.pk))
     else:
         logger.info('{} for {} changed !'.format(field_name, instance.pk))

--- a/apps/base/utils.py
+++ b/apps/base/utils.py
@@ -27,6 +27,7 @@ def paginated_queryset(queryset, request, pagination_class=PageNumberPagination(
 
 @deconstructible
 class RandomFileName(object):
+
     def __init__(self, path):
         self.path = path
 
@@ -46,8 +47,10 @@ def get_model_object(model_name):
             model_object = model_name.objects.get(pk=pk)
             return model_object
         except model_name.DoesNotExist:
-            raise NotFound('{} {} does not exist'.format(model_name.__name__, pk))
-    get_model_by_pk.__name__ = 'get_{}_object'.format(model_name.__name__.lower())
+            raise NotFound(
+                '{} {} does not exist'.format(model_name.__name__, pk))
+    get_model_by_pk.__name__ = 'get_{}_object'.format(
+        model_name.__name__.lower())
     return get_model_by_pk
 
 
@@ -67,5 +70,5 @@ def decode_data(data):
     """
     decoded = []
     for i in data:
-        decoded.append(base64.decodestring(i+"=="))
+        decoded.append(base64.decodestring(i + "=="))
     return decoded

--- a/apps/challenges/admin.py
+++ b/apps/challenges/admin.py
@@ -14,9 +14,11 @@ from .models import (Challenge,
 
 @admin.register(Challenge)
 class ChallengeAdmin(ImportExportTimeStampedAdmin):
-    list_display = ("title", "start_date", "end_date", "creator", "published", "enable_forum", "anonymous_leaderboard",
+    list_display = (
+        "title", "start_date", "end_date", "creator", "published", "enable_forum", "anonymous_leaderboard",
                     "featured")
-    list_filter = ("creator", "published", "enable_forum", "anonymous_leaderboard", "featured")
+    list_filter = ("creator", "published",
+                   "enable_forum", "anonymous_leaderboard", "featured")
     search_fields = ("title", "creator__team_name")
 
 
@@ -29,7 +31,8 @@ class DatasetSplitAdmin(ImportExportTimeStampedAdmin):
 
 @admin.register(ChallengePhase)
 class ChallengePhaseAdmin(ImportExportTimeStampedAdmin):
-    list_display = ("name", "challenge", "start_date", "end_date", "test_annotation", "is_public", "leaderboard_public")
+    list_display = ("name", "challenge", "start_date", "end_date",
+                    "test_annotation", "is_public", "leaderboard_public")
     list_filter = ("leaderboard_public", "challenge")
     search_fields = ("name",)
 
@@ -42,15 +45,19 @@ class LeaderboardAdmin(ImportExportTimeStampedAdmin):
 
 @admin.register(ChallengePhaseSplit)
 class ChallengePhaseSplitAdmin(ImportExportTimeStampedAdmin):
-    list_display = ("id", "challenge_phase", "dataset_split", "leaderboard", "visibility")
-    list_filter = ("challenge_phase", "dataset_split", "leaderboard", "visibility")
-    search_fields = ("challenge_phase__name", "dataset_split__name", "leaderboard__id",
+    list_display = ("id", "challenge_phase",
+                    "dataset_split", "leaderboard", "visibility")
+    list_filter = (
+        "challenge_phase", "dataset_split", "leaderboard", "visibility")
+    search_fields = (
+        "challenge_phase__name", "dataset_split__name", "leaderboard__id",
                      "dataset_split__codename")
 
 
 @admin.register(LeaderboardData)
 class LeaderboardDataAdmin(ImportExportTimeStampedAdmin):
-    list_display = ("challenge_phase_split", "submission", "leaderboard", "result")
+    list_display = ("challenge_phase_split",
+                    "submission", "leaderboard", "result")
     list_filter = ("challenge_phase_split", "leaderboard",)
     search_fields = ("challenge_phase_split__challenge_phase__name",
                      "submission__participant_team__team_name", "leaderboard__schema", "result")

--- a/apps/challenges/migrations/0001_initial.py
+++ b/apps/challenges/migrations/0001_initial.py
@@ -18,21 +18,30 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Challenge',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
                 ('title', models.CharField(max_length=100)),
                 ('description', models.TextField(blank=True, null=True)),
-                ('terms_and_conditions', models.TextField(blank=True, null=True)),
-                ('submission_guidelines', models.TextField(blank=True, null=True)),
-                ('evaluation_details', models.TextField(blank=True, null=True)),
-                ('image', models.ImageField(blank=True, null=True, upload_to='logos', verbose_name='Logo')),
-                ('start_date', models.DateTimeField(blank=True, null=True, verbose_name='Start Date (UTC)')),
-                ('end_date', models.DateTimeField(blank=True, null=True, verbose_name='End Date (UTC)')),
-                ('published', models.BooleanField(default=False, verbose_name='Publicly Available')),
+                ('terms_and_conditions',
+                 models.TextField(blank=True, null=True)),
+                ('submission_guidelines',
+                 models.TextField(blank=True, null=True)),
+                ('evaluation_details',
+                 models.TextField(blank=True, null=True)),
+                ('image', models.ImageField(
+                    blank=True, null=True, upload_to='logos', verbose_name='Logo')),
+                ('start_date', models.DateTimeField(
+                    blank=True, null=True, verbose_name='Start Date (UTC)')),
+                ('end_date', models.DateTimeField(
+                    blank=True, null=True, verbose_name='End Date (UTC)')),
+                ('published', models.BooleanField(
+                    default=False, verbose_name='Publicly Available')),
                 ('enable_forum', models.BooleanField(default=True)),
                 ('anonymous_leaderboard', models.BooleanField(default=False)),
-                ('creator', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='challenge_creator', to='hosts.ChallengeHostTeam')),
+                ('creator', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE,
+                 related_name='challenge_creator', to='hosts.ChallengeHostTeam')),
             ],
             options={
                 'db_table': 'challenge',
@@ -41,13 +50,15 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Phase',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
                 ('name', models.CharField(max_length=100)),
                 ('description', models.TextField()),
                 ('leaderboard_public', models.BooleanField(default=False)),
-                ('challenge', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='challenges.Challenge')),
+                ('challenge', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE, to='challenges.Challenge')),
             ],
             options={
                 'db_table': 'challenge_phase',

--- a/apps/challenges/migrations/0003_auto_20161203_2258.py
+++ b/apps/challenges/migrations/0003_auto_20161203_2258.py
@@ -15,6 +15,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='challenge',
             name='participant_teams',
-            field=models.ManyToManyField(blank=True, to='participants.ParticipantTeam'),
+            field=models.ManyToManyField(
+                blank=True, to='participants.ParticipantTeam'),
         ),
     ]

--- a/apps/challenges/migrations/0005_changed_phase_model.py
+++ b/apps/challenges/migrations/0005_changed_phase_model.py
@@ -16,14 +16,17 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='TestEnvironment',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
                 ('name', models.CharField(max_length=100)),
                 ('description', models.TextField()),
                 ('leaderboard_public', models.BooleanField(default=False)),
-                ('start_date', models.DateTimeField(blank=True, null=True, verbose_name='Start Date (UTC)')),
-                ('end_date', models.DateTimeField(blank=True, null=True, verbose_name='End Date (UTC)')),
+                ('start_date', models.DateTimeField(
+                    blank=True, null=True, verbose_name='Start Date (UTC)')),
+                ('end_date', models.DateTimeField(
+                    blank=True, null=True, verbose_name='End Date (UTC)')),
                 ('test_annotation', models.FileField(upload_to=b'')),
             ],
             options={
@@ -45,6 +48,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='testenvironment',
             name='challenge',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='challenges.Challenge'),
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE, to='challenges.Challenge'),
         ),
     ]

--- a/apps/challenges/migrations/0006_changed_path_to_upload.py
+++ b/apps/challenges/migrations/0006_changed_path_to_upload.py
@@ -15,7 +15,8 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='challenge',
             name='evaluation_script',
-            field=models.FileField(default=False, upload_to='evaluationScripts'),
+            field=models.FileField(
+                default=False, upload_to='evaluationScripts'),
         ),
         migrations.AlterField(
             model_name='testenvironment',

--- a/apps/challenges/migrations/0010_update_upload_folder_names.py
+++ b/apps/challenges/migrations/0010_update_upload_folder_names.py
@@ -15,7 +15,8 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='challenge',
             name='evaluation_script',
-            field=models.FileField(default=False, upload_to='evaluation_scripts'),
+            field=models.FileField(
+                default=False, upload_to='evaluation_scripts'),
         ),
         migrations.AlterField(
             model_name='challengephase',

--- a/apps/challenges/migrations/0011_approved_by_admin_field_added.py
+++ b/apps/challenges/migrations/0011_approved_by_admin_field_added.py
@@ -15,6 +15,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='challenge',
             name='approved_by_admin',
-            field=models.BooleanField(default=False, verbose_name='Approved By Admin'),
+            field=models.BooleanField(
+                default=False, verbose_name='Approved By Admin'),
         ),
     ]

--- a/apps/challenges/migrations/0015_added_dataset_split.py
+++ b/apps/challenges/migrations/0015_added_dataset_split.py
@@ -15,7 +15,8 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='DatasetSplit',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
                 ('name', models.CharField(max_length=100)),

--- a/apps/challenges/migrations/0016_added_dataset_split_as_m2m_field.py
+++ b/apps/challenges/migrations/0016_added_dataset_split_as_m2m_field.py
@@ -15,6 +15,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='challengephase',
             name='dataset_split',
-            field=models.ManyToManyField(blank=True, to='challenges.DatasetSplit'),
+            field=models.ManyToManyField(
+                blank=True, to='challenges.DatasetSplit'),
         ),
     ]

--- a/apps/challenges/migrations/0017_added_leaderboard_table.py
+++ b/apps/challenges/migrations/0017_added_leaderboard_table.py
@@ -16,7 +16,8 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Leaderboard',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
                 ('schema', django.contrib.postgres.fields.jsonb.JSONField()),

--- a/apps/challenges/migrations/0018_added_challenge_phase_split_table.py
+++ b/apps/challenges/migrations/0018_added_challenge_phase_split_table.py
@@ -16,13 +16,19 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='ChallengePhaseSplit',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
-                ('visibility', models.CharField(choices=[('1', 'host'), ('2', 'owner and host'), ('3', 'public')], default='3', max_length=1)),
-                ('challenge_phase', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='challenges.ChallengePhase')),
-                ('dataset_split', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='challenges.DatasetSplit')),
-                ('leaderboard', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='challenges.Leaderboard')),
+                ('visibility', models.CharField(
+                    choices=[(
+                        '1', 'host'), ('2', 'owner and host'), ('3', 'public')], default='3', max_length=1)),
+                ('challenge_phase', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE, to='challenges.ChallengePhase')),
+                ('dataset_split', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE, to='challenges.DatasetSplit')),
+                ('leaderboard', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE, to='challenges.Leaderboard')),
             ],
             options={
                 'db_table': 'challenge_phase_split',

--- a/apps/challenges/migrations/0019_added_leaderboard_data_table.py
+++ b/apps/challenges/migrations/0019_added_leaderboard_data_table.py
@@ -18,13 +18,17 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='LeaderboardData',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
                 ('result', django.contrib.postgres.fields.jsonb.JSONField()),
-                ('challenge_phase_split', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='challenges.ChallengePhaseSplit')),
-                ('leaderboard', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='challenges.Leaderboard')),
-                ('submission', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='jobs.Submission')),
+                ('challenge_phase_split', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE, to='challenges.ChallengePhaseSplit')),
+                ('leaderboard', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE, to='challenges.Leaderboard')),
+                ('submission', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE, to='jobs.Submission')),
             ],
             options={
                 'db_table': 'leaderboard_data',

--- a/apps/challenges/migrations/0020_alter_challenge_phase_split.py
+++ b/apps/challenges/migrations/0020_alter_challenge_phase_split.py
@@ -15,6 +15,8 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='challengephasesplit',
             name='visibility',
-            field=models.PositiveSmallIntegerField(choices=[(1, 'host'), (2, 'owner and host'), (3, 'public')], default=3),
+            field=models.PositiveSmallIntegerField(
+                choices=[(
+                    1, 'host'), (2, 'owner and host'), (3, 'public')], default=3),
         ),
     ]

--- a/apps/challenges/migrations/0022_challengephase_dataset_split.py
+++ b/apps/challenges/migrations/0022_challengephase_dataset_split.py
@@ -15,6 +15,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='challengephase',
             name='dataset_split',
-            field=models.ManyToManyField(blank=True, through='challenges.ChallengePhaseSplit', to='challenges.DatasetSplit'),
+            field=models.ManyToManyField(
+                blank=True, through='challenges.ChallengePhaseSplit', to='challenges.DatasetSplit'),
         ),
     ]

--- a/apps/challenges/migrations/0023_upload_unique_random_filename.py
+++ b/apps/challenges/migrations/0023_upload_unique_random_filename.py
@@ -16,11 +16,14 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='challenge',
             name='evaluation_script',
-            field=models.FileField(default=False, upload_to=base.utils.RandomFileName('evaluation_scripts')),
+            field=models.FileField(
+                default=False, upload_to=base.utils.RandomFileName(
+                    'evaluation_scripts')),
         ),
         migrations.AlterField(
             model_name='challengephase',
             name='test_annotation',
-            field=models.FileField(upload_to=base.utils.RandomFileName('test_annotations')),
+            field=models.FileField(
+                upload_to=base.utils.RandomFileName('test_annotations')),
         ),
     ]

--- a/apps/challenges/migrations/0026_adds_default_field_in_test_annotation.py
+++ b/apps/challenges/migrations/0026_adds_default_field_in_test_annotation.py
@@ -16,6 +16,8 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='challengephase',
             name='test_annotation',
-            field=models.FileField(default=False, upload_to=base.utils.RandomFileName('test_annotations')),
+            field=models.FileField(
+                default=False, upload_to=base.utils.RandomFileName(
+                    'test_annotations')),
         ),
     ]

--- a/apps/challenges/migrations/0028_zip_configuration_models_for_challenge_creation.py
+++ b/apps/challenges/migrations/0028_zip_configuration_models_for_challenge_creation.py
@@ -19,15 +19,24 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='ChallengeConfiguration',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
-                ('zip_configuration', models.FileField(upload_to=base.utils.RandomFileName('zip_configuration_files/challenge_zip'))),
+                ('zip_configuration', models.FileField(
+                    upload_to=base.utils.RandomFileName(
+                        'zip_configuration_files/challenge_zip'))),
                 ('is_created', models.BooleanField(default=False)),
-                ('stdout_file', models.FileField(blank=True, null=True, upload_to=base.utils.RandomFileName('zip_configuration_files/challenge_zip'))),
-                ('stderr_file', models.FileField(blank=True, null=True, upload_to=base.utils.RandomFileName('zip_configuration_files/challenge_zip'))),
-                ('challenge', models.OneToOneField(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='challenges.Challenge')),
-                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+                ('stdout_file', models.FileField(blank=True, null=True,
+                 upload_to=base.utils.RandomFileName(
+                     'zip_configuration_files/challenge_zip'))),
+                ('stderr_file', models.FileField(blank=True, null=True,
+                 upload_to=base.utils.RandomFileName(
+                     'zip_configuration_files/challenge_zip'))),
+                ('challenge', models.OneToOneField(blank=True, null=True,
+                 on_delete=django.db.models.deletion.CASCADE, to='challenges.Challenge')),
+                ('user', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'db_table': 'challenge_zip_configuration',

--- a/apps/challenges/migrations/0029_add_challenge_star.py
+++ b/apps/challenges/migrations/0029_add_challenge_star.py
@@ -18,11 +18,14 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='StarChallenge',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
-                ('challenge', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='challenges.Challenge')),
-                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+                ('challenge', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE, to='challenges.Challenge')),
+                ('user', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'db_table': 'starred_challenge',

--- a/apps/challenges/migrations/0031_add_db_index_to_challenge_related_models.py
+++ b/apps/challenges/migrations/0031_add_db_index_to_challenge_related_models.py
@@ -15,12 +15,14 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='challenge',
             name='approved_by_admin',
-            field=models.BooleanField(db_index=True, default=False, verbose_name='Approved By Admin'),
+            field=models.BooleanField(
+                db_index=True, default=False, verbose_name='Approved By Admin'),
         ),
         migrations.AlterField(
             model_name='challenge',
             name='end_date',
-            field=models.DateTimeField(blank=True, db_index=True, null=True, verbose_name='End Date (UTC)'),
+            field=models.DateTimeField(
+                blank=True, db_index=True, null=True, verbose_name='End Date (UTC)'),
         ),
         migrations.AlterField(
             model_name='challenge',
@@ -30,12 +32,14 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='challenge',
             name='published',
-            field=models.BooleanField(db_index=True, default=False, verbose_name='Publicly Available'),
+            field=models.BooleanField(
+                db_index=True, default=False, verbose_name='Publicly Available'),
         ),
         migrations.AlterField(
             model_name='challenge',
             name='start_date',
-            field=models.DateTimeField(blank=True, db_index=True, null=True, verbose_name='Start Date (UTC)'),
+            field=models.DateTimeField(
+                blank=True, db_index=True, null=True, verbose_name='Start Date (UTC)'),
         ),
         migrations.AlterField(
             model_name='challenge',
@@ -50,7 +54,8 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='challengephase',
             name='end_date',
-            field=models.DateTimeField(blank=True, db_index=True, null=True, verbose_name='End Date (UTC)'),
+            field=models.DateTimeField(
+                blank=True, db_index=True, null=True, verbose_name='End Date (UTC)'),
         ),
         migrations.AlterField(
             model_name='challengephase',
@@ -70,7 +75,8 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='challengephase',
             name='start_date',
-            field=models.DateTimeField(blank=True, db_index=True, null=True, verbose_name='Start Date (UTC)'),
+            field=models.DateTimeField(
+                blank=True, db_index=True, null=True, verbose_name='Start Date (UTC)'),
         ),
         migrations.AlterField(
             model_name='starchallenge',

--- a/apps/challenges/migrations/0032_adds_featured_field_in_challenge.py
+++ b/apps/challenges/migrations/0032_adds_featured_field_in_challenge.py
@@ -15,6 +15,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='challenge',
             name='featured',
-            field=models.BooleanField(db_index=True, default=False, verbose_name='Featured'),
+            field=models.BooleanField(
+                db_index=True, default=False, verbose_name='Featured'),
         ),
     ]

--- a/apps/challenges/models.py
+++ b/apps/challenges/models.py
@@ -6,7 +6,8 @@ from django.contrib.postgres.fields import JSONField
 from django.db import models
 from django.db.models import signals
 
-from base.models import (TimeStampedModel, model_field_name, create_post_model_field, )
+from base.models import (
+    TimeStampedModel, model_field_name, create_post_model_field, )
 from base.utils import RandomFileName
 from participants.models import (ParticipantTeam, )
 
@@ -82,7 +83,8 @@ class Challenge(TimeStampedModel):
         return False
 
 
-signals.post_save.connect(model_field_name(field_name='evaluation_script')(create_post_model_field),
+signals.post_save.connect(
+    model_field_name(field_name='evaluation_script')(create_post_model_field),
                           sender=Challenge, weak=False)
 
 
@@ -101,6 +103,7 @@ class DatasetSplit(TimeStampedModel):
 class ChallengePhase(TimeStampedModel):
 
     """Model representing a Challenge Phase"""
+
     def __init__(self, *args, **kwargs):
         super(ChallengePhase, self).__init__(*args, **kwargs)
         self._original_test_annotation = self.test_annotation
@@ -115,11 +118,15 @@ class ChallengePhase(TimeStampedModel):
     challenge = models.ForeignKey('Challenge')
     is_public = models.BooleanField(default=False)
     is_submission_public = models.BooleanField(default=False)
-    test_annotation = models.FileField(upload_to=RandomFileName("test_annotations"), default=False)
-    max_submissions_per_day = models.PositiveIntegerField(default=100000, db_index=True)
-    max_submissions = models.PositiveIntegerField(default=100000, db_index=True)
+    test_annotation = models.FileField(
+        upload_to=RandomFileName("test_annotations"), default=False)
+    max_submissions_per_day = models.PositiveIntegerField(
+        default=100000, db_index=True)
+    max_submissions = models.PositiveIntegerField(
+        default=100000, db_index=True)
     codename = models.CharField(max_length=100, default="Phase Code Name")
-    dataset_split = models.ManyToManyField(DatasetSplit, blank=True, through='ChallengePhaseSplit')
+    dataset_split = models.ManyToManyField(
+        DatasetSplit, blank=True, through='ChallengePhaseSplit')
 
     class Meta:
         app_label = 'challenges'
@@ -146,7 +153,8 @@ class ChallengePhase(TimeStampedModel):
         return False
 
 
-signals.post_save.connect(model_field_name(field_name='test_annotation')(create_post_model_field),
+signals.post_save.connect(
+    model_field_name(field_name='test_annotation')(create_post_model_field),
                           sender=ChallengePhase, weak=False)
 
 
@@ -207,16 +215,20 @@ class LeaderboardData(TimeStampedModel):
 
 
 class ChallengeConfiguration(TimeStampedModel):
+
     """
     Model to store zip file for challenge creation.
     """
     user = models.ForeignKey(User)
     challenge = models.OneToOneField(Challenge, null=True, blank=True)
-    zip_configuration = models.FileField(upload_to=RandomFileName('zip_configuration_files/challenge_zip'))
+    zip_configuration = models.FileField(
+        upload_to=RandomFileName('zip_configuration_files/challenge_zip'))
     is_created = models.BooleanField(default=False, db_index=True)
-    stdout_file = models.FileField(upload_to=RandomFileName('zip_configuration_files/challenge_zip'),
+    stdout_file = models.FileField(
+        upload_to=RandomFileName('zip_configuration_files/challenge_zip'),
                                    null=True, blank=True)
-    stderr_file = models.FileField(upload_to=RandomFileName('zip_configuration_files/challenge_zip'),
+    stderr_file = models.FileField(
+        upload_to=RandomFileName('zip_configuration_files/challenge_zip'),
                                    null=True, blank=True)
 
     class Meta:
@@ -225,6 +237,7 @@ class ChallengeConfiguration(TimeStampedModel):
 
 
 class StarChallenge(TimeStampedModel):
+
     """
     Model to star a challenge
     """

--- a/apps/challenges/permissions.py
+++ b/apps/challenges/permissions.py
@@ -4,6 +4,7 @@ from .models import Challenge
 
 
 class IsChallengeCreator(permissions.BasePermission):
+
     """
     Permission class for edit/delete a challenge.
     """
@@ -15,7 +16,8 @@ class IsChallengeCreator(permissions.BasePermission):
             return True
         elif request.method in ['DELETE', 'PATCH', 'PUT', 'POST']:
             try:
-                challenge = Challenge.objects.get(pk=request.parser_context['kwargs']['challenge_pk'])
+                challenge = Challenge.objects.get(
+                    pk=request.parser_context['kwargs']['challenge_pk'])
             except Challenge.DoesNotExist:
                 return False
 

--- a/apps/challenges/serializers.py
+++ b/apps/challenges/serializers.py
@@ -26,7 +26,8 @@ class ChallengeSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Challenge
-        fields = ('id', 'title', 'short_description', 'description', 'terms_and_conditions',
+        fields = (
+            'id', 'title', 'short_description', 'description', 'terms_and_conditions',
                   'submission_guidelines', 'evaluation_details',
                   'image', 'start_date', 'end_date', 'creator',
                   'published', 'enable_forum', 'anonymous_leaderboard', 'is_active',)
@@ -46,7 +47,8 @@ class ChallengePhaseSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = ChallengePhase
-        fields = ('id', 'name', 'description', 'leaderboard_public', 'start_date',
+        fields = (
+            'id', 'name', 'description', 'leaderboard_public', 'start_date',
                   'end_date', 'challenge', 'max_submissions_per_day', 'max_submissions',
                   'is_public', 'is_active', 'codename',)
 
@@ -59,6 +61,7 @@ class DatasetSplitSerializer(serializers.ModelSerializer):
 
 
 class ChallengePhaseSplitSerializer(serializers.ModelSerializer):
+
     """Serialize the ChallengePhaseSplits Model"""
 
     dataset_split_name = serializers.SerializerMethodField()
@@ -66,7 +69,8 @@ class ChallengePhaseSplitSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = ChallengePhaseSplit
-        fields = ('id', 'dataset_split', 'challenge_phase', 'challenge_phase_name', 'dataset_split_name', 'visibility')
+        fields = ('id', 'dataset_split', 'challenge_phase',
+                  'challenge_phase_name', 'dataset_split_name', 'visibility')
 
     def get_dataset_split_name(self, obj):
         return obj.dataset_split.name
@@ -76,9 +80,11 @@ class ChallengePhaseSplitSerializer(serializers.ModelSerializer):
 
 
 class ChallengeConfigSerializer(serializers.ModelSerializer):
+
     """
     Serialize the ChallengeConfiguration Model.
     """
+
     def __init__(self, *args, **kwargs):
         super(ChallengeConfigSerializer, self).__init__(*args, **kwargs)
         context = kwargs.get('context')
@@ -92,6 +98,7 @@ class ChallengeConfigSerializer(serializers.ModelSerializer):
 
 
 class LeaderboardSerializer(serializers.ModelSerializer):
+
     """
     Serialize the Leaderboard Model.
     """
@@ -101,9 +108,11 @@ class LeaderboardSerializer(serializers.ModelSerializer):
 
 
 class ZipChallengeSerializer(ChallengeSerializer):
+
     """
     Serializer used for creating challenge through zip file.
     """
+
     def __init__(self, *args, **kwargs):
         super(ZipChallengeSerializer, self).__init__(*args, **kwargs)
 
@@ -118,18 +127,21 @@ class ZipChallengeSerializer(ChallengeSerializer):
 
     class Meta:
         model = Challenge
-        fields = ('id', 'title', 'short_description', 'description', 'terms_and_conditions',
+        fields = (
+            'id', 'title', 'short_description', 'description', 'terms_and_conditions',
                   'submission_guidelines', 'start_date', 'end_date', 'creator', 'evaluation_details',
                   'published', 'enable_forum', 'anonymous_leaderboard', 'image', 'is_active', 'evaluation_script',)
 
 
 class ZipChallengePhaseSplitSerializer(serializers.ModelSerializer):
+
     """
     Serializer used for creating challenge phase split through zip file.
     """
     class Meta:
         model = ChallengePhaseSplit
-        fields = ('id', 'challenge_phase', 'dataset_split', 'leaderboard', 'visibility')
+        fields = ('id', 'challenge_phase',
+                  'dataset_split', 'leaderboard', 'visibility')
 
 
 class ChallengePhaseCreateSerializer(serializers.ModelSerializer):
@@ -149,7 +161,8 @@ class ChallengePhaseCreateSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = ChallengePhase
-        fields = ('id', 'name', 'description', 'leaderboard_public', 'start_date',
+        fields = (
+            'id', 'name', 'description', 'leaderboard_public', 'start_date',
                   'end_date', 'challenge', 'max_submissions_per_day', 'max_submissions',
                   'is_public', 'is_active', 'codename', 'test_annotation')
 
@@ -177,5 +190,6 @@ class StarChallengeSerializer(serializers.ModelSerializer):
         fields = ('user', 'challenge', 'count', 'is_starred')
 
     def get_count(self, obj):
-        count = StarChallenge.objects.filter(challenge=obj.challenge, is_starred=True).count()
+        count = StarChallenge.objects.filter(
+            challenge=obj.challenge, is_starred=True).count()
         return count

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -21,7 +21,8 @@ from rest_framework.decorators import (api_view,
                                        permission_classes,
                                        throttle_classes,)
 from rest_framework.response import Response
-from rest_framework_expiring_authtoken.authentication import (ExpiringTokenAuthentication,)
+from rest_framework_expiring_authtoken.authentication import (
+    ExpiringTokenAuthentication,)
 from rest_framework.throttling import UserRateThrottle, AnonRateThrottle
 
 from accounts.permissions import HasVerifiedEmail
@@ -72,7 +73,8 @@ except NameError:
 @authentication_classes((ExpiringTokenAuthentication,))
 def challenge_list(request, challenge_host_team_pk):
     try:
-        challenge_host_team = ChallengeHostTeam.objects.get(pk=challenge_host_team_pk)
+        challenge_host_team = ChallengeHostTeam.objects.get(
+            pk=challenge_host_team_pk)
     except ChallengeHostTeam.DoesNotExist:
         response_data = {'error': 'ChallengeHostTeam does not exist'}
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
@@ -80,7 +82,8 @@ def challenge_list(request, challenge_host_team_pk):
     if request.method == 'GET':
         challenge = Challenge.objects.filter(creator=challenge_host_team)
         paginator, result_page = paginated_queryset(challenge, request)
-        serializer = ChallengeSerializer(result_page, many=True, context={'request': request})
+        serializer = ChallengeSerializer(
+            result_page, many=True, context={'request': request})
         response_data = serializer.data
         return paginator.get_paginated_response(response_data)
 
@@ -91,7 +94,8 @@ def challenge_list(request, challenge_host_team_pk):
             return Response(response_data, status=status.HTTP_401_UNAUTHORIZED)
 
         serializer = ZipChallengeSerializer(data=request.data,
-                                            context={'challenge_host_team': challenge_host_team,
+                                            context={
+                                                'challenge_host_team': challenge_host_team,
                                                      'request': request})
         if serializer.is_valid():
             serializer.save()
@@ -108,7 +112,8 @@ def challenge_list(request, challenge_host_team_pk):
 @authentication_classes((ExpiringTokenAuthentication,))
 def challenge_detail(request, challenge_host_team_pk, challenge_pk):
     try:
-        challenge_host_team = ChallengeHostTeam.objects.get(pk=challenge_host_team_pk)
+        challenge_host_team = ChallengeHostTeam.objects.get(
+            pk=challenge_host_team_pk)
     except ChallengeHostTeam.DoesNotExist:
         response_data = {'error': 'ChallengeHostTeam does not exist'}
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
@@ -120,7 +125,8 @@ def challenge_detail(request, challenge_host_team_pk, challenge_pk):
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     if request.method == 'GET':
-        serializer = ChallengeSerializer(challenge, context={'request': request})
+        serializer = ChallengeSerializer(
+            challenge, context={'request': request})
         response_data = serializer.data
         return Response(response_data, status=status.HTTP_200_OK)
 
@@ -128,13 +134,15 @@ def challenge_detail(request, challenge_host_team_pk, challenge_pk):
         if request.method == 'PATCH':
             serializer = ZipChallengeSerializer(challenge,
                                                 data=request.data,
-                                                context={'challenge_host_team': challenge_host_team,
+                                                context={
+                                                    'challenge_host_team': challenge_host_team,
                                                          'request': request},
                                                 partial=True)
         else:
             serializer = ZipChallengeSerializer(challenge,
                                                 data=request.data,
-                                                context={'challenge_host_team': challenge_host_team,
+                                                context={
+                                                    'challenge_host_team': challenge_host_team,
                                                          'request': request})
         if serializer.is_valid():
             serializer.save()
@@ -178,7 +186,8 @@ def add_participant_team_to_challenge(request, challenge_pk, participant_team_pk
         team__id=participant_team_pk).values_list('user', flat=True))
 
     if challenge_host_team_user_ids & participant_team_user_ids:
-        response_data = {'error': 'Sorry, You cannot participate in your own challenge!',
+        response_data = {
+            'error': 'Sorry, You cannot participate in your own challenge!',
                          'challenge_id': int(challenge_pk), 'participant_team_id': int(participant_team_pk)}
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
@@ -190,7 +199,8 @@ def add_participant_team_to_challenge(request, challenge_pk, participant_team_pk
             return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     if participant_team.challenge_set.filter(id=challenge_pk).exists():
-        response_data = {'error': 'Team already exists', 'challenge_id': int(challenge_pk),
+        response_data = {
+            'error': 'Team already exists', 'challenge_id': int(challenge_pk),
                          'participant_team_id': int(participant_team_pk)}
         return Response(response_data, status=status.HTTP_200_OK)
     else:
@@ -239,7 +249,8 @@ def get_all_challenges(request, challenge_time):
 
     challenge = Challenge.objects.filter(**q_params)
     paginator, result_page = paginated_queryset(challenge, request)
-    serializer = ChallengeSerializer(result_page, many=True, context={'request': request})
+    serializer = ChallengeSerializer(
+        result_page, many=True, context={'request': request})
     response_data = serializer.data
     return paginator.get_paginated_response(response_data)
 
@@ -252,7 +263,8 @@ def get_challenge_by_pk(request, pk):
     """
     try:
         challenge = Challenge.objects.get(pk=pk)
-        serializer = ChallengeSerializer(challenge, context={'request': request})
+        serializer = ChallengeSerializer(
+            challenge, context={'request': request})
         response_data = serializer.data
         return Response(response_data, status=status.HTTP_200_OK)
     except:
@@ -294,7 +306,8 @@ def get_challenges_based_on_teams(request):
 
     challenge = Challenge.objects.filter(**q_params)
     paginator, result_page = paginated_queryset(challenge, request)
-    serializer = ChallengeSerializer(result_page, many=True, context={'request': request})
+    serializer = ChallengeSerializer(
+        result_page, many=True, context={'request': request})
     response_data = serializer.data
     return paginator.get_paginated_response(response_data)
 
@@ -311,7 +324,8 @@ def challenge_phase_list(request, challenge_pk):
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     if request.method == 'GET':
-        challenge_phase = ChallengePhase.objects.filter(challenge=challenge, is_public=True)
+        challenge_phase = ChallengePhase.objects.filter(
+            challenge=challenge, is_public=True)
         paginator, result_page = paginated_queryset(challenge_phase, request)
         serializer = ChallengePhaseSerializer(result_page, many=True)
         response_data = serializer.data
@@ -355,7 +369,8 @@ def challenge_phase_detail(request, challenge_pk, pk):
         if request.method == 'PATCH':
             serializer = ChallengePhaseCreateSerializer(challenge_phase,
                                                         data=request.data,
-                                                        context={'challenge': challenge},
+                                                        context={
+                                                            'challenge': challenge},
                                                         partial=True)
         else:
             serializer = ChallengePhaseCreateSerializer(challenge_phase,
@@ -387,8 +402,10 @@ def challenge_phase_split_list(request, challenge_pk):
         response_data = {'error': 'Challenge does not exist'}
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
-    challenge_phase_split = ChallengePhaseSplit.objects.filter(challenge_phase__challenge=challenge)
-    serializer = ChallengePhaseSplitSerializer(challenge_phase_split, many=True)
+    challenge_phase_split = ChallengePhaseSplit.objects.filter(
+        challenge_phase__challenge=challenge)
+    serializer = ChallengePhaseSplitSerializer(
+        challenge_phase_split, many=True)
     response_data = serializer.data
     return Response(response_data, status=status.HTTP_200_OK)
 
@@ -403,7 +420,8 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
     """
     challenge_host_team = get_challenge_host_team_model(challenge_host_team_pk)
 
-    serializer = ChallengeConfigSerializer(data=request.data, context={'request': request})
+    serializer = ChallengeConfigSerializer(
+        data=request.data, context={'request': request})
     if serializer.is_valid():
         uploaded_zip_file = serializer.save()
         uploaded_zip_file_path = serializer.data['zip_configuration']
@@ -415,8 +433,10 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
     BASE_LOCATION = tempfile.mkdtemp()
     try:
         response = requests.get(uploaded_zip_file_path, stream=True)
-        unique_folder_name = ''.join([random.choice(string.ascii_letters + string.digits) for i in xrange(10)])
-        CHALLENGE_ZIP_DOWNLOAD_LOCATION = join(BASE_LOCATION, '{}.zip'.format(unique_folder_name))
+        unique_folder_name = ''.join(
+            [random.choice(string.ascii_letters + string.digits) for i in xrange(10)])
+        CHALLENGE_ZIP_DOWNLOAD_LOCATION = join(
+            BASE_LOCATION, '{}.zip'.format(unique_folder_name))
         try:
             if response and response.status_code == 200:
                 with open(CHALLENGE_ZIP_DOWNLOAD_LOCATION, 'w') as zip_file:
@@ -424,13 +444,13 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
         except IOError:
             response_data = {
                 'error': 'Unable to process the uploaded zip file. Please upload it again!'
-                }
+            }
             return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
     except requests.exceptions.RequestException:
         response_data = {
             'error': 'A server error occured while processing zip file. Please try uploading it again!'
-            }
+        }
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     # Extract zip file
@@ -441,7 +461,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
     except zipfile.BadZipfile:
         response_data = {
             'error': 'The zip file contents cannot be extracted. Please check the format!'
-            }
+        }
         return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
     # Search for yaml file
@@ -455,13 +475,13 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
     if not yaml_file_count:
         response_data = {
             'error': 'There is no YAML file in zip configuration you provided!'
-            }
+        }
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     if yaml_file_count > 1:
         response_data = {
             'error': 'There are more than one YAML files in zip folder!'
-            }
+        }
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     try:
@@ -470,7 +490,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
     except yaml.YAMLError as exc:
         response_data = {
             'error': exc
-            }
+        }
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     # Check for evaluation script path in yaml file.
@@ -484,18 +504,19 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
         response_data = {
             'error': ('There is no key for evaluation script in yaml file.'
                       'Please add a key and then try uploading it again!')
-            }
+        }
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     # Check for evaluation script file in extracted zip folder.
     if isfile(evaluation_script_path):
         with open(evaluation_script_path, 'rb') as challenge_evaluation_script:
-            challenge_evaluation_script_file = ContentFile(challenge_evaluation_script.read(), evaluation_script_path)
+            challenge_evaluation_script_file = ContentFile(
+                challenge_evaluation_script.read(), evaluation_script_path)
     else:
         response_data = {
             'error': ('No evaluation script is present in the zip file.'
                       'Please try uploading again the zip file after adding evaluation script!')
-            }
+        }
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     # Check for test annotation file path in yaml file.
@@ -512,7 +533,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                 'error': ('There is no key for test annotation file for'
                           'challenge phase {} in yaml file.'
                           'Please add a key and then try uploading it again!'.format(data['name']))
-                }
+            }
             return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
         if not isfile(test_annotation_file_path):
@@ -531,7 +552,8 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                                     extracted_folder_name,
                                     image)
         if isfile(challenge_image_path):
-            challenge_image_file = ContentFile(get_file_content(challenge_image_path, 'rb'), image)
+            challenge_image_file = ContentFile(
+                get_file_content(challenge_image_path, 'rb'), image)
         else:
             challenge_image_file = None
     else:
@@ -543,7 +565,8 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                                            extracted_folder_name,
                                            yaml_file_data['description'])
     if challenge_description_file_path.endswith('.html') and isfile(challenge_description_file_path):
-        yaml_file_data['description'] = get_file_content(challenge_description_file_path, 'rb').decode('utf-8')
+        yaml_file_data['description'] = get_file_content(
+            challenge_description_file_path, 'rb').decode('utf-8')
     else:
         yaml_file_data['description'] = None
 
@@ -555,8 +578,9 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
 
     if (challenge_evaluation_details_file_path.endswith('.html') and
             isfile(challenge_evaluation_details_file_path)):
-        yaml_file_data['evaluation_details'] = get_file_content(challenge_evaluation_details_file_path,
-                                                                'rb').decode('utf-8')
+        yaml_file_data[
+            'evaluation_details'] = get_file_content(challenge_evaluation_details_file_path,
+                                                     'rb').decode('utf-8')
     else:
         yaml_file_data['evaluation_details'] = None
 
@@ -566,8 +590,9 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                                               extracted_folder_name,
                                               yaml_file_data['terms_and_conditions'])
     if challenge_terms_and_cond_file_path.endswith('.html') and isfile(challenge_terms_and_cond_file_path):
-        yaml_file_data['terms_and_conditions'] = get_file_content(challenge_terms_and_cond_file_path,
-                                                                  'rb').decode('utf-8')
+        yaml_file_data[
+            'terms_and_conditions'] = get_file_content(challenge_terms_and_cond_file_path,
+                                                       'rb').decode('utf-8')
     else:
         yaml_file_data['terms_and_conditions'] = None
 
@@ -578,8 +603,9 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                                                      yaml_file_data['submission_guidelines'])
     if (challenge_submission_guidelines_file_path.endswith('.html')
             and isfile(challenge_submission_guidelines_file_path)):
-        yaml_file_data['submission_guidelines'] = get_file_content(challenge_submission_guidelines_file_path,
-                                                                   'rb').decode('utf-8')
+        yaml_file_data[
+            'submission_guidelines'] = get_file_content(challenge_submission_guidelines_file_path,
+                                                        'rb').decode('utf-8')
     else:
         yaml_file_data['submission_guidelines'] = None
 
@@ -608,7 +634,8 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                     response_data = serializer.errors
 
             # Create Challenge Phase
-            yaml_file_data_of_challenge_phases = yaml_file_data['challenge_phases']
+            yaml_file_data_of_challenge_phases = yaml_file_data[
+                'challenge_phases']
             challenge_phase_ids = {}
             for data in yaml_file_data_of_challenge_phases:
                 # Check for challenge phase description file
@@ -618,7 +645,8 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                                                              data['description'])
                 if (challenge_phase_description_file_path.endswith('.html')
                         and isfile(challenge_phase_description_file_path)):
-                    data['description'] = get_file_content(challenge_phase_description_file_path, 'rb').decode('utf-8')
+                    data['description'] = get_file_content(
+                        challenge_phase_description_file_path, 'rb').decode('utf-8')
                 else:
                     data['description'] = None
 
@@ -631,14 +659,17 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                                                      )
                 if isfile(test_annotation_file_path):
                     with open(test_annotation_file_path, 'rb') as test_annotation_file:
-                        challenge_test_annotation_file = ContentFile(test_annotation_file.read(),
+                        challenge_test_annotation_file = ContentFile(
+                            test_annotation_file.read(),
                                                                      test_annotation_file_path)
                 serializer = ChallengePhaseCreateSerializer(data=data,
-                                                            context={'challenge': challenge,
+                                                            context={
+                                                                'challenge': challenge,
                                                                      'test_annotation': challenge_test_annotation_file})
                 if serializer.is_valid():
                     serializer.save()
-                    challenge_phase_ids[str(data['id'])] = serializer.instance.pk
+                    challenge_phase_ids[
+                        str(data['id'])] = serializer.instance.pk
                 else:
                     response_data = serializer.errors
 
@@ -655,11 +686,14 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                     response_data = serializer.errors
 
             # Create Challenge Phase Splits
-            yaml_file_data_of_challenge_phase_splits = yaml_file_data['challenge_phase_splits']
+            yaml_file_data_of_challenge_phase_splits = yaml_file_data[
+                'challenge_phase_splits']
             for data in yaml_file_data_of_challenge_phase_splits:
-                challenge_phase = challenge_phase_ids[str(data['challenge_phase_id'])]
+                challenge_phase = challenge_phase_ids[
+                    str(data['challenge_phase_id'])]
                 leaderboard = leaderboard_ids[str(data['leaderboard_id'])]
-                dataset_split = dataset_split_ids[str(data['dataset_split_id'])]
+                dataset_split = dataset_split_ids[
+                    str(data['dataset_split_id'])]
                 visibility = data['visibility']
 
                 data = {
@@ -675,7 +709,8 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                 else:
                     response_data = serializer.errors
 
-        zip_config = ChallengeConfiguration.objects.get(pk=uploaded_zip_file.pk)
+        zip_config = ChallengeConfiguration.objects.get(
+            pk=uploaded_zip_file.pk)
         if zip_config:
             zip_config.challenge = challenge
             zip_config.save()
@@ -689,21 +724,24 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                 response_data = {'error': response_data.values()[0]}
                 return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
         except:
-            response_data = {'error': 'Error in creating challenge. Please check the yaml configuration!'}
+            response_data = {
+                'error': 'Error in creating challenge. Please check the yaml configuration!'}
             return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
         finally:
             try:
                 shutil.rmtree(BASE_LOCATION)
                 logger.info('Zip folder is removed')
             except:
-                logger.info('Zip folder for challenge {} is not removed from location'.format(challenge.pk,
-                                                                                              BASE_LOCATION))
+                logger.info(
+                    'Zip folder for challenge {} is not removed from location'.format(challenge.pk,
+                                                                                      BASE_LOCATION))
     try:
         shutil.rmtree(BASE_LOCATION)
         logger.info('Zip folder is removed')
     except:
-        logger.info('Zip folder for challenge {} is not removed from location'.format(challenge.pk,
-                                                                                      BASE_LOCATION))
+        logger.info(
+            'Zip folder for challenge {} is not removed from location'.format(challenge.pk,
+                                                                              BASE_LOCATION))
 
 
 @throttle_classes([UserRateThrottle])
@@ -717,40 +755,49 @@ def get_all_submissions_of_challenge(request, challenge_pk, challenge_phase_pk):
     # To check for the corresponding challenge from challenge_pk.
     challenge = get_challenge_model(challenge_pk)
 
-    # To check for the corresponding challenge phase from the challenge_phase_pk and challenge.
+    # To check for the corresponding challenge phase from the
+    # challenge_phase_pk and challenge.
     try:
-        challenge_phase = ChallengePhase.objects.get(pk=challenge_phase_pk, challenge=challenge)
+        challenge_phase = ChallengePhase.objects.get(
+            pk=challenge_phase_pk, challenge=challenge)
     except ChallengePhase.DoesNotExist:
-        response_data = {'error': 'Challenge Phase {} does not exist'.format(challenge_phase_pk)}
+        response_data = {
+            'error': 'Challenge Phase {} does not exist'.format(challenge_phase_pk)}
         return Response(response_data, status=status.HTTP_404_NOT_FOUND)
 
-    # To check for the user as a host of the challenge from the request and challenge_pk.
+    # To check for the user as a host of the challenge from the request and
+    # challenge_pk.
     if is_user_a_host_of_challenge(user=request.user, challenge_pk=challenge_pk):
 
         # Filter submissions on the basis of challenge for host for now. Later on, the support for query
         # parameters like challenge phase, date is to be added.
-        submissions = Submission.objects.filter(challenge_phase=challenge_phase).order_by('-submitted_at')
+        submissions = Submission.objects.filter(
+            challenge_phase=challenge_phase).order_by('-submitted_at')
         paginator, result_page = paginated_queryset(submissions, request)
         try:
-            serializer = ChallengeSubmissionManagementSerializer(result_page, many=True, context={'request': request})
+            serializer = ChallengeSubmissionManagementSerializer(
+                result_page, many=True, context={'request': request})
             response_data = serializer.data
             return paginator.get_paginated_response(response_data)
         except:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    # To check for the user as a participant of the challenge from the request and challenge_pk.
+    # To check for the user as a participant of the challenge from the request
+    # and challenge_pk.
     elif has_user_participated_in_challenge(user=request.user, challenge_id=challenge_pk):
 
         # get participant team object for the user for a particular challenge.
         participant_team_pk = get_participant_team_id_of_user_for_a_challenge(
-                request.user, challenge_pk)
+            request.user, challenge_pk)
 
         # Filter submissions on the basis of challenge phase for a participant.
-        submissions = Submission.objects.filter(participant_team=participant_team_pk,
+        submissions = Submission.objects.filter(
+            participant_team=participant_team_pk,
                                                 challenge_phase=challenge_phase).order_by('-submitted_at')
         paginator, result_page = paginated_queryset(submissions, request)
         try:
-            serializer = SubmissionSerializer(result_page, many=True, context={'request': request})
+            serializer = SubmissionSerializer(
+                result_page, many=True, context={'request': request})
             response_data = serializer.data
             return paginator.get_paginated_response(response_data)
         except:
@@ -758,7 +805,8 @@ def get_all_submissions_of_challenge(request, challenge_pk, challenge_phase_pk):
 
     # when user is neither host not participant of the challenge.
     else:
-        response_data = {'error': 'You are neither host nor participant of the challenge!'}
+        response_data = {
+            'error': 'You are neither host nor participant of the challenge!'}
         return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
 
@@ -771,19 +819,25 @@ def download_all_submissions(request, challenge_pk, challenge_phase_pk, file_typ
     # To check for the corresponding challenge from challenge_pk.
     challenge = get_challenge_model(challenge_pk)
 
-    # To check for the corresponding challenge phase from the challenge_phase_pk and challenge.
+    # To check for the corresponding challenge phase from the
+    # challenge_phase_pk and challenge.
     try:
-        challenge_phase = ChallengePhase.objects.get(pk=challenge_phase_pk, challenge=challenge)
+        challenge_phase = ChallengePhase.objects.get(
+            pk=challenge_phase_pk, challenge=challenge)
     except ChallengePhase.DoesNotExist:
-        response_data = {'error': 'Challenge Phase {} does not exist'.format(challenge_phase_pk)}
+        response_data = {
+            'error': 'Challenge Phase {} does not exist'.format(challenge_phase_pk)}
         return Response(response_data, status=status.HTTP_404_NOT_FOUND)
 
     if file_type == 'csv':
         if is_user_a_host_of_challenge(user=request.user, challenge_pk=challenge_pk):
-            submissions = Submission.objects.filter(challenge_phase__challenge=challenge).order_by('-submitted_at')
-            submissions = ChallengeSubmissionManagementSerializer(submissions, many=True, context={'request': request})
+            submissions = Submission.objects.filter(
+                challenge_phase__challenge=challenge).order_by('-submitted_at')
+            submissions = ChallengeSubmissionManagementSerializer(
+                submissions, many=True, context={'request': request})
             response = HttpResponse(content_type='text/csv')
-            response['Content-Disposition'] = 'attachment; filename=all_submissions.csv'
+            response[
+                'Content-Disposition'] = 'attachment; filename=all_submissions.csv'
             writer = csv.writer(response)
             writer.writerow(['id',
                              'Team Name',
@@ -804,8 +858,12 @@ def download_all_submissions(request, challenge_pk, challenge_phase_pk, file_typ
             for submission in submissions.data:
                 writer.writerow([submission['id'],
                                  submission['participant_team'],
-                                 ",".join(username['username'] for username in submission['participant_team_members']),
-                                 ",".join(email['email'] for email in submission['participant_team_members']),
+                                 ",".join(username['username']
+                                          for username in submission[
+                                              'participant_team_members']),
+                                 ",".join(email['email']
+                                          for email in submission[
+                                              'participant_team_members']),
                                  submission['challenge_phase'],
                                  submission['status'],
                                  submission['created_by'],
@@ -822,16 +880,21 @@ def download_all_submissions(request, challenge_pk, challenge_phase_pk, file_typ
 
         elif has_user_participated_in_challenge(user=request.user, challenge_id=challenge_pk):
 
-            # get participant team object for the user for a particular challenge.
+            # get participant team object for the user for a particular
+            # challenge.
             participant_team_pk = get_participant_team_id_of_user_for_a_challenge(
                 request.user, challenge_pk)
 
-            # Filter submissions on the basis of challenge phase for a participant.
-            submissions = Submission.objects.filter(participant_team=participant_team_pk,
+            # Filter submissions on the basis of challenge phase for a
+            # participant.
+            submissions = Submission.objects.filter(
+                participant_team=participant_team_pk,
                                                     challenge_phase=challenge_phase).order_by('-submitted_at')
-            submissions = ChallengeSubmissionManagementSerializer(submissions, many=True, context={'request': request})
+            submissions = ChallengeSubmissionManagementSerializer(
+                submissions, many=True, context={'request': request})
             response = HttpResponse(content_type='text/csv')
-            response['Content-Disposition'] = 'attachment; filename=all_submissions.csv'
+            response[
+                'Content-Disposition'] = 'attachment; filename=all_submissions.csv'
             writer = csv.writer(response)
             writer.writerow(['Team Name',
                              'Method Name',
@@ -856,7 +919,8 @@ def download_all_submissions(request, challenge_pk, challenge_phase_pk, file_typ
                                  ])
             return response
         else:
-            response_data = {'error': 'You are neither host nor participant of the challenge!'}
+            response_data = {
+                'error': 'You are neither host nor participant of the challenge!'}
             return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
     else:
         response_data = {'error': 'The file type requested is not valid!'}
@@ -871,7 +935,8 @@ def create_leaderboard(request):
     """
     Creates a leaderboard
     """
-    serializer = LeaderboardSerializer(data=request.data, many=True, allow_empty=False)
+    serializer = LeaderboardSerializer(
+        data=request.data, many=True, allow_empty=False)
     if serializer.is_valid():
         serializer.save()
         response_data = serializer.data
@@ -914,7 +979,8 @@ def create_dataset_split(request):
     """
     Creates a dataset split
     """
-    serializer = DatasetSplitSerializer(data=request.data, many=True, allow_empty=False)
+    serializer = DatasetSplitSerializer(
+        data=request.data, many=True, allow_empty=False)
     if serializer.is_valid():
         serializer.save()
         response_data = serializer.data
@@ -959,7 +1025,8 @@ def create_challenge_phase_split(request):
     """
     Create Challenge Phase Split
     """
-    serializer = ZipChallengePhaseSplitSerializer(data=request.data, many=True, allow_empty=False)
+    serializer = ZipChallengePhaseSplitSerializer(
+        data=request.data, many=True, allow_empty=False)
     if serializer.is_valid():
         serializer.save()
         response_data = serializer.data
@@ -977,7 +1044,8 @@ def get_or_update_challenge_phase_split(request, challenge_phase_split_pk):
     """
     Returns or Updates challenge phase split
     """
-    challenge_phase_split = get_challenge_phase_split_model(challenge_phase_split_pk)
+    challenge_phase_split = get_challenge_phase_split_model(
+        challenge_phase_split_pk)
 
     if request.method == 'PATCH':
         serializer = ZipChallengePhaseSplitSerializer(challenge_phase_split,
@@ -1016,9 +1084,10 @@ def star_challenge(request, challenge_pk):
             response_data = serializer.data
             return Response(response_data, status=status.HTTP_200_OK)
         except:
-            serializer = StarChallengeSerializer(data=request.data, context={'request': request,
-                                                                             'challenge': challenge,
-                                                                             'is_starred': True})
+            serializer = StarChallengeSerializer(
+                data=request.data, context={'request': request,
+                                            'challenge': challenge,
+                                            'is_starred': True})
             if serializer.is_valid():
                 serializer.save()
                 response_data = serializer.data
@@ -1033,7 +1102,8 @@ def star_challenge(request, challenge_pk):
             response_data = serializer.data
             return Response(response_data, status=status.HTTP_200_OK)
         except:
-            starred_challenge = StarChallenge.objects.filter(challenge=challenge)
+            starred_challenge = StarChallenge.objects.filter(
+                challenge=challenge)
             if not starred_challenge:
                 response_data = {'is_starred': False,
                                  'count': 0}

--- a/apps/hosts/migrations/0001_initial.py
+++ b/apps/hosts/migrations/0001_initial.py
@@ -19,11 +19,15 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='ChallengeHost',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
-                ('status', models.CharField(choices=[('Accepted', 'Accepted'), ('Denied', 'Denied'), ('Pending', 'Pending'), ('Self', 'Self'), ('Unknown', 'Unknown')], max_length=30)),
-                ('permissions', models.CharField(choices=[('Admin', 'Admin'), ('Read', 'Read'), ('Restricted', 'Restricted'), ('Write', 'Write')], max_length=30)),
+                ('status', models.CharField(choices=[('Accepted', 'Accepted'), ('Denied', 'Denied'), (
+                    'Pending', 'Pending'), ('Self', 'Self'), ('Unknown', 'Unknown')], max_length=30)),
+                ('permissions', models.CharField(
+                    choices=[(
+                        'Admin', 'Admin'), ('Read', 'Read'), ('Restricted', 'Restricted'), ('Write', 'Write')], max_length=30)),
             ],
             options={
                 'db_table': 'challenge_host',
@@ -32,11 +36,13 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='ChallengeHostTeam',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
                 ('team_name', models.CharField(max_length=100)),
-                ('created_by', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='challenge_host_team_creator', to=settings.AUTH_USER_MODEL)),
+                ('created_by', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE,
+                 related_name='challenge_host_team_creator', to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'db_table': 'challenge_host_teams',
@@ -45,11 +51,13 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='challengehost',
             name='team_name',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='hosts.ChallengeHostTeam'),
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE, to='hosts.ChallengeHostTeam'),
         ),
         migrations.AddField(
             model_name='challengehost',
             name='user',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
         ),
     ]

--- a/apps/hosts/models.py
+++ b/apps/hosts/models.py
@@ -8,11 +8,13 @@ from base.models import (TimeStampedModel, )
 
 
 class ChallengeHostTeam(TimeStampedModel):
+
     """
     Model representing the Host Team for a partiuclar challenge
     """
     team_name = models.CharField(max_length=100, unique=True)
-    created_by = models.ForeignKey(User, related_name='challenge_host_team_creator')
+    created_by = models.ForeignKey(
+        User, related_name='challenge_host_team_creator')
 
     def __unicode__(self):
         return '{0}: {1}'.format(self.team_name, self.created_by)

--- a/apps/hosts/serializers.py
+++ b/apps/hosts/serializers.py
@@ -8,7 +8,8 @@ from .models import (ChallengeHost,
 
 class ChallengeHostTeamSerializer(serializers.ModelSerializer):
 
-    created_by = serializers.SlugRelatedField(slug_field='username', queryset=User.objects.all())
+    created_by = serializers.SlugRelatedField(
+        slug_field='username', queryset=User.objects.all())
 
     def __init__(self, *args, **kwargs):
         super(ChallengeHostTeamSerializer, self).__init__(*args, **kwargs)
@@ -25,8 +26,10 @@ class ChallengeHostTeamSerializer(serializers.ModelSerializer):
 class ChallengeHostSerializer(serializers.ModelSerializer):
 
     status = serializers.ChoiceField(choices=ChallengeHost.STATUS_OPTIONS)
-    permissions = serializers.ChoiceField(choices=ChallengeHost.PERMISSION_OPTIONS)
-    user = serializers.SlugRelatedField(slug_field='username', queryset=User.objects.all())
+    permissions = serializers.ChoiceField(
+        choices=ChallengeHost.PERMISSION_OPTIONS)
+    user = serializers.SlugRelatedField(
+        slug_field='username', queryset=User.objects.all())
 
     def __init__(self, *args, **kwargs):
         super(ChallengeHostSerializer, self).__init__(*args, **kwargs)
@@ -64,7 +67,8 @@ class InviteHostToTeamSerializer(serializers.Serializer):
 
     def save(self):
         email = self.validated_data.get('email')
-        return ChallengeHost.objects.get_or_create(user=User.objects.get(email=email),
+        return ChallengeHost.objects.get_or_create(
+            user=User.objects.get(email=email),
                                                    status=ChallengeHost.ACCEPTED,
                                                    team_name=self.challenge_host_team,
                                                    permissions=ChallengeHost.WRITE)
@@ -73,7 +77,8 @@ class InviteHostToTeamSerializer(serializers.Serializer):
 class HostTeamDetailSerializer(serializers.ModelSerializer):
 
     members = serializers.SerializerMethodField()
-    created_by = serializers.SlugRelatedField(slug_field='username', queryset=User.objects.all())
+    created_by = serializers.SlugRelatedField(
+        slug_field='username', queryset=User.objects.all())
 
     class Meta:
         model = ChallengeHostTeam

--- a/apps/hosts/urls.py
+++ b/apps/hosts/urls.py
@@ -4,10 +4,12 @@ from . import views
 
 urlpatterns = [
 
-    url(r'^challenge_host_team/$', views.challenge_host_team_list, name='get_challenge_host_team_list'),
+    url(r'^challenge_host_team/$', views.challenge_host_team_list,
+        name='get_challenge_host_team_list'),
     url(r'^challenge_host_team/(?P<pk>[0-9]+)$', views.challenge_host_team_detail,
         name='get_challenge_host_team_details'),
-    url(r'^create_challenge_host_team$', views.create_challenge_host_team, name='create_challenge_host_team'),
+    url(r'^create_challenge_host_team$',
+        views.create_challenge_host_team, name='create_challenge_host_team'),
     url(r'^challenge_host_team/(?P<challenge_host_team_pk>[0-9]+)/challenge_host$', views.challenge_host_list,
         name='get_challenge_host_list'),
     url(r'^challenge_host_team/(?P<challenge_host_team_pk>[0-9]+)/challenge_host/(?P<pk>[0-9]+)$',

--- a/apps/hosts/views.py
+++ b/apps/hosts/views.py
@@ -4,7 +4,8 @@ from rest_framework.decorators import (api_view,
                                        permission_classes,
                                        throttle_classes,)
 from rest_framework.response import Response
-from rest_framework_expiring_authtoken.authentication import (ExpiringTokenAuthentication,)
+from rest_framework_expiring_authtoken.authentication import (
+    ExpiringTokenAuthentication,)
 from rest_framework.throttling import UserRateThrottle
 
 from accounts.permissions import HasVerifiedEmail
@@ -24,9 +25,12 @@ from .serializers import (ChallengeHostSerializer,
 def challenge_host_team_list(request):
 
     if request.method == 'GET':
-        challenge_host_team_ids = ChallengeHost.objects.filter(user=request.user).values_list('team_name', flat=True)
-        challenge_host_teams = ChallengeHostTeam.objects.filter(id__in=challenge_host_team_ids)
-        paginator, result_page = paginated_queryset(challenge_host_teams, request)
+        challenge_host_team_ids = ChallengeHost.objects.filter(
+            user=request.user).values_list('team_name', flat=True)
+        challenge_host_teams = ChallengeHostTeam.objects.filter(
+            id__in=challenge_host_team_ids)
+        paginator, result_page = paginated_queryset(
+            challenge_host_teams, request)
         serializer = HostTeamDetailSerializer(result_page, many=True)
         response_data = serializer.data
         return paginator.get_paginated_response(response_data)
@@ -62,7 +66,8 @@ def challenge_host_team_detail(request, pk):
         if request.method == 'PATCH':
             serializer = ChallengeHostTeamSerializer(challenge_host_team,
                                                      data=request.data,
-                                                     context={'request': request},
+                                                     context={
+                                                         'request': request},
                                                      partial=True)
         else:
             serializer = ChallengeHostTeamSerializer(challenge_host_team,
@@ -87,7 +92,8 @@ def challenge_host_team_detail(request, pk):
 def challenge_host_list(request, challenge_host_team_pk):
 
     try:
-        challenge_host_team = ChallengeHostTeam.objects.get(pk=challenge_host_team_pk)
+        challenge_host_team = ChallengeHostTeam.objects.get(
+            pk=challenge_host_team_pk)
     except ChallengeHostTeam.DoesNotExist:
         response_data = {'error': 'ChallengeHostTeam does not exist'}
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
@@ -110,7 +116,8 @@ def challenge_host_list(request, challenge_host_team_pk):
 
     elif request.method == 'POST':
         serializer = ChallengeHostSerializer(data=request.data,
-                                             context={'challenge_host_team': challenge_host_team,
+                                             context={
+                                                 'challenge_host_team': challenge_host_team,
                                                       'request': request})
         if serializer.is_valid():
             serializer.save()
@@ -125,7 +132,8 @@ def challenge_host_list(request, challenge_host_team_pk):
 @authentication_classes((ExpiringTokenAuthentication,))
 def challenge_host_detail(request, challenge_host_team_pk, pk):
     try:
-        challenge_host_team = ChallengeHostTeam.objects.get(pk=challenge_host_team_pk)
+        challenge_host_team = ChallengeHostTeam.objects.get(
+            pk=challenge_host_team_pk)
     except ChallengeHostTeam.DoesNotExist:
         response_data = {'error': 'ChallengeHostTeam does not exist'}
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
@@ -145,13 +153,15 @@ def challenge_host_detail(request, challenge_host_team_pk, pk):
         if request.method == 'PATCH':
             serializer = ChallengeHostSerializer(challenge_host,
                                                  data=request.data,
-                                                 context={'challenge_host_team': challenge_host_team,
+                                                 context={
+                                                     'challenge_host_team': challenge_host_team,
                                                           'request': request},
                                                  partial=True)
         else:
             serializer = ChallengeHostSerializer(challenge_host,
                                                  data=request.data,
-                                                 context={'challenge_host_team': challenge_host_team,
+                                                 context={
+                                                     'challenge_host_team': challenge_host_team,
                                                           'request': request})
         if serializer.is_valid():
             serializer.save()
@@ -200,7 +210,8 @@ def remove_self_from_challenge_host_team(request, challenge_host_team_pk):
         response_data = {'error': 'ChallengeHostTeam does not exist'}
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
     try:
-        challenge_host = ChallengeHost.objects.filter(user=request.user.id, team_name__pk=challenge_host_team_pk)
+        challenge_host = ChallengeHost.objects.filter(
+            user=request.user.id, team_name__pk=challenge_host_team_pk)
         challenge_host.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
     except:
@@ -221,7 +232,8 @@ def invite_host_to_team(request, pk):
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     serializer = InviteHostToTeamSerializer(data=request.data,
-                                            context={'challenge_host_team': challenge_host_team,
+                                            context={
+                                                'challenge_host_team': challenge_host_team,
                                                      'request': request})
     if serializer.is_valid():
         serializer.save()

--- a/apps/jobs/admin.py
+++ b/apps/jobs/admin.py
@@ -7,7 +7,8 @@ from .models import Submission
 
 @admin.register(Submission)
 class SubmissionAdmin(ImportExportTimeStampedAdmin):
-    list_display = ('participant_team', 'challenge_phase', 'created_by', 'status', 'is_public',
+    list_display = (
+        'participant_team', 'challenge_phase', 'created_by', 'status', 'is_public',
                     'submission_number', 'submitted_at', 'execution_time', 'input_file', 'stdout_file', 'stderr_file',
                     'submission_result_file', 'submission_metadata_file', )
     list_filter = ('participant_team', 'challenge_phase',

--- a/apps/jobs/migrations/0001_squashed_0005_upload_unique_random_filename.py
+++ b/apps/jobs/migrations/0001_squashed_0005_upload_unique_random_filename.py
@@ -10,7 +10,9 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    replaces = [(b'jobs', '0001_initial'), (b'jobs', '0002_execution_time_limit'), (b'jobs', '0003_submitting_status_option'), (b'jobs', '0004_submission_output'), (b'jobs', '0005_upload_unique_random_filename')]
+    replaces = [(
+        b'jobs', '0001_initial'), (b'jobs', '0002_execution_time_limit'), (b'jobs', '0003_submitting_status_option'),
+        (b'jobs', '0004_submission_output'), (b'jobs', '0005_upload_unique_random_filename')]
 
     initial = True
 
@@ -24,24 +26,37 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Submission',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
-                ('status', models.CharField(choices=[('submitted', 'submitted'), ('running', 'running'), ('failed', 'failed'), ('cancelled', 'cancelled'), ('finished', 'finished'), ('submitting', 'submitting')], max_length=30)),
+                ('status', models.CharField(choices=[('submitted', 'submitted'), ('running', 'running'), ('failed', 'failed'), (
+                    'cancelled', 'cancelled'), ('finished', 'finished'), ('submitting', 'submitting')], max_length=30)),
                 ('is_public', models.BooleanField(default=False)),
                 ('submission_number', models.PositiveIntegerField(default=0)),
                 ('download_count', models.IntegerField(default=0)),
                 ('submitted_at', models.DateTimeField(auto_now_add=True)),
                 ('started_at', models.DateTimeField(blank=True, null=True)),
                 ('completed_at', models.DateTimeField(blank=True, null=True)),
-                ('when_made_public', models.DateTimeField(blank=True, null=True)),
-                ('input_file', models.FileField(upload_to=base.utils.RandomFileName('submission_files/submission'))),
-                ('stdout_file', models.FileField(blank=True, null=True, upload_to=base.utils.RandomFileName('submission_files/submission'))),
-                ('stderr_file', models.FileField(blank=True, null=True, upload_to=base.utils.RandomFileName('submission_files/submission'))),
-                ('challenge_phase', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='submissions', to='challenges.ChallengePhase')),
-                ('created_by', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
-                ('participant_team', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='submissions', to='participants.ParticipantTeam')),
-                ('execution_time_limit', models.PositiveIntegerField(default=300)),
+                ('when_made_public',
+                 models.DateTimeField(blank=True, null=True)),
+                ('input_file', models.FileField(
+                    upload_to=base.utils.RandomFileName(
+                        'submission_files/submission'))),
+                ('stdout_file', models.FileField(blank=True, null=True,
+                 upload_to=base.utils.RandomFileName(
+                     'submission_files/submission'))),
+                ('stderr_file', models.FileField(blank=True, null=True,
+                 upload_to=base.utils.RandomFileName(
+                     'submission_files/submission'))),
+                ('challenge_phase', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE,
+                 related_name='submissions', to='challenges.ChallengePhase')),
+                ('created_by', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+                ('participant_team', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE,
+                 related_name='submissions', to='participants.ParticipantTeam')),
+                ('execution_time_limit',
+                 models.PositiveIntegerField(default=300)),
                 ('output', models.TextField(blank=True, null=True)),
             ],
             options={

--- a/apps/jobs/migrations/0002_path_fix_for_submission_files.py
+++ b/apps/jobs/migrations/0002_path_fix_for_submission_files.py
@@ -16,16 +16,22 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='submission',
             name='input_file',
-            field=models.FileField(upload_to=base.utils.RandomFileName('submission_files/submission_{id}')),
+            field=models.FileField(
+                upload_to=base.utils.RandomFileName(
+                    'submission_files/submission_{id}')),
         ),
         migrations.AlterField(
             model_name='submission',
             name='stderr_file',
-            field=models.FileField(blank=True, null=True, upload_to=base.utils.RandomFileName('submission_files/submission_{id}')),
+            field=models.FileField(
+                blank=True, null=True, upload_to=base.utils.RandomFileName(
+                    'submission_files/submission_{id}')),
         ),
         migrations.AlterField(
             model_name='submission',
             name='stdout_file',
-            field=models.FileField(blank=True, null=True, upload_to=base.utils.RandomFileName('submission_files/submission_{id}')),
+            field=models.FileField(
+                blank=True, null=True, upload_to=base.utils.RandomFileName(
+                    'submission_files/submission_{id}')),
         ),
     ]

--- a/apps/jobs/migrations/0005_added_new_fields_to_submission_model.py
+++ b/apps/jobs/migrations/0005_added_new_fields_to_submission_model.py
@@ -16,11 +16,15 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='submission',
             name='submission_metadata_file',
-            field=models.FileField(blank=True, null=True, upload_to=base.utils.RandomFileName('submission_files/submission_{id}')),
+            field=models.FileField(
+                blank=True, null=True, upload_to=base.utils.RandomFileName(
+                    'submission_files/submission_{id}')),
         ),
         migrations.AddField(
             model_name='submission',
             name='submission_result_file',
-            field=models.FileField(blank=True, null=True, upload_to=base.utils.RandomFileName('submission_files/submission_{id}')),
+            field=models.FileField(
+                blank=True, null=True, upload_to=base.utils.RandomFileName(
+                    'submission_files/submission_{id}')),
         ),
     ]

--- a/apps/jobs/migrations/0006_add_indexing_to_some_attributes.py
+++ b/apps/jobs/migrations/0006_add_indexing_to_some_attributes.py
@@ -50,7 +50,8 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='submission',
             name='status',
-            field=models.CharField(choices=[('submitted', 'submitted'), ('running', 'running'), ('failed', 'failed'), ('cancelled', 'cancelled'), ('finished', 'finished'), ('submitting', 'submitting')], db_index=True, max_length=30),
+            field=models.CharField(choices=[('submitted', 'submitted'), ('running', 'running'), ('failed', 'failed'), (
+                'cancelled', 'cancelled'), ('finished', 'finished'), ('submitting', 'submitting')], db_index=True, max_length=30),
         ),
         migrations.AlterField(
             model_name='submission',

--- a/apps/jobs/models.py
+++ b/apps/jobs/models.py
@@ -21,7 +21,8 @@ logger = logging.getLogger(__name__)
 # submission.pk is not available when saving input_file
 # OutCome: `input_file` was saved for submission in folder named `submission_None`
 # why is the hack not done for `stdout_file` and `stderr_file`
-# Because they will be saved only after a submission instance is saved(pk will be available)
+# Because they will be saved only after a submission instance is saved(pk
+# will be available)
 
 
 @receiver(pre_save, sender='jobs.Submission')
@@ -61,7 +62,8 @@ class Submission(TimeStampedModel):
     challenge_phase = models.ForeignKey(
         ChallengePhase, related_name='submissions')
     created_by = models.ForeignKey(User)
-    status = models.CharField(max_length=30, choices=STATUS_OPTIONS, db_index=True)
+    status = models.CharField(
+        max_length=30, choices=STATUS_OPTIONS, db_index=True)
     is_public = models.BooleanField(default=False)
     is_flagged = models.BooleanField(default=False)
     submission_number = models.PositiveIntegerField(default=0)
@@ -71,9 +73,12 @@ class Submission(TimeStampedModel):
     started_at = models.DateTimeField(null=True, blank=True, db_index=True)
     completed_at = models.DateTimeField(null=True, blank=True, db_index=True)
     when_made_public = models.DateTimeField(null=True, blank=True)
-    input_file = models.FileField(upload_to=RandomFileName("submission_files/submission_{id}"))
-    stdout_file = models.FileField(upload_to=RandomFileName("submission_files/submission_{id}"), null=True, blank=True)
-    stderr_file = models.FileField(upload_to=RandomFileName("submission_files/submission_{id}"), null=True, blank=True)
+    input_file = models.FileField(
+        upload_to=RandomFileName("submission_files/submission_{id}"))
+    stdout_file = models.FileField(upload_to=RandomFileName(
+        "submission_files/submission_{id}"), null=True, blank=True)
+    stderr_file = models.FileField(upload_to=RandomFileName(
+        "submission_files/submission_{id}"), null=True, blank=True)
     submission_result_file = models.FileField(
         upload_to=RandomFileName("submission_files/submission_{id}"), null=True, blank=True)
     submission_metadata_file = models.FileField(
@@ -123,12 +128,13 @@ class Submission(TimeStampedModel):
 
             if successful_count > self.challenge_phase.max_submissions:
                 logger.info("Checking to see if the successful_count {0} is greater than maximum allowed {1}".format(
-                        successful_count, self.challenge_phase.max_submissions))
+                    successful_count, self.challenge_phase.max_submissions))
 
                 logger.info("The submission request is submitted by user {0} from participant_team {1} ".format(
-                        self.created_by.pk, self.participant_team.pk))
+                    self.created_by.pk, self.participant_team.pk))
 
-                raise PermissionDenied({'error': 'The maximum number of submissions has been reached'})
+                raise PermissionDenied(
+                    {'error': 'The maximum number of submissions has been reached'})
             else:
                 logger.info("Submission is below for user {0} form participant_team {1} for challenge_phase {2}".format(
                     self.created_by.pk, self.participant_team.pk, self.challenge_phase.pk))
@@ -148,10 +154,13 @@ class Submission(TimeStampedModel):
 
                 if ((submissions_done_today_count + 1 - failed_count > self.challenge_phase.max_submissions_per_day) or
                         (self.challenge_phase.max_submissions_per_day == 0)):
-                    logger.info("Permission Denied: The maximum number of submission for today has been reached")
-                    raise PermissionDenied({'error': 'The maximum number of submission for today has been reached'})
+                    logger.info(
+                        "Permission Denied: The maximum number of submission for today has been reached")
+                    raise PermissionDenied(
+                        {'error': 'The maximum number of submission for today has been reached'})
 
-            self.is_public = (True if self.challenge_phase.is_submission_public else False)
+            self.is_public = (
+                True if self.challenge_phase.is_submission_public else False)
 
             self.status = Submission.SUBMITTED
 

--- a/apps/jobs/sender.py
+++ b/apps/jobs/sender.py
@@ -5,7 +5,7 @@ import pika
 def publish_submission_message(challenge_id, phase_id, submission_id):
 
     connection = pika.BlockingConnection(pika.ConnectionParameters(
-            host='localhost'))
+        host='localhost'))
     channel = connection.channel()
     channel.exchange_declare(exchange='evalai_submissions', type='topic')
 

--- a/apps/jobs/serializers.py
+++ b/apps/jobs/serializers.py
@@ -29,7 +29,8 @@ class SubmissionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Submission
-        fields = ('id', 'participant_team', 'participant_team_name', 'execution_time', 'challenge_phase',
+        fields = (
+            'id', 'participant_team', 'participant_team_name', 'execution_time', 'challenge_phase',
                   'created_by', 'status', 'input_file', 'stdout_file', 'stderr_file', 'submitted_at',
                   'method_name', 'method_description', 'project_url', 'publication_url', 'is_public',
                   'submission_result_file', 'when_made_public',)
@@ -52,7 +53,8 @@ class LeaderboardDataSerializer(serializers.ModelSerializer):
     class Meta:
         model = LeaderboardData
         fields = "__all__"
-        fields = ('id', 'participant_team_name', 'challenge_phase_split', 'leaderboard_schema', 'result')
+        fields = ('id', 'participant_team_name',
+                  'challenge_phase_split', 'leaderboard_schema', 'result')
 
     def get_participant_team_name(self, obj):
         return obj.submission.participant_team.team_name
@@ -72,7 +74,8 @@ class ChallengeSubmissionManagementSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Submission
-        fields = ('id', 'participant_team', 'challenge_phase', 'created_by', 'status', 'is_public',
+        fields = (
+            'id', 'participant_team', 'challenge_phase', 'created_by', 'status', 'is_public',
                   'submission_number', 'submitted_at', 'execution_time', 'input_file', 'stdout_file',
                   'stderr_file', 'submission_result_file', 'submission_metadata_file',
                   'participant_team_members_email_ids', 'created_at', 'method_name', 'participant_team_members',)
@@ -88,11 +91,13 @@ class ChallengeSubmissionManagementSerializer(serializers.ModelSerializer):
 
     def get_participant_team_members_email_ids(self, obj):
         try:
-            participant_team = ParticipantTeam.objects.get(team_name=obj.participant_team.team_name)
+            participant_team = ParticipantTeam.objects.get(
+                team_name=obj.participant_team.team_name)
         except ParticipantTeam.DoesNotExist:
             return 'Participant team does not exist'
 
-        participant_ids = Participant.objects.filter(team=participant_team).values_list('user_id', flat=True)
+        participant_ids = Participant.objects.filter(
+            team=participant_team).values_list('user_id', flat=True)
         return list(User.objects.filter(id__in=participant_ids).values_list('email', flat=True))
 
     def get_created_at(self, obj):
@@ -100,15 +105,18 @@ class ChallengeSubmissionManagementSerializer(serializers.ModelSerializer):
 
     def get_participant_team_members(self, obj):
         try:
-            participant_team = ParticipantTeam.objects.get(team_name=obj.participant_team.team_name)
+            participant_team = ParticipantTeam.objects.get(
+                team_name=obj.participant_team.team_name)
         except ParticipantTeam.DoesNotExist:
             return 'Participant team does not exist'
 
-        participant_ids = Participant.objects.filter(team=participant_team).values_list('user_id', flat=True)
+        participant_ids = Participant.objects.filter(
+            team=participant_team).values_list('user_id', flat=True)
         return list(User.objects.filter(id__in=participant_ids).values('username', 'email'))
 
 
 class SubmissionCount(object):
+
     def __init__(self, submission_count):
         self.submission_count = submission_count
 
@@ -118,6 +126,7 @@ class SubmissionCountSerializer(serializers.Serializer):
 
 
 class LastSubmissionDateTime(object):
+
     def __init__(self, last_submission_datetime):
         self.last_submission_datetime = last_submission_datetime
 

--- a/apps/participants/admin.py
+++ b/apps/participants/admin.py
@@ -19,6 +19,7 @@ class ParticipantResource(resources.ModelResource):
 
 @admin.register(Participant)
 class ParticipantAdmin(ImportExportTimeStampedAdmin):
+
     """
     An abstract base class which provides an
     interface to display user and team status.
@@ -31,6 +32,7 @@ class ParticipantAdmin(ImportExportTimeStampedAdmin):
 
 @admin.register(ParticipantTeam)
 class ParticipantTeamAdmin(ImportExportTimeStampedAdmin):
+
     """
     A class which provides interface to display
     and filter team names.

--- a/apps/participants/migrations/0001_initial.py
+++ b/apps/participants/migrations/0001_initial.py
@@ -20,10 +20,12 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Participant',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
-                ('challenge', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='participants', to='challenges.Challenge')),
+                ('challenge', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE,
+                 related_name='participants', to='challenges.Challenge')),
             ],
             options={
                 'db_table': 'participant',
@@ -32,7 +34,8 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='ParticipantStatus',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
                 ('status', models.CharField(max_length=30, unique=True)),
@@ -44,11 +47,14 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='participant',
             name='status',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='participants.ParticipantStatus'),
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE, to='participants.ParticipantStatus'),
         ),
         migrations.AddField(
             model_name='participant',
             name='user',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='participation', to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                                    related_name='participation', to=settings.AUTH_USER_MODEL),
         ),
     ]

--- a/apps/participants/migrations/0002_participantteam_participantteammember.py
+++ b/apps/participants/migrations/0002_participantteam_participantteammember.py
@@ -17,11 +17,13 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='ParticipantTeam',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
                 ('team_name', models.CharField(max_length=100)),
-                ('challenge', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='challenges.Challenge')),
+                ('challenge', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE, to='challenges.Challenge')),
             ],
             options={
                 'db_table': 'participant_team',
@@ -30,11 +32,14 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='ParticipantTeamMember',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
-                ('participant', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='participants.Participant')),
-                ('team', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='participants.ParticipantTeam')),
+                ('participant', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE, to='participants.Participant')),
+                ('team', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE, to='participants.ParticipantTeam')),
             ],
             options={
                 'db_table': 'participant_team_member',

--- a/apps/participants/migrations/0004_add_created_by_participant_team.py
+++ b/apps/participants/migrations/0004_add_created_by_participant_team.py
@@ -18,6 +18,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='participantteam',
             name='created_by',
-            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(
+                null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
         ),
     ]

--- a/apps/participants/migrations/0006_alter_status_participant_choices.py
+++ b/apps/participants/migrations/0006_alter_status_participant_choices.py
@@ -15,7 +15,8 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='participant',
             name='status',
-            field=models.CharField(choices=[('Accepted', 'Accepted'), ('Denied', 'Denied'), ('Pending', 'Pending'), ('Self', 'Self'), ('Unknown', 'Unknown')], max_length=30),
+            field=models.CharField(choices=[('Accepted', 'Accepted'), ('Denied', 'Denied'), (
+                'Pending', 'Pending'), ('Self', 'Self'), ('Unknown', 'Unknown')], max_length=30),
         ),
         migrations.DeleteModel(
             name='ParticipantStatus',

--- a/apps/participants/migrations/0007_add_team_participant.py
+++ b/apps/participants/migrations/0007_add_team_participant.py
@@ -24,7 +24,9 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='participant',
             name='team',
-            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, related_name='participants', to='participants.ParticipantTeam'),
+            field=models.ForeignKey(
+                null=True, on_delete=django.db.models.deletion.CASCADE,
+                                    related_name='participants', to='participants.ParticipantTeam'),
         ),
         migrations.DeleteModel(
             name='ParticipantTeamMember',

--- a/apps/participants/models.py
+++ b/apps/participants/models.py
@@ -7,6 +7,7 @@ from base.models import (TimeStampedModel,)
 
 
 class Participant(TimeStampedModel):
+
     """Model representing the Participant of the competition. """
     UNKNOWN = 'Unknown'
     SELF = 'Self'
@@ -24,7 +25,8 @@ class Participant(TimeStampedModel):
 
     user = models.ForeignKey(User, related_name='participation')
     status = models.CharField(max_length=30, choices=STATUS_OPTIONS)
-    team = models.ForeignKey('ParticipantTeam', related_name='participants', null=True)
+    team = models.ForeignKey(
+        'ParticipantTeam', related_name='participants', null=True)
 
     def __unicode__(self):
         return '{}'.format(self.user)
@@ -35,6 +37,7 @@ class Participant(TimeStampedModel):
 
 
 class ParticipantTeam(TimeStampedModel):
+
     """Model representing the Teams associated with different challenges"""
     team_name = models.CharField(max_length=100, unique=True)
     created_by = models.ForeignKey(User, null=True)
@@ -43,7 +46,8 @@ class ParticipantTeam(TimeStampedModel):
         return '{}'.format(self.team_name)
 
     def get_all_participants_email(self):
-        email_ids = Participant.objects.filter(team=self).values_list('user__email', flat=True)
+        email_ids = Participant.objects.filter(
+            team=self).values_list('user__email', flat=True)
         return list(email_ids)
 
     class Meta:

--- a/apps/participants/serializers.py
+++ b/apps/participants/serializers.py
@@ -8,8 +8,10 @@ from .models import (Participant, ParticipantTeam)
 
 
 class ParticipantTeamSerializer(serializers.ModelSerializer):
+
     """Serializer class to map Participants to Teams."""
-    created_by = serializers.SlugRelatedField(slug_field='username', queryset=User.objects.all())
+    created_by = serializers.SlugRelatedField(
+        slug_field='username', queryset=User.objects.all())
 
     def __init__(self, *args, **kwargs):
         super(ParticipantTeamSerializer, self).__init__(*args, **kwargs)
@@ -24,11 +26,13 @@ class ParticipantTeamSerializer(serializers.ModelSerializer):
 
 
 class InviteParticipantToTeamSerializer(serializers.Serializer):
+
     """Serializer class for inviting Participant to Team."""
     email = serializers.EmailField()
 
     def __init__(self, *args, **kwargs):
-        super(InviteParticipantToTeamSerializer, self).__init__(*args, **kwargs)
+        super(InviteParticipantToTeamSerializer,
+              self).__init__(*args, **kwargs)
         context = kwargs.get('context')
         if context:
             self.participant_team = context.get('participant_team')
@@ -36,7 +40,8 @@ class InviteParticipantToTeamSerializer(serializers.Serializer):
 
     def validate_email(self, value):
         if value == self.user.email:
-            raise serializers.ValidationError('A participant cannot invite himself')
+            raise serializers.ValidationError(
+                'A participant cannot invite himself')
         try:
             User.objects.get(email=value)
         except User.DoesNotExist:
@@ -45,12 +50,14 @@ class InviteParticipantToTeamSerializer(serializers.Serializer):
 
     def save(self):
         email = self.validated_data.get('email')
-        return Participant.objects.get_or_create(user=User.objects.get(email=email),
+        return Participant.objects.get_or_create(
+            user=User.objects.get(email=email),
                                                  status=Participant.ACCEPTED,
                                                  team=self.participant_team)
 
 
 class ParticipantSerializer(serializers.ModelSerializer):
+
     """Serializer class for Participants."""
     member_name = serializers.SerializerMethodField()
     member_id = serializers.SerializerMethodField()
@@ -67,9 +74,11 @@ class ParticipantSerializer(serializers.ModelSerializer):
 
 
 class ParticipantTeamDetailSerializer(serializers.ModelSerializer):
+
     """Serializer for Participant Teams and Participant Combined."""
     members = serializers.SerializerMethodField()
-    created_by = serializers.SlugRelatedField(slug_field='username', queryset=User.objects.all())
+    created_by = serializers.SlugRelatedField(
+        slug_field='username', queryset=User.objects.all())
 
     class Meta:
         model = ParticipantTeam
@@ -82,27 +91,34 @@ class ParticipantTeamDetailSerializer(serializers.ModelSerializer):
 
 
 class ChallengeParticipantTeam(object):
+
     """Serializer to map Challenge and Participant Teams."""
+
     def __init__(self, challenge, participant_team):
         self.challenge = challenge
         self.participant_team = participant_team
 
 
 class ChallengeParticipantTeamSerializer(serializers.Serializer):
+
     """Serializer to initialize Challenge and Participant's Team"""
     challenge = ChallengeSerializer()
     participant_team = ParticipantTeamSerializer()
 
 
 class ChallengeParticipantTeamList(object):
+
     """Class to create a list of Challenge and Participant Teams."""
+
     def __init__(self, challenge_participant_team_list):
         self.challenge_participant_team_list = challenge_participant_team_list
 
 
 class ChallengeParticipantTeamListSerializer(serializers.Serializer):
+
     """Serializer to map a challenge's participant team lists."""
-    challenge_participant_team_list = ChallengeParticipantTeamSerializer(many=True)
+    challenge_participant_team_list = ChallengeParticipantTeamSerializer(
+        many=True)
     datetime_now = serializers.SerializerMethodField()
 
     def get_datetime_now(self, obj):
@@ -110,6 +126,7 @@ class ChallengeParticipantTeamListSerializer(serializers.Serializer):
 
 
 class ParticipantTeamCount(object):
+
     def __init__(self, participant_team_count):
         self.participant_team_count = participant_team_count
 
@@ -119,6 +136,7 @@ class ParticipantTeamCountSerializer(serializers.Serializer):
 
 
 class ParticipantCount(object):
+
     def __init__(self, participant_count):
         self.participant_count = participant_count
 

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -33,7 +33,8 @@ from .utils import (get_list_of_challenges_for_participant_team,
 def participant_team_list(request):
 
     if request.method == 'GET':
-        participant_teams_id = Participant.objects.filter(user_id=request.user).values_list('team_id', flat=True)
+        participant_teams_id = Participant.objects.filter(
+            user_id=request.user).values_list('team_id', flat=True)
         participant_teams = ParticipantTeam.objects.filter(
             id__in=participant_teams_id)
         paginator, result_page = paginated_queryset(participant_teams, request)
@@ -76,12 +77,14 @@ def participant_team_detail(request, pk):
     elif request.method in ['PUT', 'PATCH']:
 
         if request.method == 'PATCH':
-            serializer = ParticipantTeamSerializer(participant_team, data=request.data,
+            serializer = ParticipantTeamSerializer(
+                participant_team, data=request.data,
                                                    context={
                                                        'request': request},
                                                    partial=True)
         else:
-            serializer = ParticipantTeamSerializer(participant_team, data=request.data,
+            serializer = ParticipantTeamSerializer(
+                participant_team, data=request.data,
                                                    context={'request': request})
         if serializer.is_valid():
             serializer.save()
@@ -111,7 +114,8 @@ def invite_participant_to_team(request, pk):
     try:
         user = User.objects.get(email=email)
     except User.DoesNotExist:
-        response_data = {'error': 'User does not exist with this email address!'}
+        response_data = {
+            'error': 'User does not exist with this email address!'}
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     invited_user_participated_challenges = get_list_of_challenges_participated_by_a_user(
@@ -130,7 +134,8 @@ def invite_participant_to_team(request, pk):
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     serializer = InviteParticipantToTeamSerializer(data=request.data,
-                                                   context={'participant_team': participant_team,
+                                                   context={
+                                                       'participant_team': participant_team,
                                                             'request': request})
     if serializer.is_valid():
         serializer.save()
@@ -184,9 +189,11 @@ def get_teams_and_corresponding_challenges_for_a_participant(request, challenge_
     Returns list of teams and corresponding challenges for a participant
     """
     # first get list of all the participants and teams related to the user
-    participant_objs = Participant.objects.filter(user=request.user).prefetch_related('team')
+    participant_objs = Participant.objects.filter(
+        user=request.user).prefetch_related('team')
 
-    is_challenge_host = is_user_a_host_of_challenge(user=request.user, challenge_pk=challenge_pk)
+    is_challenge_host = is_user_a_host_of_challenge(
+        user=request.user, challenge_pk=challenge_pk)
 
     challenge_participated_teams = []
     for participant_obj in participant_objs:
@@ -203,7 +210,8 @@ def get_teams_and_corresponding_challenges_for_a_participant(request, challenge_
             challenge = None
             challenge_participated_teams.append(ChallengeParticipantTeam(
                 challenge, participant_team))
-    serializer = ChallengeParticipantTeamListSerializer(ChallengeParticipantTeamList(challenge_participated_teams))
+    serializer = ChallengeParticipantTeamListSerializer(
+        ChallengeParticipantTeamList(challenge_participated_teams))
     response_data = serializer.data
     response_data['is_challenge_host'] = is_challenge_host
     return Response(response_data, status=status.HTTP_200_OK)
@@ -224,13 +232,15 @@ def remove_self_from_participant_team(request, participant_team_pk):
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     try:
-        participant = Participant.objects.get(user=request.user, team__pk=participant_team_pk)
+        participant = Participant.objects.get(
+            user=request.user, team__pk=participant_team_pk)
     except:
         response_data = {'error': 'Sorry, you do not belong to this team!'}
         return Response(response_data, status=status.HTTP_401_UNAUTHORIZED)
 
     if get_list_of_challenges_for_participant_team([participant_team]).exists():
-        response_data = {'error': 'Sorry, you cannot delete this team since it has taken part in challenge(s)!'}
+        response_data = {
+            'error': 'Sorry, you cannot delete this team since it has taken part in challenge(s)!'}
         return Response(response_data, status=status.HTTP_403_FORBIDDEN)
     else:
         participant.delete()

--- a/apps/web/migrations/0001_initial.py
+++ b/apps/web/migrations/0001_initial.py
@@ -16,7 +16,8 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Contact',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
                 ('name', models.CharField(max_length=100)),

--- a/apps/web/migrations/0002_added_team_model.py
+++ b/apps/web/migrations/0002_added_team_model.py
@@ -15,15 +15,19 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Team',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(auto_created=True,
+                 primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(max_length=100)),
                 ('email', models.EmailField(max_length=70)),
-                ('headshot', models.ImageField(blank=True, null=True, upload_to='headshots')),
+                ('headshot', models.ImageField(
+                    blank=True, null=True, upload_to='headshots')),
                 ('visible', models.BooleanField(default=True)),
                 ('github_url', models.URLField()),
                 ('linkedin_url', models.URLField()),
                 ('personal_website', models.URLField()),
-                ('team_type', models.CharField(choices=[('Core Team', 'Core Team'), ('Contributor', 'Contributor')], max_length=50)),
+                ('team_type', models.CharField(
+                    choices=[(
+                        'Core Team', 'Core Team'), ('Contributor', 'Contributor')], max_length=50)),
             ],
             options={
                 'db_table': 'teams',

--- a/apps/web/migrations/0003_added_description_and_background_image_to_team_model.py
+++ b/apps/web/migrations/0003_added_description_and_background_image_to_team_model.py
@@ -15,7 +15,8 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='team',
             name='background_image',
-            field=models.ImageField(blank=True, null=True, upload_to='bg-images'),
+            field=models.ImageField(
+                blank=True, null=True, upload_to='bg-images'),
         ),
         migrations.AddField(
             model_name='team',

--- a/apps/web/models.py
+++ b/apps/web/models.py
@@ -6,6 +6,7 @@ from base.models import (TimeStampedModel, )
 
 
 class Contact(TimeStampedModel):
+
     """Model representing details of User submitting queries."""
     name = models.CharField(max_length=100,)
     email = models.EmailField(max_length=70,)
@@ -20,6 +21,7 @@ class Contact(TimeStampedModel):
 
 
 class Team(models.Model):
+
     """Model representing details of Team"""
 
     # Team Type Options
@@ -39,7 +41,8 @@ class Team(models.Model):
     github_url = models.CharField(max_length=200, null=True, blank=True)
     linkedin_url = models.CharField(max_length=200, null=True, blank=True)
     personal_website = models.CharField(max_length=200, null=True, blank=True)
-    background_image = models.ImageField(upload_to="bg-images", null=True, blank=True)
+    background_image = models.ImageField(
+        upload_to="bg-images", null=True, blank=True)
     team_type = models.CharField(choices=TEAM_TYPE_OPTIONS, max_length=50)
 
     def __unicode__(self):

--- a/apps/web/serializers.py
+++ b/apps/web/serializers.py
@@ -14,5 +14,6 @@ class TeamSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Team
-        fields = ('name', 'description', 'email', 'headshot', 'background_image', 'github_url', 'linkedin_url',
+        fields = (
+            'name', 'description', 'email', 'headshot', 'background_image', 'github_url', 'linkedin_url',
                   'personal_website', 'team_type')

--- a/apps/web/views.py
+++ b/apps/web/views.py
@@ -54,7 +54,8 @@ def contact_us(request):
         serializer = ContactSerializer(data=request_data)
         if serializer.is_valid():
             serializer.save()
-            response_data = {'message': 'We have received your request and will contact you shortly.'}
+            response_data = {
+                'message': 'We have received your request and will contact you shortly.'}
             return Response(response_data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
@@ -69,12 +70,15 @@ def contact_us(request):
 def our_team(request):
     if request.method == 'GET':
         teams = Team.objects.all()
-        serializer = TeamSerializer(teams, many=True, context={'request': request})
+        serializer = TeamSerializer(
+            teams, many=True, context={'request': request})
         response_data = serializer.data
         return Response(response_data, status=status.HTTP_200_OK)
     elif request.method == 'POST':
-        # team_type is set to Team.CONTRIBUTOR by default and can be overridden by the requester
-        request.data['team_type'] = request.data.get('team_type', Team.CONTRIBUTOR)
+        # team_type is set to Team.CONTRIBUTOR by default and can be overridden
+        # by the requester
+        request.data['team_type'] = request.data.get(
+            'team_type', Team.CONTRIBUTOR)
         serializer = TeamSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -250,7 +250,7 @@ htmlhelp_basename = 'EvalAIdoc'
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-     # The paper size ('letterpaper' or 'a4paper').
+    # The paper size ('letterpaper' or 'a4paper').
      #
      # 'papersize': 'letterpaper',
 

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -33,7 +33,9 @@
         vm.stopLeaderboard = function() {};
         vm.stopFetchingSubmissions = function() {};
         vm.currentDate = null;
-
+        vm.sortColumn = 'score';
+        vm.reverseSort = false;
+        vm.columnIndexSort = 0;
 
         // loader for existing teams
         vm.isExistLoader = false;
@@ -371,6 +373,25 @@
         };
 
         utilities.sendRequest(parameters);
+
+        // define a custom sorting function
+        vm.lastKey = null;
+        vm.sortFunction = function(key) {
+            // check which column is selected
+            // so that the values can be parsed properly
+            if (vm.sortColumn === 'date') {
+                return Date.parse(key.submission__submitted_at);
+            }
+            else if (vm.sortColumn === 'score') {
+                return parseFloat(key.result[vm.columnIndexSort]);
+            }
+            else if (vm.sortColumn === 'team'){
+                // sort teams alphabetically
+                return key.submission__participant_team__team_name.value;
+            }
+
+            return 0;
+        };
 
         // my submissions
         vm.isResult = false;

--- a/frontend/src/views/web/challenge/leaderboard.html
+++ b/frontend/src/views/web/challenge/leaderboard.html
@@ -28,26 +28,54 @@
                         </div>
                     </div>
                 </div>
-                <div class=" ev-card-body exist-team-card">
+                <div class="ev-card-body exist-team-card">
                     <div class="row">
                         <div class="col s12">
                             <div ng-if="!challenge.isResult" class="result-wrn">No phase selected.</div>
                             <table ng-if="challenge.isResult && challenge.leaderboard.length" class="highlight">
                                 <thead>
-                                    <tr>
-                                        <td data-field="rank">Rank</td>
-                                        <td data-field="team">Participant Team</td>
-                                        <td ng-repeat="key in challenge.leaderboard[0].leaderboard__schema.labels">{{key}}</td>
-                                        <td data-field="submission_time">submission time</td>
-                                    </tr>
+                                <tr>
+                                    <td data-field="rank">
+                                        <a href="#" ng-click="challenge.getLeaderboard(challenge.phaseSplitId); challenge.reverseSort = !challenge.reverseSort">
+                                            Rank
+                                        </a>
+                                    </td>
+                                    <td data-field="team">
+                                        <a href="#" ng-click="challenge.sortColumn = 'team'; challenge.reverseSort = !challenge.reverseSort">
+                                            Team
+                                            <span ng-show="challenge.sortColumn == 'team'">
+                                                <span ng-show="!challenge.reverseSort">&uarr;</span>
+                                                <span ng-show="challenge.reverseSort">&darr;</span>
+                                            </span>
+                                        </a>
+                                    </td>
+                                    <td ng-repeat="key in challenge.leaderboard[0].leaderboard__schema.labels">
+                                        <a href="#" ng-click="$parent.challenge.sortColumn = 'score'; $parent.challenge.columnIndexSort = $index; $parent.challenge.reverseSort = !$parent.challenge.reverseSort">
+                                            {{key}}
+                                            <span ng-show="$parent.challenge.sortColumn == 'score' && $parent.challenge.columnIndexSort == '{{$index}}'">
+                                                <span ng-show="!$parent.challenge.reverseSort">&uarr;</span>
+                                                <span ng-show="$parent.challenge.reverseSort">&darr;</span>
+                                            </span>
+                                        </a>
+                                    </td>
+                                    <td data-field="submission_time">
+                                        <a href="#" ng-click="challenge.sortColumn = 'date'; challenge.reverseSort = !challenge.reverseSort">
+                                            submission time
+                                            <span ng-show="challenge.sortColumn == 'date'">
+                                                <span ng-show="!challenge.reverseSort" class="glyphicon glyphicon-chevron-up">&uarr;</span>
+                                                <span ng-show="challenge.reverseSort" class="glyphicon glyphicon-chevron-down">&darr;</span>
+                                            </span>
+                                        </a>
+                                    </td>
+                                </tr>
                                 </thead>
                                 <tbody>
-                                    <tr ng-repeat="key in challenge.leaderboard">
-                                        <td>{{$index+1}}</td>
-                                        <td>{{key.submission__participant_team__team_name}}</td>
-                                        <td ng-repeat="score in key.result track by $index" >{{score | number : 2}}</td>
-                                        <td>{{ key.submission__submitted_at | date:'medium'}}</td>
-                                    </tr>
+                                <tr ng-repeat="key in challenge.leaderboard|orderBy:challenge.sortFunction:challenge.reverseSort">
+                                    <td>{{$index+1}}</td>
+                                    <td>{{key.submission__participant_team__team_name}}</td>
+                                    <td ng-repeat="score in key.result track by $index" >{{score | number : 2}}</td>
+                                    <td>{{ key.submission__submitted_at | date:'medium'}}</td>
+                                </tr>
                                 </tbody>
                             </table>
                             <div ng-if="challenge.isResult && challenge.leaderboard.error">

--- a/middleware/metrics/metrics_middleware.py
+++ b/middleware/metrics/metrics_middleware.py
@@ -16,6 +16,7 @@ initialize(**options)
 
 
 class DatadogMiddleware(MiddlewareMixin):
+
     """
     Middleware to submit some metrics to DataDog about each requests.
     """
@@ -29,12 +30,15 @@ class DatadogMiddleware(MiddlewareMixin):
         if not hasattr(request, self.DATADOG_TIMING_ATTRIBUTE):
             return response
 
-        request_time = time.time() - getattr(request, self.DATADOG_TIMING_ATTRIBUTE)
+        request_time = time.time() - getattr(
+            request, self.DATADOG_TIMING_ATTRIBUTE)
 
         timing_metric = '{0}.request_time'.format(self.app_name)
         count_metric = '{0}.no_of_requests_metric'.format(self.app_name)
-        success_metric = '{0}.no_of_successful_requests_metric'.format(self.app_name)
-        unsuccess_metric = '{0}.no_of_unsuccessful_requests_metric'.format(self.app_name)
+        success_metric = '{0}.no_of_successful_requests_metric'.format(
+            self.app_name)
+        unsuccess_metric = '{0}.no_of_unsuccessful_requests_metric'.format(
+            self.app_name)
 
         tags = self._get_metric_tags(request)
 
@@ -55,7 +59,8 @@ class DatadogMiddleware(MiddlewareMixin):
 
         tags = self._get_metric_tags(request)
         event_tags = [self.app_name, 'unhandled_exception']
-        app_error_metric = '{0}.unhandled_errors.{1}'.format(self.app_name, request.path)
+        app_error_metric = '{0}.unhandled_errors.{1}'.format(
+            self.app_name, request.path)
 
         statsd.increment(app_error_metric, tags=tags)
         api.Event.create(title=title, text=text, tags=event_tags)

--- a/scripts/migration/set_phase_code_name_unique.py
+++ b/scripts/migration/set_phase_code_name_unique.py
@@ -1,4 +1,5 @@
-# Command to run: python manage.py shell < scripts/migration/set_phase_code_name_unique.py
+# Command to run: python manage.py shell <
+# scripts/migration/set_phase_code_name_unique.py
 
 from challenges.models import ChallengePhase
 

--- a/scripts/migration/set_team_name_unique.py
+++ b/scripts/migration/set_team_name_unique.py
@@ -1,4 +1,5 @@
-# Command to run: python manage.py shell < scripts/migration/set_team_name_unique.py
+# Command to run: python manage.py shell <
+# scripts/migration/set_team_name_unique.py
 
 from participants.models import ParticipantTeam
 from hosts.models import ChallengeHostTeam

--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -1,4 +1,5 @@
-# Command to run : python manage.py shell --settings=settings.dev  < scripts/seed.py
+# Command to run : python manage.py shell --settings=settings.dev  <
+# scripts/seed.py
 import os
 
 from datetime import timedelta
@@ -44,8 +45,10 @@ def create_user(is_admin, username=""):
         is_staff=is_admin,
         is_superuser=is_admin,
     )
-    EmailAddress.objects.create(user=user, email=email, verified=True, primary=True)
-    print("{} was created with username: {} password: password".format("Super user" if is_admin else "User", username))
+    EmailAddress.objects.create(
+        user=user, email=email, verified=True, primary=True)
+    print("{} was created with username: {} password: password".format(
+        "Super user" if is_admin else "User", username))
     return user
 
 
@@ -58,9 +61,12 @@ def create_challenge_host_team(user):
         team_name=team_name,
         created_by=user,
     )
-    print("Challenge Host Team created with team_name: {} created_by: {}".format(team_name, user.username))
-    ChallengeHost.objects.create(user=user, team_name=team, status=ChallengeHost.SELF, permissions=ChallengeHost.ADMIN)
-    print("Challenge Host created with user: {} team_name: {}".format(user.username, team_name))
+    print(
+        "Challenge Host Team created with team_name: {} created_by: {}".format(team_name, user.username))
+    ChallengeHost.objects.create(
+        user=user, team_name=team, status=ChallengeHost.SELF, permissions=ChallengeHost.ADMIN)
+    print(
+        "Challenge Host created with user: {} team_name: {}".format(user.username, team_name))
     return team
 
 
@@ -93,7 +99,8 @@ def create_challenge(title, start_date, end_date, host_team):
     """
     Creates a challenge.
     """
-    evaluation_script = open(os.path.join(settings.BASE_DIR, 'examples', 'example1', 'string_matching.zip'), 'rb')
+    evaluation_script = open(
+        os.path.join(settings.BASE_DIR, 'examples', 'example1', 'string_matching.zip'), 'rb')
     Challenge.objects.create(
         title=title,
         short_description=fake.paragraph(),
@@ -101,7 +108,8 @@ def create_challenge(title, start_date, end_date, host_team):
         terms_and_conditions=fake.paragraph(),
         submission_guidelines=fake.paragraph(),
         evaluation_details=fake.paragraph(),
-        evaluation_script=SimpleUploadedFile(evaluation_script.name, evaluation_script.read()),
+        evaluation_script=SimpleUploadedFile(
+            evaluation_script.name, evaluation_script.read()),
         approved_by_admin=True,
         creator=host_team,
         published=True,
@@ -110,9 +118,10 @@ def create_challenge(title, start_date, end_date, host_team):
         start_date=start_date,
         end_date=end_date,
     )
-    print("Challenge created with title: {} creator: {} start_date: {} end_date: {}".format(title,
-                                                                                            host_team.team_name,
-                                                                                            start_date, end_date))
+    print(
+        "Challenge created with title: {} creator: {} start_date: {} end_date: {}".format(title,
+                                                                                          host_team.team_name,
+                                                                                          start_date, end_date))
 
 
 def create_challenge_phases(challenge, number_of_phases=1):
@@ -133,11 +142,14 @@ def create_challenge_phases(challenge, number_of_phases=1):
             start_date=challenge.start_date,
             end_date=challenge.end_date,
             challenge=challenge,
-            test_annotation=SimpleUploadedFile(fake.file_name(extension="txt"), data, content_type="text/plain"),
+            test_annotation=SimpleUploadedFile(
+                fake.file_name(
+                    extension="txt"), data, content_type="text/plain"),
             codename="{}{}".format("phase", i + 1),
         )
         challenge_phases.append(challenge_phase)
-        print("Challenge Phase created with name: {} challenge: {}".format(name, challenge.title))
+        print(
+            "Challenge Phase created with name: {} challenge: {}".format(name, challenge.title))
     return challenge_phases
 
 
@@ -171,7 +183,8 @@ def create_dataset_splits(number_of_splits):
         )
         dataset_splits.append(dataset_split)
         DATASET_SPLIT_ITERATOR += 1
-        print("Dataset Split created with name: {} codename: {}".format(name, codename))
+        print(
+            "Dataset Split created with name: {} codename: {}".format(name, codename))
     return dataset_splits
 
 
@@ -185,8 +198,9 @@ def create_challenge_phase_splits(challenge_phase, leaderboard, dataset_split):
         dataset_split=dataset_split,
         visibility=ChallengePhaseSplit.PUBLIC
     )
-    print("Challenge Phase Split created with challenge_phase: {} dataset_split: {}".format(challenge_phase.name,
-                                                                                            dataset_split.name))
+    print(
+        "Challenge Phase Split created with challenge_phase: {} dataset_split: {}".format(challenge_phase.name,
+                                                                                          dataset_split.name))
 
 
 def create_participant_team(user):
@@ -198,9 +212,11 @@ def create_participant_team(user):
         team_name=team_name,
         created_by=user,
     )
-    print("Participant Team created with team_name: {} created_by: {}".format(team_name, user.username))
+    print("Participant Team created with team_name: {} created_by: {}".format(
+        team_name, user.username))
     Participant.objects.create(user=user, team=team, status="Self")
-    print("Participant created with user: {} team_name: {}".format(user.username, team_name))
+    print(
+        "Participant created with user: {} team_name: {}".format(user.username, team_name))
     return team
 
 
@@ -212,7 +228,8 @@ def run():
     # Create challenge host team with challenge host
     challenge_host_team = create_challenge_host_team(user=host_user)
     # Create challenge
-    create_challenges(number_of_challenges=NUMBER_OF_CHALLENGES, host_team=challenge_host_team)
+    create_challenges(
+        number_of_challenges=NUMBER_OF_CHALLENGES, host_team=challenge_host_team)
 
     # Fetch all the created challenges
     challenges = Challenge.objects.all()
@@ -220,12 +237,15 @@ def run():
         # Create a leaderboard object for each challenge
         leaderboard = create_leaderboard()
         # Create Phases for a challenge
-        challenge_phases = create_challenge_phases(challenge, number_of_phases=NUMBER_OF_PHASES)
+        challenge_phases = create_challenge_phases(
+            challenge, number_of_phases=NUMBER_OF_PHASES)
         # Create Dataset Split for each Challenge
-        dataset_splits = create_dataset_splits(number_of_splits=NUMBER_OF_DATASET_SPLITS)
+        dataset_splits = create_dataset_splits(
+            number_of_splits=NUMBER_OF_DATASET_SPLITS)
         # Create Challenge Phase Split for each Phase and Dataset Split
         for challenge_phase in challenge_phases:
             for dataset_split in dataset_splits:
-                create_challenge_phase_splits(challenge_phase, leaderboard, dataset_split)
+                create_challenge_phase_splits(
+                    challenge_phase, leaderboard, dataset_split)
     participant_user = create_user(is_admin=False, username="participant")
     create_participant_team(user=participant_user)

--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -22,7 +22,8 @@ from django.conf import settings
 # need to add django project path in sys path
 # root directory : where manage.py lives
 # worker is present in root-directory/scripts/workers
-# but make sure that this worker is run like `python scripts/workers/submission_worker.py`
+# but make sure that this worker is run like `python
+# scripts/workers/submission_worker.py`
 DJANGO_PROJECT_PATH = dirname(dirname(dirname(os.path.abspath(__file__))))
 
 # all challenge and submission will be stored in temp directory
@@ -49,7 +50,7 @@ from challenges.models import (Challenge,
                                ChallengePhase,
                                ChallengePhaseSplit,
                                DatasetSplit,
-                               LeaderboardData) # noqa
+                               LeaderboardData)  # noqa
 
 from jobs.models import Submission          # noqa
 
@@ -59,7 +60,8 @@ CHALLENGE_DATA_DIR = join(CHALLENGE_DATA_BASE_DIR, 'challenge_{challenge_id}')
 PHASE_DATA_BASE_DIR = join(CHALLENGE_DATA_DIR, 'phase_data')
 PHASE_DATA_DIR = join(PHASE_DATA_BASE_DIR, 'phase_{phase_id}')
 PHASE_ANNOTATION_FILE_PATH = join(PHASE_DATA_DIR, '{annotation_file}')
-SUBMISSION_DATA_DIR = join(SUBMISSION_DATA_BASE_DIR, 'submission_{submission_id}')
+SUBMISSION_DATA_DIR = join(
+    SUBMISSION_DATA_BASE_DIR, 'submission_{submission_id}')
 SUBMISSION_INPUT_FILE_PATH = join(SUBMISSION_DATA_DIR, '{input_file}')
 CHALLENGE_IMPORT_STRING = 'challenge_data.challenge_{challenge_id}'
 EVALUATION_SCRIPTS = {}
@@ -137,7 +139,8 @@ def download_and_extract_zip_file(url, download_location, extract_location):
         try:
             os.remove(download_location)
         except Exception as e:
-            logger.error('Failed to remove zip file {}, error {}'.format(download_location, e))
+            logger.error(
+                'Failed to remove zip file {}, error {}'.format(download_location, e))
             traceback.print_exc()
 
 
@@ -180,34 +183,44 @@ def extract_challenge_data(challenge, phases):
 
     '''
 
-    challenge_data_directory = CHALLENGE_DATA_DIR.format(challenge_id=challenge.id)
+    challenge_data_directory = CHALLENGE_DATA_DIR.format(
+        challenge_id=challenge.id)
     evaluation_script_url = challenge.evaluation_script.url
-    evaluation_script_url = return_file_url_per_environment(evaluation_script_url)
+    evaluation_script_url = return_file_url_per_environment(
+        evaluation_script_url)
     # create challenge directory as package
     create_dir_as_python_package(challenge_data_directory)
     # set entry in map
     PHASE_ANNOTATION_FILE_NAME_MAP[challenge.id] = {}
 
-    challenge_zip_file = join(challenge_data_directory, 'challenge_{}.zip'.format(challenge.id))
-    download_and_extract_zip_file(evaluation_script_url, challenge_zip_file, challenge_data_directory)
+    challenge_zip_file = join(
+        challenge_data_directory, 'challenge_{}.zip'.format(challenge.id))
+    download_and_extract_zip_file(
+        evaluation_script_url, challenge_zip_file, challenge_data_directory)
 
-    phase_data_base_directory = PHASE_DATA_BASE_DIR.format(challenge_id=challenge.id)
+    phase_data_base_directory = PHASE_DATA_BASE_DIR.format(
+        challenge_id=challenge.id)
     create_dir(phase_data_base_directory)
 
     for phase in phases:
-        phase_data_directory = PHASE_DATA_DIR.format(challenge_id=challenge.id, phase_id=phase.id)
+        phase_data_directory = PHASE_DATA_DIR.format(
+            challenge_id=challenge.id, phase_id=phase.id)
         # create phase directory
         create_dir(phase_data_directory)
         annotation_file_url = phase.test_annotation.url
-        annotation_file_url = return_file_url_per_environment(annotation_file_url)
+        annotation_file_url = return_file_url_per_environment(
+            annotation_file_url)
         annotation_file_name = os.path.basename(phase.test_annotation.name)
-        PHASE_ANNOTATION_FILE_NAME_MAP[challenge.id][phase.id] = annotation_file_name
-        annotation_file_path = PHASE_ANNOTATION_FILE_PATH.format(challenge_id=challenge.id, phase_id=phase.id,
+        PHASE_ANNOTATION_FILE_NAME_MAP[challenge.id][
+            phase.id] = annotation_file_name
+        annotation_file_path = PHASE_ANNOTATION_FILE_PATH.format(
+            challenge_id=challenge.id, phase_id=phase.id,
                                                                  annotation_file=annotation_file_name)
         download_and_extract_file(annotation_file_url, annotation_file_path)
 
     # import the challenge after everything is finished
-    challenge_module = importlib.import_module(CHALLENGE_IMPORT_STRING.format(challenge_id=challenge.id))
+    challenge_module = importlib.import_module(
+        CHALLENGE_IMPORT_STRING.format(challenge_id=challenge.id))
     EVALUATION_SCRIPTS[challenge.id] = challenge_module
 
 
@@ -246,16 +259,20 @@ def extract_submission_data(submission_id):
         return None
 
     submission_input_file = submission.input_file.url
-    submission_input_file = return_file_url_per_environment(submission_input_file)
+    submission_input_file = return_file_url_per_environment(
+        submission_input_file)
 
-    submission_data_directory = SUBMISSION_DATA_DIR.format(submission_id=submission.id)
+    submission_data_directory = SUBMISSION_DATA_DIR.format(
+        submission_id=submission.id)
     submission_input_file_name = os.path.basename(submission.input_file.name)
-    submission_input_file_path = SUBMISSION_INPUT_FILE_PATH.format(submission_id=submission.id,
+    submission_input_file_path = SUBMISSION_INPUT_FILE_PATH.format(
+        submission_id=submission.id,
                                                                    input_file=submission_input_file_name)
     # create submission directory
     create_dir_as_python_package(submission_data_directory)
 
-    download_and_extract_file(submission_input_file, submission_input_file_path)
+    download_and_extract_file(
+        submission_input_file, submission_input_file_path)
 
     return submission
 
@@ -269,10 +286,13 @@ def run_submission(challenge_id, challenge_phase, submission_id, submission, use
     '''
     submission_output = None
     phase_id = challenge_phase.id
-    annotation_file_name = PHASE_ANNOTATION_FILE_NAME_MAP.get(challenge_id).get(phase_id)
-    annotation_file_path = PHASE_ANNOTATION_FILE_PATH.format(challenge_id=challenge_id, phase_id=phase_id,
+    annotation_file_name = PHASE_ANNOTATION_FILE_NAME_MAP.get(
+        challenge_id).get(phase_id)
+    annotation_file_path = PHASE_ANNOTATION_FILE_PATH.format(
+        challenge_id=challenge_id, phase_id=phase_id,
                                                              annotation_file=annotation_file_name)
-    submission_data_dir = SUBMISSION_DATA_DIR.format(submission_id=submission_id)
+    submission_data_dir = SUBMISSION_DATA_DIR.format(
+        submission_id=submission_id)
     # create a temporary run directory under submission directory, so that
     # main directory does not gets polluted
     temp_run_dir = join(submission_data_dir, 'run')
@@ -287,14 +307,16 @@ def run_submission(challenge_id, challenge_phase, submission_id, submission, use
     stdout = open(stdout_file, 'a+')
     stderr = open(stderr_file, 'a+')
 
-    # call `main` from globals and set `status` to running and hence `started_at`
+    # call `main` from globals and set `status` to running and hence
+    # `started_at`
     submission.status = Submission.RUNNING
     submission.started_at = timezone.now()
     submission.save()
     try:
         successful_submission_flag = True
         with stdout_redirect(stdout) as new_stdout, stderr_redirect(stderr) as new_stderr:      # noqa
-            submission_output = EVALUATION_SCRIPTS[challenge_id].evaluate(annotation_file_path,
+            submission_output = EVALUATION_SCRIPTS[challenge_id].evaluate(
+                annotation_file_path,
                                                                           user_annotation_file_path,
                                                                           challenge_phase.codename,)
         '''
@@ -329,10 +351,13 @@ def run_submission(challenge_id, challenge_phase, submission_id, submission, use
             leaderboard_data_list = []
             for split_result in submission_output['result']:
 
-                # Check if the dataset_split exists for the codename in the result
+                # Check if the dataset_split exists for the codename in the
+                # result
                 try:
-                    split_code_name = split_result.items()[0][0]  # get split_code_name that is the key of the result
-                    dataset_split = DatasetSplit.objects.get(codename=split_code_name)
+                    split_code_name = split_result.items()[0][
+                        0]  # get split_code_name that is the key of the result
+                    dataset_split = DatasetSplit.objects.get(
+                        codename=split_code_name)
                 except:
                     stderr.write("ORGINIAL EXCEPTION: The codename specified by your Challenge Host doesn't match"
                                  " with that in the evaluation Script.\n")
@@ -340,9 +365,11 @@ def run_submission(challenge_id, challenge_phase, submission_id, submission, use
                     successful_submission_flag = False
                     break
 
-                # Check if the challenge_phase_split exists for the challenge_phase and dataset_split
+                # Check if the challenge_phase_split exists for the
+                # challenge_phase and dataset_split
                 try:
-                    challenge_phase_split = ChallengePhaseSplit.objects.get(challenge_phase=challenge_phase,
+                    challenge_phase_split = ChallengePhaseSplit.objects.get(
+                        challenge_phase=challenge_phase,
                                                                             dataset_split=dataset_split)
                 except:
                     stderr.write("ORGINIAL EXCEPTION: No such relation between between Challenge Phase and DatasetSplit"
@@ -355,14 +382,16 @@ def run_submission(challenge_id, challenge_phase, submission_id, submission, use
                 leaderboard_data.challenge_phase_split = challenge_phase_split
                 leaderboard_data.submission = submission
                 leaderboard_data.leaderboard = challenge_phase_split.leaderboard
-                leaderboard_data.result = split_result.get(dataset_split.codename)
+                leaderboard_data.result = split_result.get(
+                    dataset_split.codename)
 
                 leaderboard_data_list.append(leaderboard_data)
 
             if successful_submission_flag:
                 LeaderboardData.objects.bulk_create(leaderboard_data_list)
 
-        # Once the submission_output is processed, then save the submission object with appropriate status
+        # Once the submission_output is processed, then save the submission
+        # object with appropriate status
         else:
             successful_submission_flag = False
 
@@ -375,7 +404,8 @@ def run_submission(challenge_id, challenge_phase, submission_id, submission, use
     submission.completed_at = timezone.now()
     submission.save()
 
-    # after the execution is finished, set `status` to finished and hence `completed_at`
+    # after the execution is finished, set `status` to finished and hence
+    # `completed_at`
     if submission_output:
         output = {}
         output['result'] = submission_output.get('result', '')
@@ -383,11 +413,13 @@ def run_submission(challenge_id, challenge_phase, submission_id, submission, use
 
         # Save submission_result_file
         submission_result = submission_output.get('submission_result', '')
-        submission.submission_result_file.save('submission_result.json', ContentFile(submission_result))
+        submission.submission_result_file.save(
+            'submission_result.json', ContentFile(submission_result))
 
         # Save submission_metadata_file
         submission_metadata = submission_output.get('submission_metadata', '')
-        submission.submission_metadata_file.save('submission_metadata.json', ContentFile(submission_metadata))
+        submission.submission_metadata_file.save(
+            'submission_metadata.json', ContentFile(submission_metadata))
 
     submission.save()
 
@@ -403,7 +435,8 @@ def run_submission(challenge_id, challenge_phase, submission_id, submission, use
     if (submission_status is Submission.FAILED):
         with open(stderr_file, 'r') as stderr:
             stderr_content = stderr.read()
-            submission.stderr_file.save('stderr.txt', ContentFile(stderr_content))
+            submission.stderr_file.save(
+                'stderr.txt', ContentFile(stderr_content))
 
     # delete the complete temp run directory
     shutil.rmtree(temp_run_dir)
@@ -426,9 +459,11 @@ def process_submission_message(message):
         traceback.print_exc()
         return
 
-    user_annotation_file_path = join(SUBMISSION_DATA_DIR.format(submission_id=submission_id),
+    user_annotation_file_path = join(
+        SUBMISSION_DATA_DIR.format(submission_id=submission_id),
                                      os.path.basename(submission_instance.input_file.name))
-    run_submission(challenge_id, challenge_phase, submission_id, submission_instance, user_annotation_file_path)
+    run_submission(challenge_id, challenge_phase, submission_id,
+                   submission_instance, user_annotation_file_path)
 
 
 def process_add_challenge_message(message):
@@ -452,7 +487,8 @@ def process_submission_callback(ch, method, properties, body):
         process_submission_message(body)
         ch.basic_ack(delivery_tag=method.delivery_tag)
     except Exception as e:
-        logger.error('Error in receiving message from submission queue with error {}'.format(e))
+        logger.error(
+            'Error in receiving message from submission queue with error {}'.format(e))
         traceback.print_exc()
 
 
@@ -463,13 +499,15 @@ def add_challenge_callback(ch, method, properties, body):
         process_add_challenge_message(body)
         ch.basic_ack(delivery_tag=method.delivery_tag)
     except Exception as e:
-        logger.error('Error in receiving message from add challenge queue with error {}'.format(e))
+        logger.error(
+            'Error in receiving message from add challenge queue with error {}'.format(e))
         traceback.print_exc()
 
 
 def main():
 
-    logger.info('Using {0} as temp directory to store data'.format(BASE_TEMP_DIR))
+    logger.info(
+        'Using {0} as temp directory to store data'.format(BASE_TEMP_DIR))
     create_dir_as_python_package(COMPUTE_DIRECTORY_PATH)
 
     sys.path.append(COMPUTE_DIRECTORY_PATH)
@@ -485,7 +523,8 @@ def main():
 
     # name can be a combination of hostname + process id
     # host name : to easily identify that the worker is running on which instance
-    # process id : to add uniqueness in case more than one worker is running on the same instance
+    # process id : to add uniqueness in case more than one worker is running
+    # on the same instance
     add_challenge_queue_name = '{hostname}_{process_id}'.format(hostname=socket.gethostname(),
                                                                 process_id=str(os.getpid()))
 
@@ -496,7 +535,8 @@ def main():
     # reason for using `exclusive` instead of `autodelete` is that
     # challenge addition queue should have only have one consumer on the connection
     # that creates it.
-    channel.queue_declare(queue=add_challenge_queue_name, durable=True, exclusive=True)
+    channel.queue_declare(
+        queue=add_challenge_queue_name, durable=True, exclusive=True)
     logger.info('[*] Waiting for messages. To exit press CTRL+C')
 
     # create submission base data directory
@@ -513,7 +553,8 @@ def main():
     channel.queue_bind(
         exchange=settings.RABBITMQ_PARAMETERS['EVALAI_EXCHANGE']['NAME'],
         queue=add_challenge_queue_name, routing_key='challenge.*.*')
-    channel.basic_consume(add_challenge_callback, queue=add_challenge_queue_name)
+    channel.basic_consume(
+        add_challenge_callback, queue=add_challenge_queue_name)
 
     channel.start_consuming()
 

--- a/settings/dev.sample.py
+++ b/settings/dev.sample.py
@@ -24,7 +24,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 ACCOUNT_DEFAULT_HTTP_PROTOCOL = 'http'
 
 # DJANGO-SPAGHETTI-AND-MEATBALLS SETTINGS
-INSTALLED_APPS += [ # noqa: ignore=F405
+INSTALLED_APPS += [  # noqa: ignore=F405
     'django_spaghetti',
     'autofixture',
     'debug_toolbar',
@@ -45,7 +45,7 @@ CACHES = {
 
 MEDIA_URL = "/media/"
 
-MIDDLEWARE += [ # noqa: ignore=F405
+MIDDLEWARE += [  # noqa: ignore=F405
     'debug_toolbar.middleware.DebugToolbarMiddleware',
     'silk.middleware.SilkyMiddleware',
 ]

--- a/settings/prod.py
+++ b/settings/prod.py
@@ -50,7 +50,8 @@ STATIC_URL = "https://%s/%s/" % (AWS_S3_CUSTOM_DOMAIN, STATICFILES_LOCATION)
 
 # Media files configuration on S3
 MEDIAFILES_LOCATION = 'media'
-MEDIA_URL = 'http://%s.s3.amazonaws.com/%s/' % (AWS_STORAGE_BUCKET_NAME, MEDIAFILES_LOCATION)
+MEDIA_URL = 'http://%s.s3.amazonaws.com/%s/' % (
+    AWS_STORAGE_BUCKET_NAME, MEDIAFILES_LOCATION)
 DEFAULT_FILE_STORAGE = 'settings.custom_storages.MediaStorage'
 
 # Setup Email Backend related settings
@@ -68,7 +69,7 @@ REST_FRAMEWORK_DOCS = {
 }
 
 # Port number for the python-memcached cache backend.
-CACHES['default']['LOCATION'] = os.environ.get("MEMCACHED_LOCATION", "127.0.0.1:11211") # noqa: ignore=F405
+CACHES['default']['LOCATION'] = os.environ.get("MEMCACHED_LOCATION", "127.0.0.1:11211")  # noqa: ignore=F405
 
 RAVEN_CONFIG = {
     'dsn': os.environ.get('SENTRY_URL'),

--- a/settings/staging.py
+++ b/settings/staging.py
@@ -49,7 +49,8 @@ STATIC_URL = "https://%s/%s/" % (AWS_S3_CUSTOM_DOMAIN, STATICFILES_LOCATION)
 
 # Media files configuration on S3
 MEDIAFILES_LOCATION = 'media'
-MEDIA_URL = 'http://%s.s3.amazonaws.com/%s/' % (AWS_STORAGE_BUCKET_NAME, MEDIAFILES_LOCATION)
+MEDIA_URL = 'http://%s.s3.amazonaws.com/%s/' % (
+    AWS_STORAGE_BUCKET_NAME, MEDIAFILES_LOCATION)
 DEFAULT_FILE_STORAGE = 'settings.custom_storages.MediaStorage'
 
 # Setup Email Backend related settings
@@ -67,7 +68,7 @@ REST_FRAMEWORK_DOCS = {
 }
 
 # Port number for the python-memcached cache backend.
-CACHES['default']['LOCATION'] = os.environ.get("MEMCACHED_LOCATION", "127.0.0.1:11211") # noqa: ignore=F405
+CACHES['default']['LOCATION'] = os.environ.get("MEMCACHED_LOCATION", "127.0.0.1:11211")  # noqa: ignore=F405
 
 RAVEN_CONFIG = {
     'dsn': os.environ.get('SENTRY_URL'),

--- a/tests/unit/accounts/test_models.py
+++ b/tests/unit/accounts/test_models.py
@@ -20,7 +20,7 @@ class UserStatusTestCase(BaseTestCase):
         self.user_status = UserStatus.objects.create(
             name='user',
             status=UserStatus.UNKNOWN,
-            )
+        )
 
     def test__str__(self):
         self.assertEqual(self.user_status.name, self.user_status.__str__())
@@ -33,4 +33,5 @@ class ProfileTestCase(BaseTestCase):
         self.profile = Profile.objects.get(user=self.user)
 
     def test__str__(self):
-        self.assertEqual('{}'.format(self.profile.user), self.profile.__str__())
+        self.assertEqual(
+            '{}'.format(self.profile.user), self.profile.__str__())

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -44,7 +44,8 @@ class TestUpdateUser(BaseAPITestClass):
             'username': 'anotheruser',
             'affiliation': 'some_affiliation',
         }
-        response = self.client.put(os.path.join('api', 'auth', self.url), self.data)
+        response = self.client.put(
+            os.path.join('api', 'auth', self.url), self.data)
         self.assertNotContains(response, 'anotheruser')
         self.assertContains(response, 'someuser')
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/tests/unit/analytics/test_views.py
+++ b/tests/unit/analytics/test_views.py
@@ -258,7 +258,8 @@ class ChallengePhaseSubmissionAnalysisTest(BaseAPITestClass):
 
     def setUp(self):
         super(ChallengePhaseSubmissionAnalysisTest, self).setUp()
-        self.url = reverse_lazy('analytics:get_challenge_phase_submission_analysis',
+        self.url = reverse_lazy(
+            'analytics:get_challenge_phase_submission_analysis',
                                 kwargs={'challenge_pk': self.challenge.pk,
                                         'challenge_phase_pk': self.challenge_phase.pk})
 
@@ -276,39 +277,42 @@ class ChallengePhaseSubmissionAnalysisTest(BaseAPITestClass):
         )
 
     def test_get_challenge_phase_submission_analysis_when_challenge_does_not_exist(self):
-        self.url = reverse_lazy('analytics:get_challenge_phase_submission_analysis',
-                                kwargs={'challenge_pk': self.challenge.pk+10,
+        self.url = reverse_lazy(
+            'analytics:get_challenge_phase_submission_analysis',
+                                kwargs={'challenge_pk': self.challenge.pk + 10,
                                         'challenge_phase_pk': self.challenge_phase.pk})
 
         expected = {
-            "detail": "Challenge {} does not exist".format(self.challenge.pk+10)
+            "detail": "Challenge {} does not exist".format(self.challenge.pk + 10)
         }
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_challenge_phase_submission_analysis_when_challenge_phase_does_not_exist(self):
-        self.url = reverse_lazy('analytics:get_challenge_phase_submission_analysis',
+        self.url = reverse_lazy(
+            'analytics:get_challenge_phase_submission_analysis',
                                 kwargs={'challenge_pk': self.challenge.pk,
-                                        'challenge_phase_pk': self.challenge_phase.pk+10})
+                                        'challenge_phase_pk': self.challenge_phase.pk + 10})
 
         expected = {
-            "detail": "ChallengePhase {} does not exist".format(self.challenge_phase.pk+10)
+            "detail": "ChallengePhase {} does not exist".format(self.challenge_phase.pk + 10)
         }
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_challenge_phase_submission_analysis(self):
-        self.url = reverse_lazy('analytics:get_challenge_phase_submission_analysis',
+        self.url = reverse_lazy(
+            'analytics:get_challenge_phase_submission_analysis',
                                 kwargs={'challenge_pk': self.challenge.pk,
                                         'challenge_phase_pk': self.challenge_phase.pk})
 
         expected = {
-                "submission_count": 1,
+            "submission_count": 1,
                 "participant_team_count": 1,
                 "challenge_phase": self.challenge_phase.pk
-            }
+        }
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -338,12 +342,12 @@ class GetLastSubmissionTimeTest(BaseAPITestClass):
 
     def test_get_last_submission_time_when_challenge_does_not_exists(self):
         self.url = reverse_lazy('analytics:get_last_submission_time',
-                                kwargs={'challenge_pk': self.challenge.pk+10,
+                                kwargs={'challenge_pk': self.challenge.pk + 10,
                                         'challenge_phase_pk': self.challenge_phase.pk,
                                         'submission_by': 'challenge'})
         expected = {
-            'detail': 'Challenge {} does not exist'.format(self.challenge.pk+10)
-            }
+            'detail': 'Challenge {} does not exist'.format(self.challenge.pk + 10)
+        }
 
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
@@ -352,11 +356,11 @@ class GetLastSubmissionTimeTest(BaseAPITestClass):
     def test_get_last_submission_time_when_challenge_phase_does_not_exists(self):
         self.url = reverse_lazy('analytics:get_last_submission_time',
                                 kwargs={'challenge_pk': self.challenge.pk,
-                                        'challenge_phase_pk': self.challenge_phase.pk+10,
+                                        'challenge_phase_pk': self.challenge_phase.pk + 10,
                                         'submission_by': 'challenge'})
         expected = {
-            'detail': 'ChallengePhase {} does not exist'.format(self.challenge_phase.pk+10)
-            }
+            'detail': 'ChallengePhase {} does not exist'.format(self.challenge_phase.pk + 10)
+        }
 
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
@@ -370,7 +374,7 @@ class GetLastSubmissionTimeTest(BaseAPITestClass):
         expected = {
             'last_submission_datetime': "{0}{1}".format(self.submission.created_at.isoformat(), 'Z')
                                         .replace("+00:00", "")
-            }
+        }
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -382,7 +386,7 @@ class GetLastSubmissionTimeTest(BaseAPITestClass):
                                         'submission_by': 'other'})
         expected = {
             'error': 'Page not found!'
-            }
+        }
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -392,7 +396,8 @@ class GetLastSubmissionDateTimeAnalysisTest(BaseAPITestClass):
 
     def setUp(self):
         super(GetLastSubmissionDateTimeAnalysisTest, self).setUp()
-        self.url = reverse_lazy('analytics:get_last_submission_datetime_analysis',
+        self.url = reverse_lazy(
+            'analytics:get_last_submission_datetime_analysis',
                                 kwargs={'challenge_pk': self.challenge.pk,
                                         'challenge_phase_pk': self.challenge_phase.pk})
 
@@ -410,31 +415,34 @@ class GetLastSubmissionDateTimeAnalysisTest(BaseAPITestClass):
         )
 
     def test_get_last_submission_datetime_when_challenge_does_not_exists(self):
-        self.url = reverse_lazy('analytics:get_last_submission_datetime_analysis',
-                                kwargs={'challenge_pk': self.challenge.pk+10,
+        self.url = reverse_lazy(
+            'analytics:get_last_submission_datetime_analysis',
+                                kwargs={'challenge_pk': self.challenge.pk + 10,
                                         'challenge_phase_pk': self.challenge_phase.pk})
         expected = {
-            'detail': 'Challenge {} does not exist'.format(self.challenge.pk+10)
-            }
+            'detail': 'Challenge {} does not exist'.format(self.challenge.pk + 10)
+        }
 
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_last_submission_datetime_when_challenge_phase_does_not_exists(self):
-        self.url = reverse_lazy('analytics:get_last_submission_datetime_analysis',
+        self.url = reverse_lazy(
+            'analytics:get_last_submission_datetime_analysis',
                                 kwargs={'challenge_pk': self.challenge.pk,
-                                        'challenge_phase_pk': self.challenge_phase.pk+10})
+                                        'challenge_phase_pk': self.challenge_phase.pk + 10})
         expected = {
-            'detail': 'ChallengePhase {} does not exist'.format(self.challenge_phase.pk+10)
-            }
+            'detail': 'ChallengePhase {} does not exist'.format(self.challenge_phase.pk + 10)
+        }
 
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_last_submission_datetime_analysis(self):
-        self.url = reverse_lazy('analytics:get_last_submission_datetime_analysis',
+        self.url = reverse_lazy(
+            'analytics:get_last_submission_datetime_analysis',
                                 kwargs={'challenge_pk': self.challenge.pk,
                                         'challenge_phase_pk': self.challenge_phase.pk})
 
@@ -443,9 +451,10 @@ class GetLastSubmissionDateTimeAnalysisTest(BaseAPITestClass):
             'last_submission_timestamp_in_challenge_phase': "{0}{1}".format(datetime, 'Z').replace("+00:00", ""),
             'last_submission_timestamp_in_challenge': "{0}{1}".format(datetime, 'Z').replace("+00:00", ""),
             'challenge_phase': self.challenge_phase.pk
-            }
+        }
         response = self.client.get(self.url, {})
-        datetime = response.data['last_submission_timestamp_in_challenge_phase'].isoformat()
+        datetime = response.data[
+            'last_submission_timestamp_in_challenge_phase'].isoformat()
         response_data = {
             'last_submission_timestamp_in_challenge_phase': "{0}{1}".format(datetime, 'Z').replace("+00:00", ""),
             'last_submission_timestamp_in_challenge': "{0}{1}".format(datetime, 'Z').replace("+00:00", ""),

--- a/tests/unit/base/test_utils.py
+++ b/tests/unit/base/test_utils.py
@@ -94,7 +94,8 @@ class TestRandomFileName(BaseAPITestClass):
 
     def setUp(self):
         super(TestRandomFileName, self).setUp()
-        self.test_file_path = os.path.join(settings.BASE_DIR, 'examples', 'example1', 'test_annotation.txt')
+        self.test_file_path = os.path.join(
+            settings.BASE_DIR, 'examples', 'example1', 'test_annotation.txt')
 
     def test_random_file_name_without_id(self):
         obj = RandomFileName("evaluation_scripts")
@@ -105,5 +106,6 @@ class TestRandomFileName(BaseAPITestClass):
     def test_random_file_name_with_id(self):
         obj = RandomFileName("submission_files/submission_{id}")
         filepath = obj.__call__(self.submission, self.test_file_path)
-        expected = "submission_files/submission_{}/{}".format(self.submission.pk, filepath.split('/')[2])
+        expected = "submission_files/submission_{}/{}".format(
+            self.submission.pk, filepath.split('/')[2])
         self.assertEqual(filepath, expected)

--- a/tests/unit/challenges/test_models.py
+++ b/tests/unit/challenges/test_models.py
@@ -60,16 +60,18 @@ class BaseTestCase(TestCase):
                 max_submissions=100000,
             )
 
-        self.dataset_split = DatasetSplit.objects.create(name="Test Dataset Split", codename="test-split")
+        self.dataset_split = DatasetSplit.objects.create(
+            name="Test Dataset Split", codename="test-split")
 
-        self.leaderboard = Leaderboard.objects.create(schema=json.dumps({'hello': 'world'}))
+        self.leaderboard = Leaderboard.objects.create(
+            schema=json.dumps({'hello': 'world'}))
 
         self.challenge_phase_split = ChallengePhaseSplit.objects.create(
-                dataset_split=self.dataset_split,
+            dataset_split=self.dataset_split,
                 challenge_phase=self.challenge_phase,
                 leaderboard=self.leaderboard,
                 visibility=ChallengePhaseSplit.PUBLIC
-            )
+        )
 
 
 class ChallengeTestCase(BaseTestCase):
@@ -85,7 +87,8 @@ class ChallengeTestCase(BaseTestCase):
         with self.settings(MEDIA_ROOT='/tmp/evalai'):
             self.challenge.image = SimpleUploadedFile('test_sample_file.jpg',
                                                       'Dummy image content', content_type='image')
-            self.challenge.evaluation_script = SimpleUploadedFile('test_sample_file.zip',
+            self.challenge.evaluation_script = SimpleUploadedFile(
+                'test_sample_file.zip',
                                                                   'Dummy zip content', content_type='zip')
         self.challenge.save()
 
@@ -177,7 +180,8 @@ class LeaderboardTestCase(BaseTestCase):
 
     def setUp(self):
         super(LeaderboardTestCase, self).setUp()
-        self.leaderboard = Leaderboard.objects.create(schema=json.dumps({"hello": "world"}))
+        self.leaderboard = Leaderboard.objects.create(
+            schema=json.dumps({"hello": "world"}))
 
     def test__str__(self):
         instance_id = str(self.leaderboard.id)
@@ -196,7 +200,8 @@ class ChallengePhaseSplitTestCase(BaseTestCase):
     def test__str__(self):
         challenge_phase_name = self.challenge_phase_split.challenge_phase.name
         dataset_split_name = self.challenge_phase_split.dataset_split.name
-        string_to_compare = '{} : {}'.format(challenge_phase_name, dataset_split_name)
+        string_to_compare = '{} : {}'.format(
+            challenge_phase_name, dataset_split_name)
         self.assertEqual(string_to_compare,
                          self.challenge_phase_split.__str__())
 
@@ -220,11 +225,12 @@ class LeaderboardDataTestCase(BaseTestCase):
         )
 
         self.leaderboard_data = LeaderboardData.objects.create(
-                challenge_phase_split=self.challenge_phase_split,
+            challenge_phase_split=self.challenge_phase_split,
                 submission=self.submission,
                 leaderboard=self.leaderboard,
                 result=json.dumps({'hello': 'world'}),)
 
     def test__str__(self):
-        self.assertEqual('{0} : {1}'.format(self.challenge_phase_split, self.submission),
+        self.assertEqual(
+            '{0} : {1}'.format(self.challenge_phase_split, self.submission),
                          self.leaderboard_data.__str__())

--- a/tests/unit/challenges/test_serializers.py
+++ b/tests/unit/challenges/test_serializers.py
@@ -103,27 +103,36 @@ class ChallengePhaseCreateSerializerTest(BaseTestCase):
                 'codename': self.challenge_phase.codename,
                 'is_active': self.challenge_phase.is_active,
             }
-            self.challenge_phase_create_serializer = ChallengePhaseCreateSerializer(instance=self.challenge_phase)
+            self.challenge_phase_create_serializer = ChallengePhaseCreateSerializer(
+                instance=self.challenge_phase)
 
     def test_challenge_phase_create_serializer(self):
 
         data = self.challenge_phase_create_serializer.data
 
-        self.assertItemsEqual(data.keys(), ['id', 'name', 'description', 'leaderboard_public', 'start_date',
-                                            'end_date', 'challenge', 'max_submissions_per_day', 'max_submissions',
-                                            'is_public', 'is_active', 'codename', 'test_annotation'])
+        self.assertItemsEqual(
+            data.keys(
+            ), ['id', 'name', 'description', 'leaderboard_public', 'start_date',
+                'end_date', 'challenge', 'max_submissions_per_day', 'max_submissions',
+                'is_public', 'is_active', 'codename', 'test_annotation'])
         self.assertEqual(data['id'], self.serializer_data['id'])
         self.assertEqual(data['name'], self.serializer_data['name'])
-        self.assertEqual(data['description'], self.serializer_data['description'])
-        self.assertEqual(data['leaderboard_public'], self.serializer_data['leaderboard_public'])
-        self.assertEqual(data['start_date'], self.serializer_data['start_date'])
+        self.assertEqual(
+            data['description'], self.serializer_data['description'])
+        self.assertEqual(
+            data['leaderboard_public'], self.serializer_data['leaderboard_public'])
+        self.assertEqual(
+            data['start_date'], self.serializer_data['start_date'])
         self.assertEqual(data['end_date'], self.serializer_data['end_date'])
         self.assertEqual(data['challenge'], self.serializer_data['challenge'])
-        self.assertEqual(data['max_submissions_per_day'], self.serializer_data['max_submissions_per_day'])
-        self.assertEqual(data['max_submissions'], self.serializer_data['max_submissions'])
+        self.assertEqual(data['max_submissions_per_day'],
+                         self.serializer_data['max_submissions_per_day'])
+        self.assertEqual(
+            data['max_submissions'], self.serializer_data['max_submissions'])
         self.assertEqual(data['is_public'], self.serializer_data['is_public'])
         self.assertEqual(data['codename'], self.serializer_data['codename'])
-        self.assertEqual(data['test_annotation'], self.serializer_data['test_annotation'])
+        self.assertEqual(
+            data['test_annotation'], self.serializer_data['test_annotation'])
         self.assertEqual(data['is_active'], self.serializer_data['is_active'])
 
     def test_challenge_phase_create_serializer_with_invalid_data(self):

--- a/tests/unit/challenges/test_urls.py
+++ b/tests/unit/challenges/test_urls.py
@@ -61,7 +61,8 @@ class BaseAPITestClass(APITestCase):
             team_name='Participant Team for Challenge',
             created_by=self.user)
 
-        self.dataset_split = DatasetSplit.objects.create(name="Name of the dataset split",
+        self.dataset_split = DatasetSplit.objects.create(
+            name="Name of the dataset split",
                                                          codename="codename of dataset split")
 
         self.leaderboard = Leaderboard.objects.create(schema=json.dumps({
@@ -73,7 +74,7 @@ class BaseAPITestClass(APITestCase):
             challenge_phase=self.challenge_phase,
             leaderboard=self.leaderboard,
             visibility=ChallengePhaseSplit.PUBLIC
-            )
+        )
 
         self.file_type = 'csv'
 
@@ -85,10 +86,12 @@ class TestChallengeUrls(BaseAPITestClass):
     def test_challenges_urls(self):
         url = reverse_lazy('challenges:get_challenge_list',
                            kwargs={'challenge_host_team_pk': self.challenge_host_team.pk})
-        self.assertEqual(url, '/api/challenges/challenge_host_team/' + str(self.challenge_host_team.pk) + '/challenge')
+        self.assertEqual(url, '/api/challenges/challenge_host_team/' + str(
+            self.challenge_host_team.pk) + '/challenge')
 
         url = reverse_lazy('challenges:get_challenge_detail',
-                           kwargs={'challenge_host_team_pk': self.challenge_host_team.pk,
+                           kwargs={
+                               'challenge_host_team_pk': self.challenge_host_team.pk,
                                    'challenge_pk': self.challenge.pk})
         self.assertEqual(url, '/api/challenges/challenge_host_team/' +
                          str(self.challenge_host_team.pk) + '/challenge/' + str(self.challenge.pk))
@@ -98,21 +101,28 @@ class TestChallengeUrls(BaseAPITestClass):
         self.assertEqual(url, '/api/challenges/challenge/' + str(self.challenge.pk) + '/participant_team/' +
                          str(self.participant_team.pk))
 
-        url = reverse_lazy('challenges:disable_challenge', kwargs={'challenge_pk': self.challenge.pk})
-        self.assertEqual(url, '/api/challenges/challenge/' + str(self.challenge.pk) + '/disable')
+        url = reverse_lazy(
+            'challenges:disable_challenge', kwargs={'challenge_pk': self.challenge.pk})
+        self.assertEqual(
+            url, '/api/challenges/challenge/' + str(self.challenge.pk) + '/disable')
 
-        url = reverse_lazy('challenges:get_challenge_phase_list', kwargs={'challenge_pk': self.challenge.pk})
-        self.assertEqual(url, '/api/challenges/challenge/' + str(self.challenge.pk) + '/challenge_phase')
+        url = reverse_lazy(
+            'challenges:get_challenge_phase_list', kwargs={'challenge_pk': self.challenge.pk})
+        self.assertEqual(url, '/api/challenges/challenge/' + str(
+            self.challenge.pk) + '/challenge_phase')
 
         url = reverse_lazy('challenges:get_challenge_phase_detail',
                            kwargs={'challenge_pk': self.challenge.pk, 'pk': self.challenge_phase.pk})
         self.assertEqual(url, '/api/challenges/challenge/' + str(self.challenge.pk) + '/challenge_phase/' +
                          str(self.challenge_phase.pk))
 
-        url = reverse_lazy('challenges:get_challenge_by_pk', kwargs={'pk': self.challenge.pk})
-        self.assertEqual(url, '/api/challenges/challenge/' + str(self.challenge.pk) + '/')
+        url = reverse_lazy(
+            'challenges:get_challenge_by_pk', kwargs={'pk': self.challenge.pk})
+        self.assertEqual(
+            url, '/api/challenges/challenge/' + str(self.challenge.pk) + '/')
 
-        url = reverse_lazy('challenges:get_all_challenges', kwargs={'challenge_time': "PAST"})
+        url = reverse_lazy(
+            'challenges:get_all_challenges', kwargs={'challenge_time': "PAST"})
         self.assertEqual(url, '/api/challenges/challenge/PAST')
 
         self.url = reverse_lazy('challenges:download_all_submissions',
@@ -123,7 +133,8 @@ class TestChallengeUrls(BaseAPITestClass):
                          '/api/challenges/{}/phase/{}/download_all_submissions/{}/'
                          .format(self.challenge.pk, self.challenge_phase.pk, self.file_type))
         resolver = resolve(self.url)
-        self.assertEqual(resolver.view_name, 'challenges:download_all_submissions')
+        self.assertEqual(
+            resolver.view_name, 'challenges:download_all_submissions')
 
         self.url = reverse_lazy('challenges:create_leaderboard')
         self.assertEqual(self.url,
@@ -137,7 +148,8 @@ class TestChallengeUrls(BaseAPITestClass):
                          '/api/challenges/challenge/create/leaderboard/{}/'
                          .format(self.leaderboard.pk))
         resolver = resolve(self.url)
-        self.assertEqual(resolver.view_name, 'challenges:get_or_update_leaderboard')
+        self.assertEqual(
+            resolver.view_name, 'challenges:get_or_update_leaderboard')
 
         self.url = reverse_lazy('challenges:create_dataset_split')
         self.assertEqual(self.url,
@@ -151,21 +163,25 @@ class TestChallengeUrls(BaseAPITestClass):
                          '/api/challenges/challenge/create/dataset_split/{}/'
                          .format(self.dataset_split.pk))
         resolver = resolve(self.url)
-        self.assertEqual(resolver.view_name, 'challenges:get_or_update_dataset_split')
+        self.assertEqual(
+            resolver.view_name, 'challenges:get_or_update_dataset_split')
 
         self.url = reverse_lazy('challenges:create_challenge_phase_split')
         self.assertEqual(self.url,
                          '/api/challenges/challenge/create/challenge_phase_split/step_5/')
         resolver = resolve(self.url)
-        self.assertEqual(resolver.view_name, 'challenges:create_challenge_phase_split')
+        self.assertEqual(
+            resolver.view_name, 'challenges:create_challenge_phase_split')
 
-        self.url = reverse_lazy('challenges:get_or_update_challenge_phase_split',
+        self.url = reverse_lazy(
+            'challenges:get_or_update_challenge_phase_split',
                                 kwargs={'challenge_phase_split_pk': self.challenge_phase_split.pk})
         self.assertEqual(self.url,
                          '/api/challenges/challenge/create/challenge_phase_split/{}/'
                          .format(self.challenge_phase_split.pk))
         resolver = resolve(self.url)
-        self.assertEqual(resolver.view_name, 'challenges:get_or_update_challenge_phase_split')
+        self.assertEqual(
+            resolver.view_name, 'challenges:get_or_update_challenge_phase_split')
 
         self.url = reverse_lazy('challenges:star_challenge',
                                 kwargs={'challenge_pk': self.challenge.pk})

--- a/tests/unit/challenges/test_utils.py
+++ b/tests/unit/challenges/test_utils.py
@@ -9,7 +9,8 @@ from challenges.utils import get_file_content
 class BaseTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.test_file_path = os.path.join(settings.BASE_DIR, 'examples', 'example1', 'test_annotation.txt')
+        self.test_file_path = os.path.join(
+            settings.BASE_DIR, 'examples', 'example1', 'test_annotation.txt')
 
     def test_get_file_content(self):
         test_file_content = get_file_content(self.test_file_path, 'rb')

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -169,7 +169,8 @@ class GetParticularChallenge(BaseAPITestClass):
     def setUp(self):
         super(GetParticularChallenge, self).setUp()
         self.url = reverse_lazy('challenges:get_challenge_detail',
-                                kwargs={'challenge_host_team_pk': self.challenge_host_team.pk,
+                                kwargs={
+                                    'challenge_host_team_pk': self.challenge_host_team.pk,
                                         'challenge_pk': self.challenge.pk})
 
     def test_get_particular_challenge(self):
@@ -212,9 +213,11 @@ class GetParticularChallenge(BaseAPITestClass):
 
         self.client.force_authenticate(user=self.user1)
 
-        expected = {"detail": "Sorry, you are not allowed to perform this operation!"}
+        expected = {
+            "detail": "Sorry, you are not allowed to perform this operation!"}
 
-        response = self.client.put(self.url, {'title': 'Rose Challenge', 'description': 'Version 2.0'})
+        response = self.client.put(
+            self.url, {'title': 'Rose Challenge', 'description': 'Version 2.0'})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -242,13 +245,15 @@ class GetParticularChallenge(BaseAPITestClass):
             "anonymous_leaderboard": self.challenge.anonymous_leaderboard,
             "is_active": True
         }
-        response = self.client.put(self.url, {'title': new_title, 'description': new_description})
+        response = self.client.put(
+            self.url, {'title': new_title, 'description': new_description})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_particular_challenge_does_not_exist(self):
         self.url = reverse_lazy('challenges:get_challenge_detail',
-                                kwargs={'challenge_host_team_pk': self.challenge_host_team.pk,
+                                kwargs={
+                                    'challenge_host_team_pk': self.challenge_host_team.pk,
                                         'challenge_pk': self.challenge.pk + 1})
         expected = {
             'error': 'Challenge does not exist'
@@ -259,7 +264,8 @@ class GetParticularChallenge(BaseAPITestClass):
 
     def test_particular_challenge_host_team_for_challenge_does_not_exist(self):
         self.url = reverse_lazy('challenges:get_challenge_detail',
-                                kwargs={'challenge_host_team_pk': self.challenge_host_team.pk + 1,
+                                kwargs={
+                                    'challenge_host_team_pk': self.challenge_host_team.pk + 1,
                                         'challenge_pk': self.challenge.pk})
         expected = {
             'error': 'ChallengeHostTeam does not exist'
@@ -274,7 +280,8 @@ class UpdateParticularChallenge(BaseAPITestClass):
     def setUp(self):
         super(UpdateParticularChallenge, self).setUp()
         self.url = reverse_lazy('challenges:get_challenge_detail',
-                                kwargs={'challenge_host_team_pk': self.challenge_host_team.pk,
+                                kwargs={
+                                    'challenge_host_team_pk': self.challenge_host_team.pk,
                                         'challenge_pk': self.challenge.pk})
 
         self.partial_update_challenge_title = 'Partial Update Test Challenge'
@@ -358,7 +365,8 @@ class DeleteParticularChallenge(BaseAPITestClass):
     def setUp(self):
         super(DeleteParticularChallenge, self).setUp()
         self.url = reverse_lazy('challenges:get_challenge_detail',
-                                kwargs={'challenge_host_team_pk': self.challenge_host_team.pk,
+                                kwargs={
+                                    'challenge_host_team_pk': self.challenge_host_team.pk,
                                         'challenge_pk': self.challenge.pk})
 
     def test_particular_challenge_delete(self):
@@ -931,7 +939,8 @@ class GetChallengeBasedOnTeams(BaseAPITestClass):
             "is_active": True
         }]
 
-        response = self.client.get(self.url, {'host_team': self.challenge_host_team2.pk})
+        response = self.client.get(
+            self.url, {'host_team': self.challenge_host_team2.pk})
         self.assertEqual(response.data['results'], expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -960,7 +969,8 @@ class GetChallengeBasedOnTeams(BaseAPITestClass):
             "is_active": True
         }]
 
-        response = self.client.get(self.url, {'participant_team': self.participant_team2.pk})
+        response = self.client.get(
+            self.url, {'participant_team': self.participant_team2.pk})
         self.assertEqual(response.data['results'], expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -1051,7 +1061,8 @@ class GetChallengeBasedOnTeams(BaseAPITestClass):
         expected = {
             'error': 'Invalid url pattern!'
         }
-        response = self.client.get(self.url, {'invalid_q_param': 'invalidvalue'})
+        response = self.client.get(
+            self.url, {'invalid_q_param': 'invalidvalue'})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
 
@@ -1061,9 +1072,10 @@ class GetChallengeBasedOnTeams(BaseAPITestClass):
         expected = {
             'error': 'Invalid url pattern!'
         }
-        response = self.client.get(self.url, {'host_team': self.challenge_host_team2.pk,
-                                              'participant_team': self.participant_team2.pk,
-                                              'mode': 'participant'})
+        response = self.client.get(
+            self.url, {'host_team': self.challenge_host_team2.pk,
+                       'participant_team': self.participant_team2.pk,
+                       'mode': 'participant'})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
 
@@ -1184,18 +1196,20 @@ class CreateChallengePhaseTest(BaseChallengePhaseClass):
 
     @override_settings(MEDIA_ROOT='/tmp/evalai')
     def test_create_challenge_phase_with_all_data(self):
-        self.data['test_annotation'] = SimpleUploadedFile('another_test_file.txt',
-                                                          'Another Dummy file content',
-                                                          content_type='text/plain')
+        self.data[
+            'test_annotation'] = SimpleUploadedFile('another_test_file.txt',
+                                                    'Another Dummy file content',
+                                                    content_type='text/plain')
         self.data['codename'] = "Test Code Name"
         response = self.client.post(self.url, self.data, format='multipart')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @override_settings(MEDIA_ROOT='/tmp/evalai')
     def test_create_challenge_phase_with_same_codename(self):
-        self.data['test_annotation'] = SimpleUploadedFile('another_test_file.txt',
-                                                          'Another Dummy file content',
-                                                          content_type='text/plain')
+        self.data[
+            'test_annotation'] = SimpleUploadedFile('another_test_file.txt',
+                                                    'Another Dummy file content',
+                                                    content_type='text/plain')
 
         expected = {
             'non_field_errors': ['The fields codename, challenge must make a unique set.']
@@ -1305,9 +1319,11 @@ class GetParticularChallengePhase(BaseChallengePhaseClass):
 
         self.client.force_authenticate(user=self.user1)
 
-        expected = {"detail": "Sorry, you are not allowed to perform this operation!"}
+        expected = {
+            "detail": "Sorry, you are not allowed to perform this operation!"}
 
-        response = self.client.put(self.url, {'name': 'Rose Phase', 'description': 'New description.'})
+        response = self.client.put(
+            self.url, {'name': 'Rose Phase', 'description': 'New description.'})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -1328,7 +1344,8 @@ class GetParticularChallengePhase(BaseChallengePhaseClass):
             "max_submissions_per_day": self.challenge_phase.max_submissions_per_day,
             "max_submissions": self.challenge_phase.max_submissions,
         }
-        response = self.client.put(self.url, {'name': new_name, 'description': new_description})
+        response = self.client.put(
+            self.url, {'name': new_name, 'description': new_description})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -1407,7 +1424,8 @@ class UpdateParticularChallengePhase(BaseChallengePhaseClass):
     @override_settings(MEDIA_ROOT='/tmp/evalai')
     def test_particular_challenge_phase_update(self):
 
-        self.update_test_annotation = SimpleUploadedFile('update_test_sample_file.txt',
+        self.update_test_annotation = SimpleUploadedFile(
+            'update_test_sample_file.txt',
                                                          'Dummy update file content', content_type='text/plain')
         self.data['test_annotation'] = self.update_test_annotation
         response = self.client.put(self.url, self.data, format='multipart')
@@ -1478,16 +1496,18 @@ class BaseChallengePhaseSplitClass(BaseAPITestClass):
                                                    'Dummy file content', content_type='text/plain')
             )
 
-        self.dataset_split = DatasetSplit.objects.create(name="Test Dataset Split", codename="test-split")
+        self.dataset_split = DatasetSplit.objects.create(
+            name="Test Dataset Split", codename="test-split")
 
-        self.leaderboard = Leaderboard.objects.create(schema=json.dumps({'hello': 'world'}))
+        self.leaderboard = Leaderboard.objects.create(
+            schema=json.dumps({'hello': 'world'}))
 
         self.challenge_phase_split = ChallengePhaseSplit.objects.create(
             dataset_split=self.dataset_split,
             challenge_phase=self.challenge_phase,
             leaderboard=self.leaderboard,
             visibility=ChallengePhaseSplit.PUBLIC
-            )
+        )
 
     def tearDown(self):
         shutil.rmtree('/tmp/evalai')
@@ -1550,15 +1570,24 @@ class CreateChallengeUsingZipFile(APITestCase):
             team_name='Test Challenge Host Team',
             created_by=self.user)
 
-        self.path = join(settings.BASE_DIR, 'examples', 'example1', 'test_zip_file')
+        self.path = join(
+            settings.BASE_DIR, 'examples', 'example1', 'test_zip_file')
 
         self.challenge = Challenge.objects.create(
             title='Challenge Title',
             short_description='Short description of the challenge (preferably 140 characters)',
-            description=open(join(self.path, 'description.html'), 'rb').read().decode('utf-8'),
-            terms_and_conditions=open(join(self.path, 'terms_and_conditions.html'), 'rb').read().decode('utf-8'),
-            submission_guidelines=open(join(self.path, 'submission_guidelines.html'), 'rb').read().decode('utf-8'),
-            evaluation_details=open(join(self.path, 'evaluation_details.html'), 'rb').read().decode('utf-8'),
+            description=open(
+                join(
+                    self.path, 'description.html'), 'rb').read().decode('utf-8'),
+            terms_and_conditions=open(
+                join(
+                    self.path, 'terms_and_conditions.html'), 'rb').read().decode('utf-8'),
+            submission_guidelines=open(
+                join(
+                    self.path, 'submission_guidelines.html'), 'rb').read().decode('utf-8'),
+            evaluation_details=open(
+                join(
+                    self.path, 'evaluation_details.html'), 'rb').read().decode('utf-8'),
             creator=self.challenge_host_team,
             published=False,
             enable_forum=True,
@@ -1570,17 +1599,23 @@ class CreateChallengeUsingZipFile(APITestCase):
         with self.settings(MEDIA_ROOT='/tmp/evalai'):
             self.challenge_phase = ChallengePhase.objects.create(
                 name='Challenge Phase',
-                description=open(join(self.path, 'challenge_phase_description.html'), 'rb').read().decode('utf-8'),
+                description=open(
+                    join(
+                        self.path, 'challenge_phase_description.html'), 'rb').read().decode('utf-8'),
                 leaderboard_public=False,
                 is_public=False,
                 start_date=timezone.now() - timedelta(days=2),
                 end_date=timezone.now() + timedelta(days=1),
                 challenge=self.challenge,
-                test_annotation=SimpleUploadedFile(open(join(self.path, 'test_annotation.txt'), 'rb').name,
-                                                   open(join(self.path, 'test_annotation.txt'), 'rb').read(),
+                test_annotation=SimpleUploadedFile(
+                    open(join(self.path, 'test_annotation.txt'), 'rb').name,
+                                                   open(
+                                                       join(
+                                                           self.path, 'test_annotation.txt'), 'rb').read(),
                                                    content_type='text/plain')
             )
-        self.dataset_split = DatasetSplit.objects.create(name="Name of the dataset split",
+        self.dataset_split = DatasetSplit.objects.create(
+            name="Name of the dataset split",
                                                          codename="codename of dataset split")
 
         self.leaderboard = Leaderboard.objects.create(schema=json.dumps({
@@ -1592,9 +1627,10 @@ class CreateChallengeUsingZipFile(APITestCase):
             challenge_phase=self.challenge_phase,
             leaderboard=self.leaderboard,
             visibility=ChallengePhaseSplit.PUBLIC
-            )
+        )
 
-        self.zip_file = open(join(settings.BASE_DIR, 'examples', 'example1', 'test_zip_file.zip'), 'rb')
+        self.zip_file = open(
+            join(settings.BASE_DIR, 'examples', 'example1', 'test_zip_file.zip'), 'rb')
 
         self.test_zip_file = SimpleUploadedFile(self.zip_file.name,
                                                 self.zip_file.read(),
@@ -1608,7 +1644,7 @@ class CreateChallengeUsingZipFile(APITestCase):
                                                  content_type='application/zip'),
             stdout_file=None,
             stderr_file=None
-            )
+        )
         self.client.force_authenticate(user=self.user)
 
         self.input_zip_file = SimpleUploadedFile('test_sample.zip',
@@ -1632,7 +1668,8 @@ class CreateChallengeUsingZipFile(APITestCase):
         expected = {
             'zip_configuration': ['The submitted data was not a file. Check the encoding type on the form.']
         }
-        response = self.client.post(self.url, {'zip_configuration': self.input_zip_file})
+        response = self.client.post(
+            self.url, {'zip_configuration': self.input_zip_file})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -1641,18 +1678,20 @@ class CreateChallengeUsingZipFile(APITestCase):
                                 kwargs={'challenge_host_team_pk': self.challenge_host_team.pk})
         expected = {
             'error': 'A server error occured while processing zip file. Please try uploading it again!'
-            }
-        response = self.client.post(self.url, {'zip_configuration': self.input_zip_file}, format='multipart')
+        }
+        response = self.client.post(
+            self.url, {'zip_configuration': self.input_zip_file}, format='multipart')
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
 
     def test_create_challenge_using_zip_file_when_challenge_host_team_does_not_exists(self):
         self.url = reverse_lazy('challenges:create_challenge_using_zip_file',
-                                kwargs={'challenge_host_team_pk': self.challenge_host_team.pk+10})
+                                kwargs={'challenge_host_team_pk': self.challenge_host_team.pk + 10})
         expected = {
-            'detail': 'ChallengeHostTeam {} does not exist'.format(self.challenge_host_team.pk+10)
+            'detail': 'ChallengeHostTeam {} does not exist'.format(self.challenge_host_team.pk + 10)
         }
-        response = self.client.post(self.url, {'zip_configuration': self.input_zip_file}, format='multipart')
+        response = self.client.post(
+            self.url, {'zip_configuration': self.input_zip_file}, format='multipart')
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -1846,10 +1885,11 @@ class GetAllSubmissionsTest(BaseAPITestClass):
 
     def test_get_all_submissions_when_challenge_does_not_exist(self):
         self.url = reverse_lazy('challenges:get_all_submissions_of_challenge',
-                                kwargs={'challenge_pk': self.challenge5.pk+10,
+                                kwargs={
+                                    'challenge_pk': self.challenge5.pk + 10,
                                         'challenge_phase_pk': self.challenge5_phase3.pk})
         expected = {
-            'detail': 'Challenge {} does not exist'.format(self.challenge5.pk+10)
+            'detail': 'Challenge {} does not exist'.format(self.challenge5.pk + 10)
         }
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
@@ -1858,20 +1898,24 @@ class GetAllSubmissionsTest(BaseAPITestClass):
     def test_get_all_submissions_when_challenge_phase_does_not_exist(self):
         self.url = reverse_lazy('challenges:get_all_submissions_of_challenge',
                                 kwargs={'challenge_pk': self.challenge5.pk,
-                                        'challenge_phase_pk': self.challenge5_phase3.pk+10})
+                                        'challenge_phase_pk': self.challenge5_phase3.pk + 10})
         expected = {
-            'error': 'Challenge Phase {} does not exist'.format(self.challenge5_phase3.pk+10)
+            'error': 'Challenge Phase {} does not exist'.format(self.challenge5_phase3.pk + 10)
         }
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_all_submissions_when_user_is_host_of_challenge(self):
-        self.url_phase1 = reverse_lazy('challenges:get_all_submissions_of_challenge',
-                                       kwargs={'challenge_pk': self.challenge5.pk,
+        self.url_phase1 = reverse_lazy(
+            'challenges:get_all_submissions_of_challenge',
+                                       kwargs={
+                                           'challenge_pk': self.challenge5.pk,
                                                'challenge_phase_pk': self.challenge5_phase1.pk})
-        self.url_phase2 = reverse_lazy('challenges:get_all_submissions_of_challenge',
-                                       kwargs={'challenge_pk': self.challenge5.pk,
+        self.url_phase2 = reverse_lazy(
+            'challenges:get_all_submissions_of_challenge',
+                                       kwargs={
+                                           'challenge_pk': self.challenge5.pk,
                                                'challenge_phase_pk': self.challenge5_phase2.pk})
         self.client.force_authenticate(user=self.user5)
         submissions = [self.submission3, self.submission2]
@@ -2028,11 +2072,11 @@ class DownloadAllSubmissionsFileTest(BaseAPITestClass):
 
     def test_download_all_submissions_when_challenge_does_not_exist(self):
         self.url = reverse_lazy('challenges:download_all_submissions',
-                                kwargs={'challenge_pk': self.challenge.pk+10,
+                                kwargs={'challenge_pk': self.challenge.pk + 10,
                                         'challenge_phase_pk': self.challenge_phase.pk,
                                         'file_type': self.file_type_csv})
         expected = {
-            'detail': 'Challenge {} does not exist'.format(self.challenge.pk+10)
+            'detail': 'Challenge {} does not exist'.format(self.challenge.pk + 10)
         }
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
@@ -2041,10 +2085,10 @@ class DownloadAllSubmissionsFileTest(BaseAPITestClass):
     def test_download_all_submissions_when_challenge_phase_does_not_exist(self):
         self.url = reverse_lazy('challenges:download_all_submissions',
                                 kwargs={'challenge_pk': self.challenge.pk,
-                                        'challenge_phase_pk': self.challenge_phase.pk+10,
+                                        'challenge_phase_pk': self.challenge_phase.pk + 10,
                                         'file_type': self.file_type_csv})
         expected = {
-            'error': 'Challenge Phase {} does not exist'.format(self.challenge_phase.pk+10)
+            'error': 'Challenge Phase {} does not exist'.format(self.challenge_phase.pk + 10)
         }
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
@@ -2105,7 +2149,7 @@ class CreateLeaderboardTest(BaseAPITestClass):
         self.data = [
             {'schema': {'key': 'value'}},
             {'schema': {'key2': 'value2'}}
-            ]
+        ]
 
     def test_create_leaderboard_with_all_data(self):
         self.url = reverse_lazy('challenges:create_leaderboard')
@@ -2131,13 +2175,13 @@ class GetOrUpdateLeaderboardTest(BaseAPITestClass):
                                 kwargs={'leaderboard_pk': self.leaderboard.pk})
         self.data = {
             'schema': {'key': 'updated schema'}
-            }
+        }
 
     def test_get_or_update_leaderboard_when_leaderboard_doesnt_exist(self):
         self.url = reverse_lazy('challenges:get_or_update_leaderboard',
-                                kwargs={'leaderboard_pk': self.leaderboard.pk+10})
+                                kwargs={'leaderboard_pk': self.leaderboard.pk + 10})
         expected = {
-            'detail': 'Leaderboard {} does not exist'.format(self.leaderboard.pk+10)
+            'detail': 'Leaderboard {} does not exist'.format(self.leaderboard.pk + 10)
         }
         response = self.client.patch(self.url, self.data)
         self.assertEqual(response.data, expected)
@@ -2197,7 +2241,8 @@ class GetOrUpdateDatasetSplitTest(BaseAPITestClass):
 
     def setUp(self):
         super(GetOrUpdateDatasetSplitTest, self).setUp()
-        self.dataset_split = DatasetSplit.objects.create(name="Name of the dataset split",
+        self.dataset_split = DatasetSplit.objects.create(
+            name="Name of the dataset split",
                                                          codename="codename of dataset split")
 
         self.url = reverse_lazy('challenges:get_or_update_dataset_split',
@@ -2205,13 +2250,13 @@ class GetOrUpdateDatasetSplitTest(BaseAPITestClass):
         self.data = {
             'name': 'Updated Name of dataset split',
             'codename': 'Updated codename of dataset split'
-            }
+        }
 
     def test_get_or_update_dataset_split_when_dataset_split_doesnt_exist(self):
         self.url = reverse_lazy('challenges:get_or_update_dataset_split',
-                                kwargs={'dataset_split_pk': self.dataset_split.pk+10})
+                                kwargs={'dataset_split_pk': self.dataset_split.pk + 10})
         expected = {
-            'detail': 'DatasetSplit {} does not exist'.format(self.dataset_split.pk+10)
+            'detail': 'DatasetSplit {} does not exist'.format(self.dataset_split.pk + 10)
         }
         response = self.client.patch(self.url, self.data)
         self.assertEqual(response.data, expected)
@@ -2258,7 +2303,7 @@ class CreateChallengePhaseSplitTest(BaseChallengePhaseSplitClass):
              "challenge_phase": self.challenge_phase.pk,
              "leaderboard": self.leaderboard.pk,
              "visibility": 3}
-            ]
+        ]
 
     def test_create_challenge_phase_split_with_all_data(self):
         self.url = reverse_lazy('challenges:create_challenge_phase_split')
@@ -2279,24 +2324,26 @@ class GetOrUpdateChallengePhaseSplitTest(BaseChallengePhaseSplitClass):
         self.url = reverse_lazy('challenges:get_or_update_dataset_split',
                                 kwargs={'challenge_phase_split_pk': self.challenge_phase_split.pk})
         self.leaderboard1 = Leaderboard.objects.create(schema=json.dumps({
-                                                      "labels": ["yes/no", "number", "others", "overall"],
+            "labels": ["yes/no", "number", "others", "overall"],
                                                       "default_order_by": "overall"}))
         self.data = {
             'leaderboard': self.leaderboard1.pk,
-            }
+        }
 
     def test_get_or_update_dataset_split_when_dataset_split_doesnt_exist(self):
-        self.url = reverse_lazy('challenges:get_or_update_challenge_phase_split',
-                                kwargs={'challenge_phase_split_pk': self.challenge_phase_split.pk+10})
+        self.url = reverse_lazy(
+            'challenges:get_or_update_challenge_phase_split',
+                                kwargs={'challenge_phase_split_pk': self.challenge_phase_split.pk + 10})
         expected = {
-            'detail': 'ChallengePhaseSplit {} does not exist'.format(self.challenge_phase_split.pk+10)
+            'detail': 'ChallengePhaseSplit {} does not exist'.format(self.challenge_phase_split.pk + 10)
         }
         response = self.client.patch(self.url, self.data)
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_dataset_split(self):
-        self.url = reverse_lazy('challenges:get_or_update_challenge_phase_split',
+        self.url = reverse_lazy(
+            'challenges:get_or_update_challenge_phase_split',
                                 kwargs={'challenge_phase_split_pk': self.challenge_phase_split.pk})
         expected = {
             'id': self.challenge_phase_split.pk,
@@ -2310,13 +2357,15 @@ class GetOrUpdateChallengePhaseSplitTest(BaseChallengePhaseSplitClass):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_update_challenge_phase_split_with_all_data(self):
-        self.url = reverse_lazy('challenges:get_or_update_challenge_phase_split',
+        self.url = reverse_lazy(
+            'challenges:get_or_update_challenge_phase_split',
                                 kwargs={'challenge_phase_split_pk': self.challenge_phase_split.pk})
         response = self.client.patch(self.url, self.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_update_dataset_split_with_no_data(self):
-        self.url = reverse_lazy('challenges:get_or_update_challenge_phase_split',
+        self.url = reverse_lazy(
+            'challenges:get_or_update_challenge_phase_split',
                                 kwargs={'challenge_phase_split_pk': self.challenge_phase_split.pk})
         del self.data['leaderboard']
         response = self.client.patch(self.url, self.data)
@@ -2324,6 +2373,7 @@ class GetOrUpdateChallengePhaseSplitTest(BaseChallengePhaseSplitClass):
 
 
 class StarChallengesTest(BaseAPITestClass):
+
     def setUp(self):
         super(StarChallengesTest, self).setUp()
         self.url = reverse_lazy('challenges:star_challenge',
@@ -2361,10 +2411,10 @@ class StarChallengesTest(BaseAPITestClass):
 
     def test_star_challenge_when_challenge_does_not_exist(self):
         self.url = reverse_lazy('challenges:star_challenge',
-                                kwargs={'challenge_pk': self.challenge.pk+10})
+                                kwargs={'challenge_pk': self.challenge.pk + 10})
 
         expected = {
-            'detail': 'Challenge {} does not exist'.format(self.challenge.pk+10)
+            'detail': 'Challenge {} does not exist'.format(self.challenge.pk + 10)
         }
         response = self.client.post(self.url, {})
         self.assertEqual(response.data, expected)

--- a/tests/unit/evalai/test_urls.py
+++ b/tests/unit/evalai/test_urls.py
@@ -16,7 +16,7 @@ class BaseAPITestClass(APITestCase):
             username='someuser',
             email="user@test.com",
             password='secret_password'
-            )
+        )
 
         self.client.force_authenticate(user=self.user)
 
@@ -28,10 +28,12 @@ class TestEvalAiUrls(BaseAPITestClass):
         self.assertEqual(url, '/api/auth/login')
 
         url = reverse_lazy('account_confirm_email', kwargs={'key': 1111})
-        self.assertEqual(url, '/api/auth/registration/account-confirm-email/1111/')
+        self.assertEqual(
+            url, '/api/auth/registration/account-confirm-email/1111/')
 
         url = reverse_lazy('password_reset_confirm',
-                           kwargs={'uidb64': urlsafe_base64_encode(force_bytes(self.user.pk)),
+                           kwargs={
+                               'uidb64': urlsafe_base64_encode(force_bytes(self.user.pk)),
                                    'token': default_token_generator.make_token(self.user)})
         self.assertEqual(url, '/auth/api/password/reset/confirm/' +
                          str(urlsafe_base64_encode(force_bytes(self.user.pk))) + '/' +

--- a/tests/unit/hosts/test_models.py
+++ b/tests/unit/hosts/test_models.py
@@ -11,17 +11,17 @@ class BaseTestCase(TestCase):
             username='user',
             email='user@test.com',
             password='password'
-            )
+        )
         self.challenge_host_team = ChallengeHostTeam.objects.create(
             team_name='Test Challenge Host Team',
             created_by=self.user
-            )
+        )
         self.challenge_host = ChallengeHost.objects.create(
             user=self.user,
             team_name=self.challenge_host_team,
             status=ChallengeHost.ACCEPTED,
             permissions=ChallengeHost.ADMIN
-            )
+        )
 
 
 class ChallengeHostTestCase(BaseTestCase):

--- a/tests/unit/hosts/test_urls.py
+++ b/tests/unit/hosts/test_urls.py
@@ -28,19 +28,23 @@ class BaseAPITestClass(APITestCase):
 
 
 class TestStringMethods(BaseAPITestClass):
+
     def test_host_urls(self):
         url = reverse_lazy('hosts:get_challenge_host_team_list')
         self.assertEqual(url, '/api/hosts/challenge_host_team/')
 
-        url = reverse_lazy('hosts:get_challenge_host_team_details', kwargs={'pk': self.challenge_host.pk})
-        self.assertEqual(url, '/api/hosts/challenge_host_team/' + str(self.challenge_host.pk))
+        url = reverse_lazy(
+            'hosts:get_challenge_host_team_details', kwargs={'pk': self.challenge_host.pk})
+        self.assertEqual(
+            url, '/api/hosts/challenge_host_team/' + str(self.challenge_host.pk))
 
         url = reverse_lazy('hosts:create_challenge_host_team')
         self.assertEqual(url, '/api/hosts/create_challenge_host_team')
 
         url = reverse_lazy('hosts:get_challenge_host_list',
                            kwargs={'challenge_host_team_pk': self.challenge_host_team.pk})
-        self.assertEqual(url, '/api/hosts/challenge_host_team/' + str(self.challenge_host_team.pk) + '/challenge_host')
+        self.assertEqual(url, '/api/hosts/challenge_host_team/' + str(
+            self.challenge_host_team.pk) + '/challenge_host')
 
         url = reverse_lazy('hosts:get_challenge_host_details',
                            kwargs={'challenge_host_team_pk': self.challenge_host_team.pk, 'pk': self.challenge_host.pk})
@@ -49,8 +53,10 @@ class TestStringMethods(BaseAPITestClass):
 
         url = reverse_lazy('hosts:remove_self_from_challenge_host_team',
                            kwargs={'challenge_host_team_pk': self.challenge_host_team.pk})
-        self.assertEqual(url, '/api/hosts/remove_self_from_challenge_host/' + str(self.challenge_host_team.pk))
+        self.assertEqual(
+            url, '/api/hosts/remove_self_from_challenge_host/' + str(self.challenge_host_team.pk))
 
         url = reverse_lazy('hosts:invite_host_to_team',
                            kwargs={'pk': self.challenge_host_team.pk})
-        self.assertEqual(url, '/api/hosts/challenge_host_teams/' + str(self.challenge_host_team.pk) + '/invite')
+        self.assertEqual(url, '/api/hosts/challenge_host_teams/' + str(
+            self.challenge_host_team.pk) + '/invite')

--- a/tests/unit/hosts/test_views.py
+++ b/tests/unit/hosts/test_views.py
@@ -133,7 +133,8 @@ class GetParticularChallengeHostTeam(BaseAPITestClass):
 
     def setUp(self):
         super(GetParticularChallengeHostTeam, self).setUp()
-        self.url = reverse_lazy('hosts:get_challenge_host_team_details', kwargs={'pk': self.challenge_host_team.pk})
+        self.url = reverse_lazy(
+            'hosts:get_challenge_host_team_details', kwargs={'pk': self.challenge_host_team.pk})
 
         self.user2 = User.objects.create(
             username='someuser2',
@@ -183,7 +184,8 @@ class UpdateParticularChallengeHostTeam(BaseAPITestClass):
 
     def setUp(self):
         super(UpdateParticularChallengeHostTeam, self).setUp()
-        self.url = reverse_lazy('hosts:get_challenge_host_team_details', kwargs={'pk': self.challenge_host_team.pk})
+        self.url = reverse_lazy(
+            'hosts:get_challenge_host_team_details', kwargs={'pk': self.challenge_host_team.pk})
         self.data = {
             'team_name': 'Test Team'
         }
@@ -224,7 +226,8 @@ class UpdateParticularChallengeHostTeam(BaseAPITestClass):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_particular_challenge_host_team_does_not_exist(self):
-        self.url = reverse_lazy('hosts:get_challenge_host_team_details', kwargs={'pk': self.challenge_host_team.pk + 1})
+        self.url = reverse_lazy(
+            'hosts:get_challenge_host_team_details', kwargs={'pk': self.challenge_host_team.pk + 1})
         expected = {
             'error': 'ChallengeHostTeam does not exist'
         }
@@ -237,7 +240,8 @@ class DeleteParticularChallengeHostTeam(BaseAPITestClass):
 
     def setUp(self):
         super(DeleteParticularChallengeHostTeam, self).setUp()
-        self.url = reverse_lazy('hosts:get_challenge_host_team_details', kwargs={'pk': self.challenge_host_team.pk})
+        self.url = reverse_lazy(
+            'hosts:get_challenge_host_team_details', kwargs={'pk': self.challenge_host_team.pk})
 
     def test_particular_challenge_host_team_delete(self):
         response = self.client.delete(self.url, {})
@@ -320,7 +324,8 @@ class GetParticularChallengeHost(BaseAPITestClass):
     def setUp(self):
         super(GetParticularChallengeHost, self).setUp()
         self.url = reverse_lazy('hosts:get_challenge_host_details',
-                                kwargs={'challenge_host_team_pk': self.challenge_host_team.pk,
+                                kwargs={
+                                    'challenge_host_team_pk': self.challenge_host_team.pk,
                                         'pk': self.challenge_host.pk})
 
     def test_get_particular_challenge_host(self):
@@ -337,7 +342,8 @@ class GetParticularChallengeHost(BaseAPITestClass):
 
     def test_particular_challenge_host_does_not_exist(self):
         self.url = reverse_lazy('hosts:get_challenge_host_details',
-                                kwargs={'challenge_host_team_pk': self.challenge_host_team.pk,
+                                kwargs={
+                                    'challenge_host_team_pk': self.challenge_host_team.pk,
                                         'pk': self.challenge_host.pk + 1})
         expected = {
             'error': 'ChallengeHost does not exist'
@@ -348,7 +354,8 @@ class GetParticularChallengeHost(BaseAPITestClass):
 
     def test_particular_challenge_host_team_for_challenge_host_does_not_exist(self):
         self.url = reverse_lazy('hosts:get_challenge_host_details',
-                                kwargs={'challenge_host_team_pk': self.challenge_host_team.pk + 1,
+                                kwargs={
+                                    'challenge_host_team_pk': self.challenge_host_team.pk + 1,
                                         'pk': self.challenge_host.pk})
         expected = {
             'error': 'ChallengeHostTeam does not exist'
@@ -363,7 +370,8 @@ class UpdateParticularChallengeHost(BaseAPITestClass):
     def setUp(self):
         super(UpdateParticularChallengeHost, self).setUp()
         self.url = reverse_lazy('hosts:get_challenge_host_details',
-                                kwargs={'challenge_host_team_pk': self.challenge_host_team.pk,
+                                kwargs={
+                                    'challenge_host_team_pk': self.challenge_host_team.pk,
                                         'pk': self.challenge_host.pk})
         self.data = {
             'status': ChallengeHost.SELF,
@@ -410,7 +418,8 @@ class DeleteParticularChallengeHost(BaseAPITestClass):
     def setUp(self):
         super(DeleteParticularChallengeHost, self).setUp()
         self.url = reverse_lazy('hosts:get_challenge_host_details',
-                                kwargs={'challenge_host_team_pk': self.challenge_host_team.pk,
+                                kwargs={
+                                    'challenge_host_team_pk': self.challenge_host_team.pk,
                                         'pk': self.challenge_host.pk})
 
     def test_particular_challenge_host_delete(self):
@@ -468,8 +477,9 @@ class RemoveChallengeHostFromTeamHimselfTest(BaseAPITestClass):
 
     def test_when_a_challenge_host_is_successfully_removed_from_team(self):
         self.url = reverse_lazy('hosts:remove_self_from_challenge_host_team',
-                                kwargs={'challenge_host_team_pk': self.challenge_host_team.pk,
-                                        })
+                                kwargs={
+                                    'challenge_host_team_pk': self.challenge_host_team.pk,
+                                })
         response = self.client.delete(self.url, {})
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 

--- a/tests/unit/jobs/test_models.py
+++ b/tests/unit/jobs/test_models.py
@@ -76,4 +76,5 @@ class SubmissionTestCase(BaseTestCase):
         )
 
     def test__str__(self):
-        self.assertEqual('{}'.format(self.submission.id), self.submission.__str__())
+        self.assertEqual(
+            '{}'.format(self.submission.id), self.submission.__str__())

--- a/tests/unit/jobs/test_urls.py
+++ b/tests/unit/jobs/test_urls.py
@@ -88,16 +88,18 @@ class BaseAPITestClass(APITestCase):
                                                    'Dummy file content', content_type='text/plain')
             )
 
-        self.dataset_split = DatasetSplit.objects.create(name="Test Dataset Split", codename="test-split")
+        self.dataset_split = DatasetSplit.objects.create(
+            name="Test Dataset Split", codename="test-split")
 
-        self.leaderboard = Leaderboard.objects.create(schema=json.dumps({'hello': 'world'}))
+        self.leaderboard = Leaderboard.objects.create(
+            schema=json.dumps({'hello': 'world'}))
 
         self.challenge_phase_split = ChallengePhaseSplit.objects.create(
             dataset_split=self.dataset_split,
             challenge_phase=self.challenge_phase,
             leaderboard=self.leaderboard,
             visibility=ChallengePhaseSplit.PUBLIC
-            )
+        )
 
         self.submission = Submission.objects.create(
             participant_team=self.participant_team,
@@ -130,7 +132,8 @@ class TestJobsUrls(BaseAPITestClass):
                                                                                           self.challenge_phase.pk,
                                                                                           self.submission.pk))
         resolver = resolve(self.url)
-        self.assertEqual(resolver.view_name, 'jobs:change_submission_data_and_visibility')
+        self.assertEqual(
+            resolver.view_name, 'jobs:change_submission_data_and_visibility')
 
     def test_challenge_submisson_url(self):
         self.url = reverse_lazy('jobs:challenge_submission',
@@ -146,8 +149,9 @@ class TestJobsUrls(BaseAPITestClass):
         self.url = reverse_lazy('jobs:get_remaining_submissions',
                                 kwargs={'challenge_pk': self.challenge.pk,
                                         'challenge_phase_pk': self.challenge_phase.pk})
-        self.assertEqual(self.url, '/api/jobs/{}/phases/{}/remaining_submissions'.format(self.challenge.pk,
-                                                                                         self.challenge_phase.pk))
+        self.assertEqual(
+            self.url, '/api/jobs/{}/phases/{}/remaining_submissions'.format(self.challenge.pk,
+                                                                            self.challenge_phase.pk))
         resolver = resolve(self.url)
         self.assertEqual(resolver.view_name, 'jobs:get_remaining_submissions')
 

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -379,7 +379,8 @@ class GetRemainingSubmissionTest(BaseAPITestClass):
     def setUp(self):
         super(GetRemainingSubmissionTest, self).setUp()
         self.url = reverse_lazy('jobs:get_remaining_submissions',
-                                kwargs={'challenge_phase_id': self.challenge_phase.pk,
+                                kwargs={
+                                    'challenge_phase_id': self.challenge_phase.pk,
                                         'challenge_id': self.challenge.pk})
 
         self.submission1 = Submission.objects.create(
@@ -410,11 +411,12 @@ class GetRemainingSubmissionTest(BaseAPITestClass):
 
     def test_get_remaining_submission_when_challenge_does_not_exist(self):
         self.url = reverse_lazy('jobs:get_remaining_submissions',
-                                kwargs={'challenge_phase_pk': self.challenge_phase.pk,
-                                        'challenge_pk': self.challenge.pk+1})
+                                kwargs={
+                                    'challenge_phase_pk': self.challenge_phase.pk,
+                                        'challenge_pk': self.challenge.pk + 1})
 
         expected = {
-            'detail': 'Challenge {} does not exist'.format(self.challenge.pk+1)
+            'detail': 'Challenge {} does not exist'.format(self.challenge.pk + 1)
         }
 
         response = self.client.get(self.url, {})
@@ -423,11 +425,12 @@ class GetRemainingSubmissionTest(BaseAPITestClass):
 
     def test_get_remaining_submission_when_challenge_phase_does_not_exist(self):
         self.url = reverse_lazy('jobs:get_remaining_submissions',
-                                kwargs={'challenge_phase_pk': self.challenge_phase.pk+1,
+                                kwargs={
+                                    'challenge_phase_pk': self.challenge_phase.pk + 1,
                                         'challenge_pk': self.challenge.pk})
 
         expected = {
-            'detail': 'ChallengePhase {} does not exist'.format(self.challenge_phase.pk+1)
+            'detail': 'ChallengePhase {} does not exist'.format(self.challenge_phase.pk + 1)
         }
 
         response = self.client.get(self.url, {})
@@ -436,7 +439,8 @@ class GetRemainingSubmissionTest(BaseAPITestClass):
 
     def test_get_remaining_submission_when_participant_team_hasnt_participated_in_challenge(self):
         self.url = reverse_lazy('jobs:get_remaining_submissions',
-                                kwargs={'challenge_phase_pk': self.challenge_phase.pk,
+                                kwargs={
+                                    'challenge_phase_pk': self.challenge_phase.pk,
                                         'challenge_pk': self.challenge.pk})
 
         expected = {
@@ -449,7 +453,8 @@ class GetRemainingSubmissionTest(BaseAPITestClass):
 
     def test_get_remaining_submission(self):
         self.url = reverse_lazy('jobs:get_remaining_submissions',
-                                kwargs={'challenge_phase_pk': self.challenge_phase.pk,
+                                kwargs={
+                                    'challenge_phase_pk': self.challenge_phase.pk,
                                         'challenge_pk': self.challenge.pk})
         expected = {
             'remaining_submissions_today_count': 99998,
@@ -464,7 +469,8 @@ class GetRemainingSubmissionTest(BaseAPITestClass):
 
     def test_get_remaining_submission_time_when_limit_is_exhausted(self):
         self.url = reverse_lazy('jobs:get_remaining_submissions',
-                                kwargs={'challenge_phase_pk': self.challenge_phase.pk,
+                                kwargs={
+                                    'challenge_phase_pk': self.challenge_phase.pk,
                                         'challenge_pk': self.challenge.pk})
         setattr(self.challenge_phase, 'max_submissions_per_day', 1)
         self.challenge_phase.save()
@@ -506,12 +512,12 @@ class ChangeSubmissionDataAndVisibilityTest(BaseAPITestClass):
 
     def test_change_submission_data_and_visibility_when_challenge_does_not_exist(self):
         self.url = reverse_lazy('jobs:change_submission_data_and_visibility',
-                                kwargs={'challenge_pk': self.challenge.pk+10,
+                                kwargs={'challenge_pk': self.challenge.pk + 10,
                                         'challenge_phase_pk': self.challenge_phase.pk,
                                         'submission_pk': self.submission.pk})
 
         expected = {
-            'detail': 'Challenge {} does not exist'.format(self.challenge.pk+10)
+            'detail': 'Challenge {} does not exist'.format(self.challenge.pk + 10)
         }
 
         response = self.client.patch(self.url, {})
@@ -521,11 +527,11 @@ class ChangeSubmissionDataAndVisibilityTest(BaseAPITestClass):
     def test_change_submission_data_and_visibility_when_challenge_phase_does_not_exist(self):
         self.url = reverse_lazy('jobs:change_submission_data_and_visibility',
                                 kwargs={'challenge_pk': self.challenge.pk,
-                                        'challenge_phase_pk': self.challenge_phase.pk+10,
+                                        'challenge_phase_pk': self.challenge_phase.pk + 10,
                                         'submission_pk': self.submission.pk})
 
         expected = {
-            'detail': 'ChallengePhase {} does not exist'.format(self.challenge_phase.pk+10)
+            'detail': 'ChallengePhase {} does not exist'.format(self.challenge_phase.pk + 10)
         }
 
         response = self.client.patch(self.url, {})
@@ -616,7 +622,7 @@ class ChangeSubmissionDataAndVisibilityTest(BaseAPITestClass):
             'method_name': 'Updated Method Name'
         }
         expected = {
-                'id': self.submission.id,
+            'id': self.submission.id,
                 'participant_team': self.submission.participant_team.pk,
                 'participant_team_name': self.submission.participant_team.team_name,
                 'execution_time': self.submission.execution_time,
@@ -635,7 +641,7 @@ class ChangeSubmissionDataAndVisibilityTest(BaseAPITestClass):
                 "is_public": self.submission.is_public,
                 "when_made_public": "{0}{1}".format(self.submission.when_made_public.isoformat(),
                                                     'Z').replace("+00:00", ""),
-            }
+        }
         self.challenge.participant_teams.add(self.participant_team)
         response = self.client.patch(self.url, self.data)
         self.assertEqual(response.data, expected)
@@ -662,7 +668,7 @@ class ChangeSubmissionDataAndVisibilityTest(BaseAPITestClass):
             'is_public': False
         }
         expected = {
-                'id': self.submission.id,
+            'id': self.submission.id,
                 'participant_team': self.submission.participant_team.pk,
                 'participant_team_name': self.submission.participant_team.team_name,
                 'execution_time': self.submission.execution_time,
@@ -681,7 +687,7 @@ class ChangeSubmissionDataAndVisibilityTest(BaseAPITestClass):
                 "is_public": self.submission.is_public,
                 "when_made_public": "{0}{1}".format(self.submission.when_made_public.isoformat(), 'Z')
                                     .replace("+00:00", ""),
-            }
+        }
         self.challenge.participant_teams.add(self.participant_team)
         response = self.client.patch(self.url, self.data)
         self.assertEqual(response.data, expected)

--- a/tests/unit/participants/test_models.py
+++ b/tests/unit/participants/test_models.py
@@ -11,7 +11,7 @@ class BaseTestCase(TestCase):
             username='user',
             email='user@test.com',
             password='password'
-            )
+        )
         self.participant_team = ParticipantTeam.objects.create(
             team_name='Participant Team',
             created_by=self.user)

--- a/tests/unit/participants/test_urls.py
+++ b/tests/unit/participants/test_urls.py
@@ -98,7 +98,8 @@ class TestStringMethods(BaseAPITestClass):
 
     def test_delete_participant_from_team_url(self):
         self.url = reverse_lazy('participants:delete_participant_from_team',
-                                kwargs={'participant_team_pk': self.participant_team.pk,
+                                kwargs={
+                                    'participant_team_pk': self.participant_team.pk,
                                         'participant_pk': self.invite_user.pk})
         self.assertEqual(unicode(self.url), '/api/participants/participant_team/%s/participant/%s' %
                          (self.participant_team.pk, self.invite_user.pk))
@@ -117,7 +118,8 @@ class TestStringMethods(BaseAPITestClass):
             resolver.view_name, 'participants:get_teams_and_corresponding_challenges_for_a_participant')
 
     def test_remove_self_from_participant_team_url(self):
-        self.url = reverse_lazy('participants:remove_self_from_participant_team',
+        self.url = reverse_lazy(
+            'participants:remove_self_from_participant_team',
                                 kwargs={'participant_team_pk': self.participant_team.pk})
         self.assertEqual(unicode(
             self.url), '/api/participants/remove_self_from_participant_team/%s' % (self.participant_team.pk))

--- a/tests/unit/participants/test_views.py
+++ b/tests/unit/participants/test_views.py
@@ -411,15 +411,17 @@ class DeleteParticipantFromTeamTest(BaseAPITestClass):
             team=self.participant_team)
 
         self.url = reverse_lazy('participants:delete_participant_from_team',
-                                kwargs={'participant_team_pk': self.participant_team.pk,
+                                kwargs={
+                                    'participant_team_pk': self.participant_team.pk,
                                         'participant_pk': self.invite_user.pk
-                                        })
+                                })
 
     def test_participant_does_not_exist_in_team(self):
         self.url = reverse_lazy('participants:delete_participant_from_team',
-                                kwargs={'participant_team_pk': self.participant_team.pk,
+                                kwargs={
+                                    'participant_team_pk': self.participant_team.pk,
                                         'participant_pk': self.participant2.pk + 1
-                                        })
+                                })
 
         expected = {
             'error': 'Participant does not exist'
@@ -431,9 +433,10 @@ class DeleteParticipantFromTeamTest(BaseAPITestClass):
 
     def test_when_participant_team_does_not_exist(self):
         self.url = reverse_lazy('participants:delete_participant_from_team',
-                                kwargs={'participant_team_pk': self.participant_team.pk + 1,
+                                kwargs={
+                                    'participant_team_pk': self.participant_team.pk + 1,
                                         'participant_pk': self.participant2.pk
-                                        })
+                                })
 
         expected = {
             'error': 'ParticipantTeam does not exist'
@@ -445,9 +448,10 @@ class DeleteParticipantFromTeamTest(BaseAPITestClass):
 
     def test_when_participant_is_admin_and_wants_to_delete_himself(self):
         self.url = reverse_lazy('participants:delete_participant_from_team',
-                                kwargs={'participant_team_pk': self.participant_team.pk,
+                                kwargs={
+                                    'participant_team_pk': self.participant_team.pk,
                                         'participant_pk': self.participant1.pk
-                                        })
+                                })
 
         expected = {
             'error': 'You are not allowed to remove yourself since you are admin. Please delete the team if you want to do so!'  # noqa: ignore=E501
@@ -459,9 +463,10 @@ class DeleteParticipantFromTeamTest(BaseAPITestClass):
 
     def test_when_participant_does_not_have_permissions_to_remove_another_participant(self):
         self.url = reverse_lazy('participants:delete_participant_from_team',
-                                kwargs={'participant_team_pk': self.participant_team.pk,
+                                kwargs={
+                                    'participant_team_pk': self.participant_team.pk,
                                         'participant_pk': self.participant2.pk
-                                        })
+                                })
 
         self.user3 = User.objects.create(
             username='user3',
@@ -491,9 +496,10 @@ class DeleteParticipantFromTeamTest(BaseAPITestClass):
 
     def test_when_a_participant_is_successfully_removed_from_team(self):
         self.url = reverse_lazy('participants:delete_participant_from_team',
-                                kwargs={'participant_team_pk': self.participant_team.pk,
+                                kwargs={
+                                    'participant_team_pk': self.participant_team.pk,
                                         'participant_pk': self.participant2.pk
-                                        })
+                                })
         response = self.client.delete(self.url, {})
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
@@ -562,7 +568,7 @@ class GetTeamsAndCorrespondingChallengesForAParticipant(BaseAPITestClass):
             anonymous_leaderboard=False,
             start_date=timezone.now() - timedelta(days=2),
             end_date=timezone.now() + timedelta(days=1),
-            )
+        )
 
         self.url = reverse_lazy(
             'participants:get_teams_and_corresponding_challenges_for_a_participant',
@@ -588,13 +594,15 @@ class GetTeamsAndCorrespondingChallengesForAParticipant(BaseAPITestClass):
                         "evaluation_details": self.challenge1.evaluation_details,
                         "image": self.challenge1.image,
                         "start_date":
-                            "{0}{1}".format(self.challenge1.start_date.isoformat(), 'Z').replace("+00:00", ""),
+                            "{0}{1}".format(
+                                self.challenge1.start_date.isoformat(
+                                ), 'Z').replace("+00:00", ""),
                         "end_date": "{0}{1}".format(self.challenge1.end_date.isoformat(), 'Z').replace("+00:00", ""),
                         "creator": {
                             "id": self.challenge_host_team.id,
                             "team_name": self.challenge_host_team.team_name,
                             "created_by": self.challenge_host_team.created_by.username
-                            },
+                        },
                         "published": self.challenge1.published,
                         "enable_forum": self.challenge1.enable_forum,
                         "anonymous_leaderboard": self.challenge1.anonymous_leaderboard,
@@ -610,9 +618,12 @@ class GetTeamsAndCorrespondingChallengesForAParticipant(BaseAPITestClass):
             "is_challenge_host": False
         }
         response = self.client.get(self.url, {})
-        # checking 'datetime_now' separately because of time difference in microseconds
-        self.assertTrue(abs(response.data['datetime_now'] - self.time) < timedelta(seconds=1))
-        # deleting field 'datetime_now' from response to check with expected response without time field
+        # checking 'datetime_now' separately because of time difference in
+        # microseconds
+        self.assertTrue(
+            abs(response.data['datetime_now'] - self.time) < timedelta(seconds=1))
+        # deleting field 'datetime_now' from response to check with expected
+        # response without time field
         del response.data['datetime_now']
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -633,9 +644,12 @@ class GetTeamsAndCorrespondingChallengesForAParticipant(BaseAPITestClass):
             "is_challenge_host": False
         }
         response = self.client.get(self.url, {})
-        # checking 'datetime_now' separately because of time difference in microseconds
-        self.assertTrue(abs(response.data['datetime_now'] - self.time) < timedelta(seconds=1))
-        # deleting field 'datetime_now' from response to check with expected response without time field
+        # checking 'datetime_now' separately because of time difference in
+        # microseconds
+        self.assertTrue(
+            abs(response.data['datetime_now'] - self.time) < timedelta(seconds=1))
+        # deleting field 'datetime_now' from response to check with expected
+        # response without time field
         del response.data['datetime_now']
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -650,9 +664,12 @@ class GetTeamsAndCorrespondingChallengesForAParticipant(BaseAPITestClass):
         }
 
         response = self.client.get(self.url, {})
-        # checking 'datetime_now' separately because of time difference in microseconds
-        self.assertTrue(abs(response.data['datetime_now'] - self.time) < timedelta(seconds=1))
-        # deleting field 'datetime_now' from response to check with expected response without time field
+        # checking 'datetime_now' separately because of time difference in
+        # microseconds
+        self.assertTrue(
+            abs(response.data['datetime_now'] - self.time) < timedelta(seconds=1))
+        # deleting field 'datetime_now' from response to check with expected
+        # response without time field
         del response.data['datetime_now']
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -697,12 +714,14 @@ class RemoveSelfFromParticipantTeamTest(BaseAPITestClass):
             end_date=timezone.now() + timedelta(days=1),
         )
 
-        self.url = reverse_lazy('participants:remove_self_from_participant_team',
+        self.url = reverse_lazy(
+            'participants:remove_self_from_participant_team',
                                 kwargs={'participant_team_pk': self.participant_team.pk
                                         })
 
     def test_when_participant_team_does_not_exist(self):
-        self.url = reverse_lazy('participants:remove_self_from_participant_team',
+        self.url = reverse_lazy(
+            'participants:remove_self_from_participant_team',
                                 kwargs={'participant_team_pk': self.participant_team.pk + 1
                                         })
 
@@ -715,9 +734,11 @@ class RemoveSelfFromParticipantTeamTest(BaseAPITestClass):
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
 
     def test_when_a_participant_is_successfully_removed_from_team(self):
-        self.url = reverse_lazy('participants:remove_self_from_participant_team',
-                                kwargs={'participant_team_pk': self.participant_team.pk,
-                                        })
+        self.url = reverse_lazy(
+            'participants:remove_self_from_participant_team',
+                                kwargs={
+                                    'participant_team_pk': self.participant_team.pk,
+                                })
         response = self.client.delete(self.url, {})
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 

--- a/tests/unit/web/test_models.py
+++ b/tests/unit/web/test_models.py
@@ -12,7 +12,7 @@ class ContactTestCase(TestCase):
             name='user',
             email='user@domain.com',
             message='test message',
-            )
+        )
 
     def test__str__(self):
         name = self.contact.name

--- a/tests/unit/web/test_views.py
+++ b/tests/unit/web/test_views.py
@@ -56,7 +56,8 @@ class CreateContactMessage(BaseAPITestCase):
     def test_create_contact_message_with_all_data(self):
         if self.data['message']:
             response = self.client.post(self.url, self.data)
-            expected = {'message': 'We have received your request and will contact you shortly.'}
+            expected = {
+                'message': 'We have received your request and will contact you shortly.'}
             self.assertEqual(response.data, expected)
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -67,6 +68,7 @@ class CreateContactMessage(BaseAPITestCase):
 
 
 class CreateTeamMember(APITestCase):
+
     def setUp(self):
         self.url = reverse_lazy('web:our_team')
         self.data = {
@@ -114,6 +116,7 @@ class CreateTeamMember(APITestCase):
 
 
 class GetTeamTest(APITestCase):
+
     def setUp(self):
         self.url = reverse_lazy('web:our_team')
         self.team = Team.objects.create(


### PR DESCRIPTION
Fix #1547: 
Leaderboard table can be sorted column-wise in ascending or descending order.

Examples: 
sort by score2 in decreasing order
![0](https://user-images.githubusercontent.com/8584694/37255530-15aa8cce-254e-11e8-8c99-aaff16f1f8bc.png)

sort by submission date in increasing order (from earliest to latest)
![1](https://user-images.githubusercontent.com/8584694/37255540-3c024966-254e-11e8-964f-c1486167d28f.png)

**Note**: several files have been changed after running autopep8. The real changes are in files frontend/src/js/controllers/challengeCtrl.js and frontend/src/views/web/challenge/leaderboard.html

