### PR TITLE
Update Python version to 3.6.5 in Dockerfiles along with minor fixes

### DIFF
--- a/apps/jobs/migrations/0001_squashed_0005_upload_unique_random_filename.py
+++ b/apps/jobs/migrations/0001_squashed_0005_upload_unique_random_filename.py
@@ -10,8 +10,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    replaces = [(b'jobs', '0001_initial'), (b'jobs', '0002_execution_time_limit'), (b'jobs', '0003_submitting_status_option'), (b'jobs', '0004_submission_output'), (b'jobs', '0005_upload_unique_random_filename')]
-
     initial = True
 
     dependencies = [

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -18,8 +18,6 @@ services:
     build:
       context: ./
       dockerfile: docker/prod/worker/Dockerfile
-    depends_on:
-      - django
     env_file:
       - docker/prod/docker_staging.env
 

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:3.6.5
 
 ENV PYTHONUNBUFFERED 1
 

--- a/docker/dev/worker/Dockerfile
+++ b/docker/dev/worker/Dockerfile
@@ -1,5 +1,4 @@
-FROM python:3.4
-MAINTAINER CloudCV
+FROM python:3.6.5
 
 ENV PYTHONUNBUFFERED 1
 

--- a/docker/prod/django/Dockerfile
+++ b/docker/prod/django/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:3.6.5
 
 ENV PYTHONUNBUFFERED 1
 

--- a/docker/prod/worker/Dockerfile
+++ b/docker/prod/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:3.6.5
 
 ENV PYTHONUNBUFFERED 1
 
@@ -13,4 +13,4 @@ RUN pip install -r worker.txt
 
 ADD . /code
 
-CMD ["./docker/wait-for-it.sh", "django:8000", "--", "python", "-m", "scripts.workers.submission_worker"]
+CMD ["python", "-m", "scripts.workers.submission_worker"]

--- a/middleware/metrics/__init__.py
+++ b/middleware/metrics/__init__.py
@@ -1,3 +1,3 @@
-from metrics_middleware import DatadogMiddleware
+from .metrics_middleware import DatadogMiddleware
 
 __all__ = [DatadogMiddleware]


### PR DESCRIPTION
This PR includes the following changes:

- [ ] Update Jobs migrations to make it work with Python 3 environment
- [ ] Update Python docker image version for both staging and production environment
- [ ] Remove dependency on django for worker in production environment. 

@RishabhJain2018 PTAL. :) 