### PR TITLE
Settings: Allow all hostnames to request files in dev env

### DIFF
--- a/settings/dev.py
+++ b/settings/dev.py
@@ -5,6 +5,8 @@ from .common import *  # noqa: ignore=F405
 
 DEBUG = True
 
+ALLOWED_HOSTS = ["*"]
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',


### PR DESCRIPTION
## Current Scenario 

While creating a challenge using docker in dev environment, django server throws 400 BAD REQUEST as the response code when worker tries to fetch challenge related files and throws the following error:

```
Traceback (most recent call last):
  File "scripts/workers/submission_worker.py", line 303, in run_submission
    submission_output = EVALUATION_SCRIPTS[challenge_id].evaluate(
AttributeError: 'module' object has no attribute 'evaluate'
```

This PR fixes the above mentioned error. Thanks @abhiskk for mentioning this issue. Please feel free to comment if you still face the issue after this merge. 