### PR TITLE
Submission Worker: Add exception handling if there is a syntax error

### DIFF
--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -211,9 +211,13 @@ def extract_challenge_data(challenge, phases):
                                                                  annotation_file=annotation_file_name)
         download_and_extract_file(annotation_file_url, annotation_file_path)
 
-    # import the challenge after everything is finished
-    challenge_module = importlib.import_module(CHALLENGE_IMPORT_STRING.format(challenge_id=challenge.id))
-    EVALUATION_SCRIPTS[challenge.id] = challenge_module
+    try:
+        # import the challenge after everything is finished
+        challenge_module = importlib.import_module(CHALLENGE_IMPORT_STRING.format(challenge_id=challenge.id))
+        EVALUATION_SCRIPTS[challenge.id] = challenge_module
+    except:
+        logger.error('Error while creating Python module for challenge_id: %s' % (challenge.id))
+        traceback.print_exc()
 
 
 def load_active_challenges():


### PR DESCRIPTION
## Description

Currenly if there is an error in the evaluation script of a challenge, then the worker cannot create a python package for that challenge and hence the worker fails to start. See the screenshot below for an example: 

![screen shot 2018-09-10 at 6 22 14 pm](https://user-images.githubusercontent.com/2945708/45327674-7b7d6400-b526-11e8-85f5-938ca312ba60.png)

## Changes

- [x] Add exception handling while creating a python module out of challenge configuration

Please see the screenshot below after adding the changes:

![screen shot 2018-09-10 at 6 21 47 pm](https://user-images.githubusercontent.com/2945708/45327730-b41d3d80-b526-11e8-934b-110cbf0fb595.png)
