### PR TITLE
Restrict API to give results for only participant team

### DIFF
--- a/apps/analytics/serializers.py
+++ b/apps/analytics/serializers.py
@@ -3,15 +3,13 @@ from rest_framework import serializers
 
 class ChallengePhaseSubmissionCount(object):
 
-    def __init__(self, submission_count, participant_team_count, challenge_phase_pk):
-        self.submission_count = submission_count
-        self.participant_team_count = participant_team_count
+    def __init__(self, participant_team_submission_count, challenge_phase_pk):
+        self.participant_team_submission_count = participant_team_submission_count
         self.challenge_phase = challenge_phase_pk
 
 
 class ChallengePhaseSubmissionCountSerializer(serializers.Serializer):
-    submission_count = serializers.IntegerField()
-    participant_team_count = serializers.IntegerField()
+    participant_team_submission_count = serializers.IntegerField()
     challenge_phase = serializers.IntegerField()
 
 

--- a/apps/analytics/urls.py
+++ b/apps/analytics/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
     url(r'^challenge/(?P<challenge_pk>[0-9]+)/submission/(?P<duration>[A-Za-z]+)/count$',
         views.get_submission_count, name='get_submission_count'),
     url(r'^challenge/(?P<challenge_pk>[0-9]+)/challenge_phase/(?P<challenge_phase_pk>[0-9]+)/count$',
-        views.get_challenge_phase_submission_analysis, name='get_challenge_phase_submission_analysis'),
+        views.get_challenge_phase_submission_count_by_team, name='get_challenge_phase_submission_count_by_team'),
     url(r'^challenge/(?P<challenge_pk>[0-9]+)/challenge_phase/'
         r'(?P<challenge_phase_pk>[0-9]+)/last_submission/(?P<submission_by>[A-Za-z_]+)$',
         views.get_last_submission_time, name='get_last_submission_time'),

--- a/apps/analytics/views.py
+++ b/apps/analytics/views.py
@@ -108,11 +108,9 @@ def get_submission_count(request, challenge_pk, duration):
 @api_view(['GET', ])
 @permission_classes((permissions.IsAuthenticated, HasVerifiedEmail, IsChallengeCreator))
 @authentication_classes((ExpiringTokenAuthentication,))
-def get_challenge_phase_submission_analysis(request, challenge_pk, challenge_phase_pk):
+def get_challenge_phase_submission_count_by_team(request, challenge_pk, challenge_phase_pk):
     """
-    API to fetch
-    1. The submissions count for challenge phase.
-    2. The participated team count for challenge phase.
+    API to fetch the submissions count in a challenge phase for a participant team.
     """
     challenge = get_challenge_model(challenge_pk)
 
@@ -122,14 +120,10 @@ def get_challenge_phase_submission_analysis(request, challenge_pk, challenge_pha
 
     submissions = Submission.objects.filter(
         challenge_phase=challenge_phase, challenge_phase__challenge=challenge, participant_team=participant_team)
-    submission_count = submissions.count()
-    submissions = Submission.objects.filter(
-        challenge_phase=challenge_phase, challenge_phase__challenge=challenge)
-    participant_team_count = submissions.values_list(
-        'participant_team', flat=True).distinct().count()
+    participant_team_submission_count = submissions.count()
 
     challenge_phase_submission_count = ChallengePhaseSubmissionCount(
-        submission_count, participant_team_count, challenge_phase.pk)
+        participant_team_submission_count, challenge_phase.pk)
     try:
         serializer = ChallengePhaseSubmissionCountSerializer(challenge_phase_submission_count)
         response_data = serializer.data

--- a/apps/analytics/views.py
+++ b/apps/analytics/views.py
@@ -110,7 +110,7 @@ def get_submission_count(request, challenge_pk, duration):
 @authentication_classes((ExpiringTokenAuthentication,))
 def get_challenge_phase_submission_count_by_team(request, challenge_pk, challenge_phase_pk):
     """
-    API to fetch the submissions count in a challenge phase for a participant team.
+    Returns number of submissions done by a participant team in a challenge phase
     """
     challenge = get_challenge_model(challenge_pk)
 
@@ -120,10 +120,10 @@ def get_challenge_phase_submission_count_by_team(request, challenge_pk, challeng
 
     submissions = Submission.objects.filter(
         challenge_phase=challenge_phase, challenge_phase__challenge=challenge, participant_team=participant_team)
-    participant_team_submission_count = submissions.count()
+    participant_team_submissions = submissions.count()
 
     challenge_phase_submission_count = ChallengePhaseSubmissionCount(
-        participant_team_submission_count, challenge_phase.pk)
+        participant_team_submissions, challenge_phase.pk)
     try:
         serializer = ChallengePhaseSubmissionCountSerializer(challenge_phase_submission_count)
         response_data = serializer.data

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -553,7 +553,7 @@
             parameters.callback = {
                 onSuccess: function(response) {
                     var details = response.data;
-                    vm.submissionCount = details.submission_count;
+                    vm.submissionCount = details.participant_team_submission_count;
                 },
                 onError: function(response) {
                     var error = response.data;

--- a/tests/unit/analytics/test_views.py
+++ b/tests/unit/analytics/test_views.py
@@ -345,10 +345,10 @@ class GetSubmissionCountForChallengeTest(BaseAPITestClass):
         self.assertEqual(response.data, expected)
 
 
-class ChallengePhaseSubmissionAnalysisTest(BaseAPITestClass):
+class ChallengePhaseSubmissionCountByTeamTest(BaseAPITestClass):
 
     def setUp(self):
-        super(ChallengePhaseSubmissionAnalysisTest, self).setUp()
+        super(ChallengePhaseSubmissionCountByTeamTest, self).setUp()
         self.url = reverse_lazy('analytics:get_challenge_phase_submission_count_by_team',
                                 kwargs={'challenge_pk': self.challenge.pk,
                                         'challenge_phase_pk': self.challenge_phase.pk})

--- a/tests/unit/analytics/test_views.py
+++ b/tests/unit/analytics/test_views.py
@@ -438,7 +438,7 @@ class ChallengePhaseSubmissionCountByTeamTest(BaseAPITestClass):
                                         'challenge_phase_pk': self.challenge_phase.pk})
 
         expected = {
-                "participant_team_submission_count": 3,
+                "participant_team_submission_count": self.participant_team.submissions.count(),
                 "challenge_phase": self.challenge_phase.pk
             }
         self.client.force_authenticate(user=self.user2)
@@ -455,7 +455,7 @@ class ChallengePhaseSubmissionCountByTeamTest(BaseAPITestClass):
                                         'challenge_phase_pk': self.challenge_phase.pk})
 
         expected = {
-                "participant_team_submission_count": 1,
+                "participant_team_submission_count": self.participant_team3.submissions.count(),
                 "challenge_phase": self.challenge_phase.pk
             }
         self.client.force_authenticate(user=self.user3)

--- a/tests/unit/analytics/test_views.py
+++ b/tests/unit/analytics/test_views.py
@@ -349,7 +349,7 @@ class ChallengePhaseSubmissionAnalysisTest(BaseAPITestClass):
 
     def setUp(self):
         super(ChallengePhaseSubmissionAnalysisTest, self).setUp()
-        self.url = reverse_lazy('analytics:get_challenge_phase_submission_analysis',
+        self.url = reverse_lazy('analytics:get_challenge_phase_submission_count_by_team',
                                 kwargs={'challenge_pk': self.challenge.pk,
                                         'challenge_phase_pk': self.challenge_phase.pk})
 
@@ -405,8 +405,8 @@ class ChallengePhaseSubmissionAnalysisTest(BaseAPITestClass):
             is_public=True,
         )
 
-    def test_get_challenge_phase_submission_analysis_when_challenge_does_not_exist(self):
-        self.url = reverse_lazy('analytics:get_challenge_phase_submission_analysis',
+    def test_get_challenge_phase_submission_count_by_team_when_challenge_does_not_exist(self):
+        self.url = reverse_lazy('analytics:get_challenge_phase_submission_count_by_team',
                                 kwargs={'challenge_pk': self.challenge.pk+10,
                                         'challenge_phase_pk': self.challenge_phase.pk})
 
@@ -417,8 +417,8 @@ class ChallengePhaseSubmissionAnalysisTest(BaseAPITestClass):
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_get_challenge_phase_submission_analysis_when_challenge_phase_does_not_exist(self):
-        self.url = reverse_lazy('analytics:get_challenge_phase_submission_analysis',
+    def test_get_challenge_phase_submission_count_by_team_when_challenge_phase_does_not_exist(self):
+        self.url = reverse_lazy('analytics:get_challenge_phase_submission_count_by_team',
                                 kwargs={'challenge_pk': self.challenge.pk,
                                         'challenge_phase_pk': self.challenge_phase.pk+10})
 
@@ -429,17 +429,16 @@ class ChallengePhaseSubmissionAnalysisTest(BaseAPITestClass):
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_get_challenge_phase_submission_analysis_for_participant_team_1(self):
+    def test_get_challenge_phase_submission_count_by_team_for_participant_team_1(self):
         self.challenge.participant_teams.add(self.participant_team)
         self.challenge.participant_teams.add(self.participant_team3)
 
-        self.url = reverse_lazy('analytics:get_challenge_phase_submission_analysis',
+        self.url = reverse_lazy('analytics:get_challenge_phase_submission_count_by_team',
                                 kwargs={'challenge_pk': self.challenge.pk,
                                         'challenge_phase_pk': self.challenge_phase.pk})
 
         expected = {
-                "submission_count": 3,
-                "participant_team_count": 2,
+                "participant_team_submission_count": 3,
                 "challenge_phase": self.challenge_phase.pk
             }
         self.client.force_authenticate(user=self.user2)
@@ -447,17 +446,16 @@ class ChallengePhaseSubmissionAnalysisTest(BaseAPITestClass):
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_get_challenge_phase_submission_analysis_for_participant_team_3(self):
+    def test_get_challenge_phase_submission_count_by_team_for_participant_team_3(self):
         self.challenge.participant_teams.add(self.participant_team)
         self.challenge.participant_teams.add(self.participant_team3)
 
-        self.url = reverse_lazy('analytics:get_challenge_phase_submission_analysis',
+        self.url = reverse_lazy('analytics:get_challenge_phase_submission_count_by_team',
                                 kwargs={'challenge_pk': self.challenge.pk,
                                         'challenge_phase_pk': self.challenge_phase.pk})
 
         expected = {
-                "submission_count": 1,
-                "participant_team_count": 2,
+                "participant_team_submission_count": 1,
                 "challenge_phase": self.challenge_phase.pk
             }
         self.client.force_authenticate(user=self.user3)


### PR DESCRIPTION
This PR will restrict the `get_challenge_phase_submission_count_by_team` function to give the results for a participant team only.

@deshraj Please review the PR.