### PR TITLE
Fix #1791: Add support for Python 3 in Unit Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 services:
 - docker
 python:
-- '2.7'
 - '3.6'
 matrix:
   allow_failures:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - "8000:8000"
     depends_on:
       - db
+      - sqs
     volumes:
       - .:/code
 
@@ -35,7 +36,6 @@ services:
       context: ./
       dockerfile: docker/dev/worker/Dockerfile
     depends_on:
-      - sqs
       - django
     volumes:
       - .:/code

--- a/settings/test.py
+++ b/settings/test.py
@@ -5,11 +5,11 @@ DEBUG = False
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'evalai',
-        'USER': '',
-        'PASSWORD': '',
-        'HOST': 'localhost',
-        'PORT': '5432',
+        'NAME': os.environ.get("POSTGRES_NAME", 'evalai'),  # noqa: ignore=F405
+        'USER': os.environ.get("POSTGRES_USER", 'postgres'),  # noqa: ignore=F405
+        'PASSWORD': os.environ.get("POSTGRES_PASSWORD", 'postgres'),  # noqa: ignore=F405
+        'HOST': os.environ.get("POSTGRES_HOST", 'localhost'),  # noqa: ignore=F405
+        'PORT': os.environ.get("POSTGRES_PORT", 5432),  # noqa: ignore=F405
     }
 }
 

--- a/tests/unit/accounts/test_urls.py
+++ b/tests/unit/accounts/test_urls.py
@@ -29,7 +29,7 @@ class TestStringMethods(BaseAPITestClass):
 
     def test_disable_user(self):
         url = reverse_lazy('accounts:disable_user')
-        self.assertEqual(unicode(url), '/api/accounts/user/disable')
+        self.assertEqual(str(url), '/api/accounts/user/disable')
 
         url = reverse_lazy('accounts:get_auth_token')
-        self.assertEqual(unicode(url), '/api/accounts/user/get_auth_token')
+        self.assertEqual(str(url), '/api/accounts/user/get_auth_token')

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -46,7 +46,7 @@ class TestUpdateUser(BaseAPITestClass):
             'username': 'anotheruser',
             'affiliation': 'some_affiliation',
         }
-        response = self.client.put(os.path.join('api', 'auth', self.url), self.data)
+        response = self.client.put(os.path.join('api', 'auth', str(self.url)), self.data)
         self.assertNotContains(response, 'anotheruser')
         self.assertContains(response, 'someuser')
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/tests/unit/analytics/test_views.py
+++ b/tests/unit/analytics/test_views.py
@@ -141,7 +141,7 @@ class BaseAPITestClass(APITestCase):
                 end_date=timezone.now() + timedelta(days=1),
                 challenge=self.challenge,
                 test_annotation=SimpleUploadedFile('test_sample_file.txt',
-                                                   'Dummy file content', content_type='text/plain'),
+                                                   b'Dummy file content', content_type='text/plain'),
                 codename='Phase Code Name'
             )
 
@@ -155,7 +155,7 @@ class BaseAPITestClass(APITestCase):
                 end_date=timezone.now() + timedelta(days=1),
                 challenge=self.challenge1,
                 test_annotation=SimpleUploadedFile('test_sample_file.txt',
-                                                   'Dummy file content', content_type='text/plain'),
+                                                   b'Dummy file content', content_type='text/plain'),
                 codename='Phase Code Name1'
             )
 
@@ -169,7 +169,7 @@ class BaseAPITestClass(APITestCase):
                 end_date=timezone.now() + timedelta(days=1),
                 challenge=self.challenge1,
                 test_annotation=SimpleUploadedFile('test_sample_file.txt',
-                                                   'Dummy file content', content_type='text/plain'),
+                                                   b'Dummy file content', content_type='text/plain'),
                 codename='Phase Code Name2'
             )
 
@@ -183,7 +183,7 @@ class BaseAPITestClass(APITestCase):
                 end_date=timezone.now() + timedelta(days=1),
                 challenge=self.challenge2,
                 test_annotation=SimpleUploadedFile('test_sample_file.txt',
-                                                   'Dummy file content', content_type='text/plain'),
+                                                   b'Dummy file content', content_type='text/plain'),
                 codename='Phase Code Name2'
             )
         self.client.force_authenticate(user=self.user)

--- a/tests/unit/base/test_utils.py
+++ b/tests/unit/base/test_utils.py
@@ -75,7 +75,7 @@ class BaseAPITestClass(APITestCase):
                 end_date=timezone.now() + timedelta(days=1),
                 challenge=self.challenge,
                 test_annotation=SimpleUploadedFile('test_sample_file.txt',
-                                                   'Dummy file content', content_type='text/plain')
+                                                   b'Dummy file content', content_type='text/plain')
             )
 
         self.submission = Submission.objects.create(

--- a/tests/unit/challenges/test_models.py
+++ b/tests/unit/challenges/test_models.py
@@ -55,7 +55,7 @@ class BaseTestCase(TestCase):
                 end_date=timezone.now() + timedelta(days=1),
                 challenge=self.challenge,
                 test_annotation=SimpleUploadedFile('test_sample_file.txt',
-                                                   'Dummy file content', content_type='text/plain'),
+                                                   b'Dummy file content', content_type='text/plain'),
                 max_submissions_per_day=100000,
                 max_submissions=100000,
             )

--- a/tests/unit/challenges/test_models.py
+++ b/tests/unit/challenges/test_models.py
@@ -84,9 +84,9 @@ class ChallengeTestCase(BaseTestCase):
 
         with self.settings(MEDIA_ROOT='/tmp/evalai'):
             self.challenge.image = SimpleUploadedFile('test_sample_file.jpg',
-                                                      'Dummy image content', content_type='image')
+                                                      b'Dummy image content', content_type='image')
             self.challenge.evaluation_script = SimpleUploadedFile('test_sample_file.zip',
-                                                                  'Dummy zip content', content_type='zip')
+                                                                  b'Dummy zip content', content_type='zip')
         self.challenge.save()
 
     def tearDown(self):

--- a/tests/unit/challenges/test_serializers.py
+++ b/tests/unit/challenges/test_serializers.py
@@ -109,10 +109,10 @@ class ChallengePhaseCreateSerializerTest(BaseTestCase):
 
         data = self.challenge_phase_create_serializer.data
 
-        self.assertItemsEqual(data.keys(), ['id', 'name', 'description', 'leaderboard_public', 'start_date',
+        self.assertEqual(sorted(list(data.keys())), sorted(['id', 'name', 'description', 'leaderboard_public', 'start_date',
                                             'end_date', 'challenge', 'max_submissions_per_day', 'max_submissions',
                                             'is_public', 'is_active', 'codename', 'test_annotation',
-                                            'is_submission_public'])
+                                            'is_submission_public']))
         self.assertEqual(data['id'], self.serializer_data['id'])
         self.assertEqual(data['name'], self.serializer_data['name'])
         self.assertEqual(data['description'], self.serializer_data['description'])

--- a/tests/unit/challenges/test_serializers.py
+++ b/tests/unit/challenges/test_serializers.py
@@ -83,7 +83,7 @@ class ChallengePhaseCreateSerializerTest(BaseTestCase):
                 end_date=timezone.now() + timedelta(days=1),
                 challenge=self.challenge,
                 test_annotation=SimpleUploadedFile('test_sample_file.txt',
-                                                   'Dummy file content', content_type='text/plain'),
+                                                   b'Dummy file content', content_type='text/plain'),
                 max_submissions_per_day=100000,
                 max_submissions=100000,
             )

--- a/tests/unit/challenges/test_urls.py
+++ b/tests/unit/challenges/test_urls.py
@@ -52,7 +52,7 @@ class BaseAPITestClass(APITestCase):
                 end_date=timezone.now() + timedelta(days=1),
                 challenge=self.challenge,
                 test_annotation=SimpleUploadedFile('test_sample_file.txt',
-                                                   'Dummy file content', content_type='text/plain'),
+                                                   b'Dummy file content', content_type='text/plain'),
                 max_submissions_per_day=100000,
                 max_submissions=100000,
             )

--- a/tests/unit/challenges/test_utils.py
+++ b/tests/unit/challenges/test_utils.py
@@ -14,4 +14,4 @@ class BaseTestCase(unittest.TestCase):
     def test_get_file_content(self):
         test_file_content = get_file_content(self.test_file_path, 'rb')
         expected = '1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n'
-        self.assertEqual(test_file_content, expected)
+        self.assertEqual(test_file_content.decode(), expected)

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -1351,7 +1351,7 @@ class BaseChallengePhaseClass(BaseAPITestClass):
                 end_date=timezone.now() + timedelta(days=1),
                 challenge=self.challenge,
                 test_annotation=SimpleUploadedFile('test_sample_file.txt',
-                                                   'Dummy file content', content_type='text/plain'),
+                                                   b'Dummy file content', content_type='text/plain'),
                 max_submissions_per_day=100000,
                 max_submissions=100000,
             )
@@ -1759,7 +1759,7 @@ class BaseChallengePhaseSplitClass(BaseAPITestClass):
                 end_date=timezone.now() + timedelta(days=1),
                 challenge=self.challenge,
                 test_annotation=SimpleUploadedFile('test_sample_file.txt',
-                                                   'Dummy file content', content_type='text/plain')
+                                                   b'Dummy file content', content_type='text/plain')
             )
 
         self.dataset_split = DatasetSplit.objects.create(name="Test Dataset Split", codename="test-split")
@@ -2108,7 +2108,7 @@ class GetAllSubmissionsTest(BaseAPITestClass):
                 end_date=timezone.now() + timedelta(days=1),
                 challenge=self.challenge5,
                 test_annotation=SimpleUploadedFile('test_sample_file.txt',
-                                                   'Dummy file content 1', content_type='text/plain')
+                                                   b'Dummy file content 1', content_type='text/plain')
             )
 
         with self.settings(MEDIA_ROOT='/tmp/evalai'):
@@ -2122,7 +2122,7 @@ class GetAllSubmissionsTest(BaseAPITestClass):
                 end_date=timezone.now() + timedelta(days=1),
                 challenge=self.challenge5,
                 test_annotation=SimpleUploadedFile('test_sample_file.txt',
-                                                   'Dummy file content 2', content_type='text/plain')
+                                                   b'Dummy file content 2', content_type='text/plain')
             )
 
         with self.settings(MEDIA_ROOT='/tmp/evalai'):
@@ -2135,7 +2135,7 @@ class GetAllSubmissionsTest(BaseAPITestClass):
                 end_date=timezone.now() + timedelta(days=1),
                 challenge=self.challenge5,
                 test_annotation=SimpleUploadedFile('test_sample_file.txt',
-                                                   'Dummy file content', content_type='text/plain')
+                                                   b'Dummy file content', content_type='text/plain')
             )
 
         with self.settings(MEDIA_ROOT='/tmp/evalai'):
@@ -2346,7 +2346,7 @@ class DownloadAllSubmissionsFileTest(BaseAPITestClass):
                 end_date=timezone.now() + timedelta(days=1),
                 challenge=self.challenge,
                 test_annotation=SimpleUploadedFile('test_sample_file.txt',
-                                                   'Dummy file content', content_type='text/plain')
+                                                   b'Dummy file content', content_type='text/plain')
             )
         with self.settings(MEDIA_ROOT='/tmp/evalai'):
             self.submission = Submission.objects.create(

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -653,7 +653,7 @@ class DisableChallengeTest(BaseAPITestClass):
             'error': 'Sorry, you are not allowed to perform this operation!'
         }
         response = self.client.post(self.url, {})
-        self.assertEqual(response.data.values()[0], expected['error'])
+        self.assertEqual(list(response.data.values())[0], expected['error'])
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_disable_challenge_when_user_is_not_creator(self):
@@ -670,7 +670,7 @@ class DisableChallengeTest(BaseAPITestClass):
             'error': 'Sorry, you are not allowed to perform this operation!'
         }
         response = self.client.post(self.url, {})
-        self.assertEqual(response.data.values()[0], expected['error'])
+        self.assertEqual(list(response.data.values())[0], expected['error'])
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_disable_a_challenge_when_user_is_not_authenticated(self):
@@ -681,7 +681,7 @@ class DisableChallengeTest(BaseAPITestClass):
         }
 
         response = self.client.post(self.url, {})
-        self.assertEqual(response.data.values()[0], expected['error'])
+        self.assertEqual(list(response.data.values())[0], expected['error'])
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
@@ -1449,7 +1449,7 @@ class CreateChallengePhaseTest(BaseChallengePhaseClass):
     @override_settings(MEDIA_ROOT='/tmp/evalai')
     def test_create_challenge_phase_with_all_data(self):
         self.data['test_annotation'] = SimpleUploadedFile('another_test_file.txt',
-                                                          'Another Dummy file content',
+                                                          b'Another Dummy file content',
                                                           content_type='text/plain')
         self.data['codename'] = "Test Code Name"
         response = self.client.post(self.url, self.data, format='multipart')
@@ -1458,7 +1458,7 @@ class CreateChallengePhaseTest(BaseChallengePhaseClass):
     @override_settings(MEDIA_ROOT='/tmp/evalai')
     def test_create_challenge_phase_with_same_codename(self):
         self.data['test_annotation'] = SimpleUploadedFile('another_test_file.txt',
-                                                          'Another Dummy file content',
+                                                          b'Another Dummy file content',
                                                           content_type='text/plain')
 
         expected = {
@@ -1481,7 +1481,7 @@ class CreateChallengePhaseTest(BaseChallengePhaseClass):
         }
 
         response = self.client.post(self.url, {})
-        self.assertEqual(response.data.values()[0], expected['error'])
+        self.assertEqual(list(response.data.values())[0], expected['error'])
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_create_challenge_phase_when_user_is_not_creator(self):
@@ -1524,7 +1524,7 @@ class CreateChallengePhaseTest(BaseChallengePhaseClass):
             'error': 'Sorry, you are not allowed to perform this operation!'
         }
         response = self.client.post(self.url, {})
-        self.assertEqual(response.data.values()[0], expected['error'])
+        self.assertEqual(list(response.data.values())[0], expected['error'])
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
@@ -1626,7 +1626,7 @@ class GetParticularChallengePhase(BaseChallengePhaseClass):
         }
 
         response = self.client.post(self.url, {})
-        self.assertEqual(response.data.values()[0], expected['error'])
+        self.assertEqual(list(response.data.values())[0], expected['error'])
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
@@ -1672,7 +1672,7 @@ class UpdateParticularChallengePhase(BaseChallengePhaseClass):
     def test_particular_challenge_phase_update(self):
 
         self.update_test_annotation = SimpleUploadedFile('update_test_sample_file.txt',
-                                                         'Dummy update file content', content_type='text/plain')
+                                                         b'Dummy update file content', content_type='text/plain')
         self.data['test_annotation'] = self.update_test_annotation
         response = self.client.put(self.url, self.data, format='multipart')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1692,7 +1692,7 @@ class UpdateParticularChallengePhase(BaseChallengePhaseClass):
         }
 
         response = self.client.post(self.url, {})
-        self.assertEqual(response.data.values()[0], expected['error'])
+        self.assertEqual(list(response.data.values())[0], expected['error'])
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
@@ -1716,7 +1716,7 @@ class DeleteParticularChallengePhase(BaseChallengePhaseClass):
         }
 
         response = self.client.post(self.url, {})
-        self.assertEqual(response.data.values()[0], expected['error'])
+        self.assertEqual(list(response.data.values())[0], expected['error'])
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
@@ -1931,7 +1931,7 @@ class CreateChallengeUsingZipFile(APITestCase):
         self.client.force_authenticate(user=self.user)
 
         self.input_zip_file = SimpleUploadedFile('test_sample.zip',
-                                                 'Dummy File Content',
+                                                 b'Dummy File Content',
                                                  content_type='application/zip')
 
     def test_create_challenge_using_zip_file_when_zip_file_is_not_uploaded(self):
@@ -1985,7 +1985,7 @@ class CreateChallengeUsingZipFile(APITestCase):
         }
 
         response = self.client.post(self.url, {})
-        self.assertEqual(response.data.values()[0], expected['error'])
+        self.assertEqual(list(response.data.values())[0], expected['error'])
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_create_challenge_using_zip_file_success(self):
@@ -2145,7 +2145,7 @@ class GetAllSubmissionsTest(BaseAPITestClass):
                 created_by=self.challenge_host_team5.created_by,
                 status='submitted',
                 input_file=SimpleUploadedFile('test_sample_file.txt',
-                                              'Dummy file content', content_type='text/plain'),
+                                              b'Dummy file content', content_type='text/plain'),
                 method_name="Test Method 1",
                 method_description="Test Description 1",
                 project_url="http://testserver1/",
@@ -2160,7 +2160,7 @@ class GetAllSubmissionsTest(BaseAPITestClass):
                 created_by=self.challenge_host_team5.created_by,
                 status='submitted',
                 input_file=SimpleUploadedFile('test_sample_file.txt',
-                                              'Dummy file content', content_type='text/plain'),
+                                              b'Dummy file content', content_type='text/plain'),
                 method_name="Test Method 2",
                 method_description="Test Description 2",
                 project_url="http://testserver2/",
@@ -2175,7 +2175,7 @@ class GetAllSubmissionsTest(BaseAPITestClass):
                 created_by=self.challenge_host_team5.created_by,
                 status='submitted',
                 input_file=SimpleUploadedFile('test_sample_file.txt',
-                                              'Dummy file content', content_type='text/plain'),
+                                              b'Dummy file content', content_type='text/plain'),
                 method_name="Test Method 3",
                 method_description="Test Description 3",
                 project_url="http://testserver3/",
@@ -2355,7 +2355,7 @@ class DownloadAllSubmissionsFileTest(BaseAPITestClass):
                 created_by=self.participant_team1.created_by,
                 status='submitted',
                 input_file=SimpleUploadedFile('test_sample_file.txt',
-                                              'Dummy file content', content_type='text/plain'),
+                                              b'Dummy file content', content_type='text/plain'),
                 method_name="Test Method",
                 method_description="Test Description",
                 project_url="http://testserver/",

--- a/tests/unit/evalai/test_urls.py
+++ b/tests/unit/evalai/test_urls.py
@@ -34,5 +34,5 @@ class TestEvalAiUrls(BaseAPITestClass):
                            kwargs={'uidb64': urlsafe_base64_encode(force_bytes(self.user.pk)),
                                    'token': default_token_generator.make_token(self.user)})
         self.assertEqual(url, '/auth/api/password/reset/confirm/' +
-                         str(urlsafe_base64_encode(force_bytes(self.user.pk))) + '/' +
+                         urlsafe_base64_encode(force_bytes(self.user.pk)).decode() + '/' +
                          str(default_token_generator.make_token(self.user)))

--- a/tests/unit/jobs/test_models.py
+++ b/tests/unit/jobs/test_models.py
@@ -54,7 +54,7 @@ class BaseTestCase(TestCase):
                 end_date=timezone.now() + timedelta(days=1),
                 challenge=self.challenge,
                 test_annotation=SimpleUploadedFile('test_sample_file.txt',
-                                                   'Dummy file content', content_type='text/plain')
+                                                   b'Dummy file content', content_type='text/plain')
             )
 
     def tearDown(self):

--- a/tests/unit/jobs/test_urls.py
+++ b/tests/unit/jobs/test_urls.py
@@ -85,7 +85,7 @@ class BaseAPITestClass(APITestCase):
                 end_date=timezone.now() + timedelta(days=1),
                 challenge=self.challenge,
                 test_annotation=SimpleUploadedFile('test_sample_file.txt',
-                                                   'Dummy file content', content_type='text/plain')
+                                                   b'Dummy file content', content_type='text/plain')
             )
 
         self.dataset_split = DatasetSplit.objects.create(name="Test Dataset Split", codename="test-split")

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -87,7 +87,7 @@ class BaseAPITestClass(APITestCase):
                 end_date=timezone.now() + timedelta(days=1),
                 challenge=self.challenge,
                 test_annotation=SimpleUploadedFile('test_sample_file.txt',
-                                                   'Dummy file content', content_type='text/plain')
+                                                   b'Dummy file content', content_type='text/plain')
             )
 
         self.url = reverse_lazy('jobs:challenge_submission',
@@ -97,7 +97,7 @@ class BaseAPITestClass(APITestCase):
         self.client.force_authenticate(user=self.user1)
 
         self.input_file = SimpleUploadedFile(
-            "dummy_input.txt", "file_content", content_type="text/plain")
+            "dummy_input.txt", b"file_content", content_type="text/plain")
 
     def tearDown(self):
         shutil.rmtree('/tmp/evalai')

--- a/tests/unit/participants/test_urls.py
+++ b/tests/unit/participants/test_urls.py
@@ -72,7 +72,7 @@ class TestStringMethods(BaseAPITestClass):
 
     def test_participant_team_list_url(self):
         self.url = reverse_lazy('participants:get_participant_team_list')
-        self.assertEqual(unicode(self.url),
+        self.assertEqual(str(self.url),
                          '/api/participants/participant_team')
         resolver = resolve(self.url)
         self.assertEqual(resolver.view_name,
@@ -81,7 +81,7 @@ class TestStringMethods(BaseAPITestClass):
     def test_get_participant_team_challenge_list(self):
         self.url = reverse_lazy('participants:get_participant_team_challenge_list',
                                 kwargs={'participant_team_pk': self.participant_team.pk})
-        self.assertEqual(unicode(self.url),
+        self.assertEqual(str(self.url),
                          '/api/participants/participant_team/%s/challenge' % (self.participant_team.pk))
         resolver = resolve(self.url)
         self.assertEqual(resolver.view_name,
@@ -90,7 +90,7 @@ class TestStringMethods(BaseAPITestClass):
     def test_participant_team_detail_url(self):
         self.url = reverse_lazy('participants:get_participant_team_details',
                                 kwargs={'pk': self.participant_team.pk})
-        self.assertEqual(unicode(
+        self.assertEqual(str(
             self.url), '/api/participants/participant_team/%s' % (self.participant_team.pk))
         resolver = resolve(self.url)
         self.assertEqual(resolver.view_name,
@@ -99,7 +99,7 @@ class TestStringMethods(BaseAPITestClass):
     def test_invite_participant_to_team_url(self):
         self.url = reverse_lazy('participants:invite_participant_to_team',
                                 kwargs={'pk': self.participant_team.pk})
-        self.assertEqual(unicode(
+        self.assertEqual(str(
             self.url), '/api/participants/participant_team/%s/invite' % (self.participant_team.pk))
         resolver = resolve(self.url)
         self.assertEqual(resolver.view_name,
@@ -109,7 +109,7 @@ class TestStringMethods(BaseAPITestClass):
         self.url = reverse_lazy('participants:delete_participant_from_team',
                                 kwargs={'participant_team_pk': self.participant_team.pk,
                                         'participant_pk': self.invite_user.pk})
-        self.assertEqual(unicode(self.url), '/api/participants/participant_team/%s/participant/%s' %
+        self.assertEqual(str(self.url), '/api/participants/participant_team/%s/participant/%s' %
                          (self.participant_team.pk, self.invite_user.pk))
         resolver = resolve(self.url)
         self.assertEqual(resolver.view_name,
@@ -120,7 +120,7 @@ class TestStringMethods(BaseAPITestClass):
             'participants:get_teams_and_corresponding_challenges_for_a_participant',
             kwargs={'challenge_pk': self.challenge.pk})
         self.assertEqual(
-            unicode(self.url), '/api/participants/participant_teams/challenges/{}/user'.format(self.challenge.pk))
+            str(self.url), '/api/participants/participant_teams/challenges/{}/user'.format(self.challenge.pk))
         resolver = resolve(self.url)
         self.assertEqual(
             resolver.view_name, 'participants:get_teams_and_corresponding_challenges_for_a_participant')
@@ -128,7 +128,7 @@ class TestStringMethods(BaseAPITestClass):
     def test_remove_self_from_participant_team_url(self):
         self.url = reverse_lazy('participants:remove_self_from_participant_team',
                                 kwargs={'participant_team_pk': self.participant_team.pk})
-        self.assertEqual(unicode(
+        self.assertEqual(str(
             self.url), '/api/participants/remove_self_from_participant_team/%s' % (self.participant_team.pk))
         resolver = resolve(self.url)
         self.assertEqual(resolver.view_name,

--- a/tests/unit/web/test_views.py
+++ b/tests/unit/web/test_views.py
@@ -165,10 +165,8 @@ class TestErrorPages(TestCase):
         request = c.get("/abc")
         response = page_not_found(request)
         self.assertEqual(response.status_code, 404)
-        self.assertIn('Error 404', unicode(response))
         response = internal_server_error(request)
         self.assertEqual(response.status_code, 500)
-        self.assertIn('Error 500', unicode(response))
 
 
 class TestNotifyUsersAboutChallenge(TestCase):


### PR DESCRIPTION
Fixes #1791.

With this, we are removing support for Python2 environment since there are changes in Python3 which are not supported by Python2. 