### PR TITLE
Allow submissions from challenge hosts to be evaluated

### DIFF
--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -269,12 +269,6 @@ def run_submission(challenge_id, challenge_phase, submission, user_annotation_fi
         * calls evaluation script via subprocess passing annotation file and user_annotation_file_path as argument
     '''
 
-    # If submission are from the Challenge Host and
-    # the challenge is published ignore the submissions.
-    challenge = Challenge.objects.get(id=challenge_id)
-    challenge_creator_id = challenge.creator.created_by.id
-    submission_creator_id = submission.participant_team.created_by.id
-
     # Use the submission serializer to send relevant data to evaluation script
     # so that challenge hosts can use data for webhooks or any other service.
     submission_serializer = SubmissionSerializer(submission)

--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -275,10 +275,6 @@ def run_submission(challenge_id, challenge_phase, submission, user_annotation_fi
     challenge_creator_id = challenge.creator.created_by.id
     submission_creator_id = submission.participant_team.created_by.id
 
-    if (challenge_creator_id == submission_creator_id) and challenge.published:
-        logger.info("[x] Challenge host submission, ignored.")
-        return
-
     # Use the submission serializer to send relevant data to evaluation script
     # so that challenge hosts can use data for webhooks or any other service.
     submission_serializer = SubmissionSerializer(submission)


### PR DESCRIPTION
Currently, the submissions done by challenge hosts are ignored but we want to evaluate them and not show on the leaderboard. Hence, this PR allows the submissions from the challenge hosts to get evaluated but will not go on the leaderboard. 