### PR TITLE
Docker: Specify postgres version in docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 services:
 
   db:
-    image: postgres
+    image: postgres:10.4
     ports:
       - "5432:5432"
 


### PR DESCRIPTION
We were using the latest version of postgres inside the `docker-compose.yml` which is not ideal and fails for the lastest version of postgres. Please see the log below:

<img width="1358" alt="screen shot 2018-10-29 at 6 24 29 pm" src="https://user-images.githubusercontent.com/2945708/47684348-f79c3b80-dba8-11e8-95d3-5e97cc66bed1.png">

This PR fixes the above issue. 