### PR TITLE
Fix #1782: Corrected improper API Naming for Safari

### DIFF
--- a/apps/hosts/urls.py
+++ b/apps/hosts/urls.py
@@ -4,7 +4,7 @@ from . import views
 
 urlpatterns = [
 
-    url(r'^challenge_host_team/$', views.challenge_host_team_list, name='get_challenge_host_team_list'),
+    url(r'^challenge_host_team', views.challenge_host_team_list, name='get_challenge_host_team_list'),
     url(r'^challenge_host_team/(?P<pk>[0-9]+)$', views.challenge_host_team_detail,
         name='get_challenge_host_team_details'),
     url(r'^create_challenge_host_team$', views.create_challenge_host_team, name='create_challenge_host_team'),

--- a/tests/unit/hosts/test_urls.py
+++ b/tests/unit/hosts/test_urls.py
@@ -30,7 +30,7 @@ class BaseAPITestClass(APITestCase):
 class TestStringMethods(BaseAPITestClass):
     def test_host_urls(self):
         url = reverse_lazy('hosts:get_challenge_host_team_list')
-        self.assertEqual(url, '/api/hosts/challenge_host_team/')
+        self.assertEqual(url, '/api/hosts/challenge_host_team')
 
         url = reverse_lazy('hosts:get_challenge_host_team_details', kwargs={'pk': self.challenge_host.pk})
         self.assertEqual(url, '/api/hosts/challenge_host_team/' + str(self.challenge_host.pk))


### PR DESCRIPTION
Closes #1782 
Corrected improper API Naming for `api/hosts/challenge_host_team`, which was causing error in Safari.
![screen shot 2018-10-18 at 7 20 23 pm](https://user-images.githubusercontent.com/3920286/47159703-14fd1a00-d30c-11e8-884e-1db66c4b23ce.png)
Safari Version 11.1.2 (13605.3.8)