### PR TITLE
Add dist clean task & specific runserver task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,7 @@ var styles = JSON.parse(fs.readFileSync('frontend/app.styles.json'));
 var configJson = JSON.parse(fs.readFileSync('frontend/src/js/config.json'));
 
 function clean() {
-    return del(['frontend/dist/']);
+    return del(['frontend/dist/*']);
 };
 
 /*
@@ -319,9 +319,12 @@ gulp.task('dev', gulp.series(clean, function(done) {
     done();
 }, parallelTasks, configDev, injectpaths, lint));
 
-gulp.task('dev:runserver', gulp.series(function(done) {
+gulp.task('dev:runserver', gulp.series(clean ,function(done) {
     production = false;
     done();
 }, parallelTasks, configDev, injectpaths, lint, gulp.parallel(watch, startServer)));
 
-
+gulp.task('runserver', gulp.series(function(done) {
+    production = false;
+    done();
+}, gulp.parallel(watch, startServer)));


### PR DESCRIPTION
@deshraj @spyshiv Please review the PR.

**Description:** This PR is a fix to the error mentioned [here](https://github.com/Cloud-CV/EvalAI/pull/1757#issuecomment-410528426).

**Issue:** The files are being duplicated in the `dist` folder due to the absence of the `clean` task in the `gulp dev:runserver` task.

**Fix:** Added a clean task for clearing the files & generating new compressed file everytime one builds a dev or staging or prod server.
I have also added a task `runserver` which can be useful when we compress the files locally and then running the server. The commands should have the order:
1. gulp staging
2. gulp runserver
