### PR TITLE
Updated the .gitignore file to avoid future merge conflicts arising from JetBrains IDE's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,29 +58,7 @@ ssl/
 
 # Code editors
 .vscode
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/**/usage.statistics.xml
-.idea/**/dictionaries
-.idea/**/shelf
-
-# Generated files
-.idea/**/contentModel.xml
-
-# Sensitive or high-churn files
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-.idea/**/dbnavigator.xml
-
-# CMake
-cmake-build-*/
-
-# Mongo Explorer plugin
-.idea/**/mongoSettings.xml
+.idea/
 
 # File-based project format
 *.iws
@@ -91,5 +69,3 @@ out/
 # mpeltonen/sbt-idea plugin
 .idea_modules/
 
-# Editor-based Rest Client
-.idea/httpRequests

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,38 @@ ssl/
 
 # Code editors
 .vscode
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# PyCharm
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# Editor-based Rest Client
+.idea/httpRequests

--- a/.gitignore
+++ b/.gitignore
@@ -59,13 +59,7 @@ ssl/
 # Code editors
 .vscode
 .idea/
-
-# File-based project format
 *.iws
-
-# PyCharm
 out/
-
-# mpeltonen/sbt-idea plugin
 .idea_modules/
 


### PR DESCRIPTION
Previously the repository whenever cloned and opened in any JetBrains IDE, automatically created the .idea/ folder which lead to merge conflicts. Updating the .gitignore file now allows us to ignore that. Many developers including me use PyCharm or WebStorm for exploring and contributing to the source code of EvalAI.

IMPORTANT NOTES (please read, then delete):

This PR is not addressing any currently existing Issue. This is just an addition to ease the use of IDE's without resulting into merge conflicts.


