### PR TITLE
Update challenge data extraction condition

### DIFF
--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -216,7 +216,7 @@ def load_active_challenges():
     '''
          * Fetches active challenges and corresponding active phases for it.
     '''
-    q_params = {'published': True, 'approved_by_admin': True}
+    q_params = {'approved_by_admin': True}
     q_params['start_date__lt'] = timezone.now()
     q_params['end_date__gt'] = timezone.now()
 


### PR DESCRIPTION
Since we have the feature for the challenge hosts to try out submissions to a particular challenge even when the challenge is not published, so we have to remove the filter by `published=True`
