### PR TITLE
Fixes #1714 disables dialog box's submit button when team name is not changed

### DIFF
--- a/frontend/src/js/controllers/teamsCtrl.js
+++ b/frontend/src/js/controllers/teamsCtrl.js
@@ -385,7 +385,7 @@
                 scope: $scope,
                 preserveScope: true,
                 targetEvent: ev,
-                templateUrl: 'dist/views/web/edit-teams.html'
+                templateUrl: 'dist/views/web/edit_teams.html'
             });
         };
 

--- a/frontend/src/views/web/edit_teams.html
+++ b/frontend/src/views/web/edit_teams.html
@@ -14,7 +14,7 @@
                     </div>
                     <ul class="inline-list pointer">
                         <li><a class="dark-link" type="button" ng-click="teams.updateParticipantTeamData(false)"><strong>Cancel </strong></a></li>
-                        <li><button class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-14" type="submit" value="Submit">Submit </button></li>
+                        <li><button class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-14" ng-disabled="!updateParticipantTeamDataForm.$dirty" type="submit" value="Submit">Submit </button></li>
                     </ul>
                 </form>
             </div>


### PR DESCRIPTION
Fixes https://github.com/Cloud-CV/EvalAI/issues/1714
Disables the submit button of dialog box change team name when no new team name is entered.