### PR TITLE
Fix #1782: Corrected improper API Naming for Safari 

### DIFF
--- a/frontend/src/js/controllers/dashCtrl.js
+++ b/frontend/src/js/controllers/dashCtrl.js
@@ -91,7 +91,7 @@
         utilities.sendRequest(parameters);
 
         //check for host teams.
-        parameters.url = 'hosts/challenge_host_team';
+        parameters.url = 'hosts/challenge_host_team/';
         parameters.method = 'GET';
         parameters.token = userKey;
         parameters.callback = {

--- a/settings/common.py
+++ b/settings/common.py
@@ -139,6 +139,8 @@ USE_L10N = True
 
 USE_TZ = True
 
+APPEND_SLASH = False
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 

--- a/settings/common.py
+++ b/settings/common.py
@@ -139,8 +139,6 @@ USE_L10N = True
 
 USE_TZ = True
 
-APPEND_SLASH = False
-
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 


### PR DESCRIPTION
Closes #1782 
![screen shot 2018-10-18 at 8 57 00 pm](https://user-images.githubusercontent.com/3920286/47165850-8b077e00-d318-11e8-9b2f-dd49d90c43bf.png)
 Safari Version 11.1.2 (13605.3.8)
