### PR TITLE
Fix #1980: Fixing Generator Expression Error

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -2,7 +2,7 @@ asgi-redis==1.4.3
 boto3==1.7.31
 botocore==1.10.12
 commonmark==0.5.4
-django==1.11.15
+django==1.11.17
 django-import-export==0.5.1
 djangorestframework==3.7.7
 djangorestframework-expiring-authtoken==0.1.4


### PR DESCRIPTION
Closes: #1980 

Deliverables:
- [x] Solved `SyntaxError: Generator expression must be parenthesized` in MacOS by Updating Django to 1.11.17 - [Source](https://stackoverflow.com/a/48822656)
