### PR TITLE
Update travis config for python3 & postgres 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,8 @@ services:
 - docker
 python:
 - '3.6'
-matrix:
-  allow_failures:
-  - python: '3.6'
 addons:
-  postgresql: '9.4'
+  postgresql: '10.4'
   apt:
     packages:
     - oracle-java8-set-default

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 python:
 - '3.6'
 addons:
-  postgresql: '10.4'
+  postgresql: '10'
   apt:
     packages:
     - postgresql-10
@@ -20,6 +20,9 @@ cache:
 before_cache:
 - rm -f $HOME/.cache/pip/log/debug.log
 before_script:
+- sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/10/main/postgresql.conf
+- sudo cp /etc/postgresql/{9.4,10}/main/pg_hba.conf
+- sudo service postgresql restart
 - psql -c "CREATE DATABASE evalai" -U postgres
 - wget https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.14.2.jar
 - java -jar elasticmq-server-0.14.2.jar &

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,12 @@ addons:
   postgresql: '10.4'
   apt:
     packages:
+    - postgresql-10
+    - postgresql-client-10
     - oracle-java8-set-default
+env:
+  global:
+  - PGPORT=5432
 cache:
   directories:
   - "$HOME/.cache/pip"

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -274,30 +274,31 @@ def change_submission_data_and_visibility(request, challenge_pk, challenge_phase
                     items=openapi.Schema(
                         type=openapi.TYPE_OBJECT,
                         properties={
-                        'submission__participant_team__team_name': openapi.Schema(
-                            type=openapi.TYPE_STRING,
-                            description='Participant Team Name'
-                            ),
-                        'challenge_phase_split': openapi.Schema(
-                            type=openapi.TYPE_STRING,
-                            description='Challenge Phase Split ID'
-                            ),
-                        'filtering_score': openapi.Schema(
-                            type=openapi.TYPE_STRING,
-                            description='Default filtering score for results'
-                            ),
-                        'leaderboard__schema': openapi.Schema(
-                            type=openapi.TYPE_STRING,
-                            description='Leaderboard Schema of the corresponding challenge'
-                            ),
-                        'result': openapi.Schema(
-                            type=openapi.TYPE_ARRAY,
-                            description='Leaderboard Metrics values according to leaderboard schema'
-                            ),
-                        'submission__submitted_at': openapi.Schema(
-                            type=openapi.TYPE_STRING,
-                            description='Time stamp when submission was submitted at')
-                        })
+                            'submission__participant_team__team_name': openapi.Schema(
+                                type=openapi.TYPE_STRING,
+                                description='Participant Team Name'
+                                ),
+                            'challenge_phase_split': openapi.Schema(
+                                type=openapi.TYPE_STRING,
+                                description='Challenge Phase Split ID'
+                                ),
+                            'filtering_score': openapi.Schema(
+                                type=openapi.TYPE_STRING,
+                                description='Default filtering score for results'
+                                ),
+                            'leaderboard__schema': openapi.Schema(
+                                type=openapi.TYPE_STRING,
+                                description='Leaderboard Schema of the corresponding challenge'
+                                ),
+                            'result': openapi.Schema(
+                                type=openapi.TYPE_ARRAY,
+                                description='Leaderboard Metrics values according to leaderboard schema'
+                                ),
+                            'submission__submitted_at': openapi.Schema(
+                                type=openapi.TYPE_STRING,
+                                description='Time stamp when submission was submitted at')
+                            }
+                        )
                     ),
                 }
             )

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -28,11 +28,8 @@ from challenges.models import (
     Challenge,
     ChallengePhaseSplit,
     LeaderboardData,)
-from challenges.models import Leaderboard
-from challenges.permissions import IsChallengeCreator
 from challenges.utils import (get_challenge_model,
-                              get_challenge_phase_model,
-                              get_challenge_phase_split_model)
+                              get_challenge_phase_model)
 from hosts.models import ChallengeHost
 from hosts.utils import is_user_a_host_of_challenge
 from participants.models import (ParticipantTeam,)
@@ -257,53 +254,54 @@ def change_submission_data_and_visibility(request, challenge_pk, challenge_phase
     operation_id='Get_Leaderboard_Data',
     responses={
         status.HTTP_200_OK: openapi.Response(description='', schema=openapi.Schema(
-        type=openapi.TYPE_OBJECT,
-        properties={
-            'count': openapi.Schema(
-                type=openapi.TYPE_STRING,
-                description='Count of values on the leaderboard'
-                ),
-            'next': openapi.Schema(
-                type=openapi.TYPE_STRING,
-                description='URL of next page of results'
-                ),
-            'previous': openapi.Schema(
-                type=openapi.TYPE_STRING,
-                description='URL of previous page of results'
-                ),
-            'results': openapi.Schema(
-                type=openapi.TYPE_ARRAY,
-                description='Array of results object',
-                items=openapi.Schema(
-                    type=openapi.TYPE_OBJECT,
-                    properties={
-                    'submission__participant_team__team_name': openapi.Schema(
-                        type=openapi.TYPE_STRING,
-                        description='Participant Team Name'
-                        ),
-                    'challenge_phase_split': openapi.Schema(
-                        type=openapi.TYPE_STRING,
-                        description='Challenge Phase Split ID'
-                        ),
-                    'filtering_score': openapi.Schema(
-                        type=openapi.TYPE_STRING,
-                        description='Default filtering score for results'
-                        ),
-                    'leaderboard__schema': openapi.Schema(
-                        type=openapi.TYPE_STRING,
-                        description='Leaderboard Schema of the corresponding challenge'
-                        ),
-                    'result': openapi.Schema(
-                        type=openapi.TYPE_ARRAY,
-                        description='Leaderboard Metrics values according to leaderboard schema'
-                        ),
-                    'submission__submitted_at': openapi.Schema(
-                        type=openapi.TYPE_STRING,
-                        description='Time stamp when submission was submitted at')
-                    })
-                ),
-            }
-        )),
+            type=openapi.TYPE_OBJECT,
+            properties={
+                'count': openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description='Count of values on the leaderboard'
+                    ),
+                'next': openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description='URL of next page of results'
+                    ),
+                'previous': openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description='URL of previous page of results'
+                    ),
+                'results': openapi.Schema(
+                    type=openapi.TYPE_ARRAY,
+                    description='Array of results object',
+                    items=openapi.Schema(
+                        type=openapi.TYPE_OBJECT,
+                        properties={
+                        'submission__participant_team__team_name': openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description='Participant Team Name'
+                            ),
+                        'challenge_phase_split': openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description='Challenge Phase Split ID'
+                            ),
+                        'filtering_score': openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description='Default filtering score for results'
+                            ),
+                        'leaderboard__schema': openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description='Leaderboard Schema of the corresponding challenge'
+                            ),
+                        'result': openapi.Schema(
+                            type=openapi.TYPE_ARRAY,
+                            description='Leaderboard Metrics values according to leaderboard schema'
+                            ),
+                        'submission__submitted_at': openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description='Time stamp when submission was submitted at')
+                        })
+                    ),
+                }
+            )
+        ),
     }
 )
 @throttle_classes([AnonRateThrottle])
@@ -564,14 +562,14 @@ def get_submission_by_pk(request, submission_id):
                     }
                 )
             ),
-            'metadata' : openapi.Schema(
+            'metadata': openapi.Schema(
                 type=openapi.TYPE_OBJECT,
                 description='It contains the metadata related to submission (only visible to challenge hosts)',
                 properties={
                     'foo': openapi.Schema(
                         type=openapi.TYPE_STRING,
                         description='Some data relevant to key'
-                    ) 
+                    )
                 }
             )
         }
@@ -581,8 +579,8 @@ def get_submission_by_pk(request, submission_id):
         status.HTTP_400_BAD_REQUEST: openapi.Response("{'error': 'Error message goes here'}"),
     }
 )
-@throttle_classes([UserRateThrottle,])
-@api_view(['PUT',])
+@throttle_classes([UserRateThrottle, ])
+@api_view(['PUT', ])
 @permission_classes((permissions.IsAuthenticated, HasVerifiedEmail,))
 @authentication_classes((ExpiringTokenAuthentication,))
 def update_submission(request, challenge_pk):
@@ -595,7 +593,8 @@ def update_submission(request, challenge_pk):
      - ``submission``: submission id, e.g. 123 (**required**)
      - ``stdout``: Stdout after evaluation, e.g. "Evaluation completed in 2 minutes" (**required**)
      - ``stderr``: Stderr after evaluation, e.g. "Failed due to incorrect file format" (**required**)
-     - ``submission_status``: Status of submission after evaluation (can take one of the following values: `FINISHED`/`CANCELLED`/`FAILED`), e.g. FINISHED (**required**)
+     - ``submission_status``: Status of submission after evaluation
+        (can take one of the following values: `FINISHED`/`CANCELLED`/`FAILED`), e.g. FINISHED (**required**)
      - ``result``: contains accuracies for each metric, (**required**) e.g.
             [
                 {
@@ -656,7 +655,8 @@ def update_submission(request, challenge_pk):
                     challenge_phase__pk=challenge_phase_pk,
                     dataset_split__codename=split)
             except ChallengePhaseSplit.DoesNotExist:
-                response_data = {'error': 'Challenge Phase Split does not exist with phase_id: {} and split codename: {}'.format(challenge_phase_pk, split)}
+                response_data = {'error': 'Challenge Phase Split does not exist with phase_id: {} and'
+                                 'split codename: {}'.format(challenge_phase_pk, split)}
                 return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
             leaderboard_metrics = challenge_phase_split.leaderboard.schema.get('labels')
@@ -670,11 +670,13 @@ def update_submission(request, challenge_pk):
                     malformed_metrics.append((metric, type(value)))
 
             if len(missing_metrics):
-                response_data = {'error': 'Following metrics are missing in the leaderboard data: {}'.format(missing_metrics)}
+                response_data = {'error': 'Following metrics are missing in the'
+                                 'leaderboard data: {}'.format(missing_metrics)}
                 return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
             if len(malformed_metrics):
-                response_data = {'error': 'Values for following metrics are not of float/int: {}'.format(malformed_metrics)}
+                response_data = {'error': 'Values for following metrics are not of'
+                                 'float/int: {}'.format(malformed_metrics)}
                 return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
             serializer = CreateLeaderboardDataSerializer(

--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -31,7 +31,7 @@ except NameError:
 def check_database():
     if len(EmailAddress.objects.all()) > 0:
         print("Are you sure you want to wipe the existing development database and reseed it? (Y/N)")
-        if settings.TEST or raw_input().lower() == "y":
+        if settings.TEST or input().lower() == "y":
             destroy_database()
             return True
         else:

--- a/tests/unit/challenges/test_serializers.py
+++ b/tests/unit/challenges/test_serializers.py
@@ -109,10 +109,11 @@ class ChallengePhaseCreateSerializerTest(BaseTestCase):
 
         data = self.challenge_phase_create_serializer.data
 
-        self.assertEqual(sorted(list(data.keys())), sorted(['id', 'name', 'description', 'leaderboard_public', 'start_date',
-                                            'end_date', 'challenge', 'max_submissions_per_day', 'max_submissions',
-                                            'is_public', 'is_active', 'codename', 'test_annotation',
-                                            'is_submission_public']))
+        self.assertEqual(sorted(list(data.keys())), sorted(['id', 'name', 'description', 'leaderboard_public',
+                                                            'start_date', 'end_date', 'challenge',
+                                                            'max_submissions_per_day', 'max_submissions',
+                                                            'is_public', 'is_active', 'codename',
+                                                            'test_annotation', 'is_submission_public']))
         self.assertEqual(data['id'], self.serializer_data['id'])
         self.assertEqual(data['name'], self.serializer_data['name'])
         self.assertEqual(data['description'], self.serializer_data['description'])


### PR DESCRIPTION
The files in the PR's are changed due to:

1. Since travis supports postgresql version 10 for now, so travis config is modified to support it.
References: 
https://github.com/travis-ci/travis-ci/issues/8537
https://docs.travis-ci.com/user/database-setup/#using-a-different-postgresql-version

2. Since we now support Python3 only, so flake8 errors for Python3 will not be allowed in further builds. Hence removing `allow_failures` from `travis.yml`

3. The other files are changed in order to fix the flake8 errors which were caused due to allowing build failures for python 3 in the earlier Travis configuration.

