### PR TITLE
Fix# 1982: Loading YAML Safely

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -563,7 +563,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
 
     try:
         with open(join(BASE_LOCATION, unique_folder_name, yaml_file), "r") as stream:
-            yaml_file_data = yaml.load(stream)
+            yaml_file_data = yaml.safe_load(stream)
     except (yaml.YAMLError, ScannerError) as exc:
         message = 'Error in creating challenge. Please check the yaml configuration!'
         response_data = {

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -16,6 +16,6 @@ pika==0.10.0
 pickleshare==0.7.4
 Pillow==3.4.2
 psycopg2==2.7.3.2
-PyYaml==3.12
+PyYaml==4.2b1
 proc==0.10.1
 rstr==2.2.5


### PR DESCRIPTION
Fixes: #1982 

Updated PyYaml to 4.2b1

> Prior to [#74](https://github.com/yaml/pyyaml/issues/193), yaml.load could run arbitrary python when parsing yaml, by design. [#74](https://github.com/yaml/pyyaml/issues/193) changed this so that by default, load didnt run python, and instead was an alias to safe_load. In this release, this was reverted, which means it's now a known security issue, hence the release of a security notice (CVE-2017-18342).
**From : [Security fixe reported by github #243](https://github.com/yaml/pyyaml/issues/243)**

Directly Updated to 4.2b1 as  [4.1 was retracted](https://github.com/yaml/pyyaml/projects)

Also, replaced `yaml.load()` with `yaml.safe_load()` in [apps/challenges/views.py#L566](https://github.com/Cloud-CV/EvalAI/blob/c2f00611df128488e4b2cc86b85340b96a1cd5e2/apps/challenges/views.py#L566)
>In PyYAML before 4.1, the yaml.load() API could execute arbitrary code. In other words, yaml.safe_load is not used.<br> **From : [National Vulnerability Database : CVE-2017-18342](https://github.com/yaml/pyyaml/issues/243)**

**Edit**: This [PyYAML 4.2 Release Plan](https://github.com/yaml/pyyaml/issues/193) acts on reverting the PR : [Make pyyaml safe by default. #74](https://github.com/yaml/pyyaml/pull/74) which is still not closed.
> Make PR to revert [#74](https://github.com/yaml/pyyaml/pull/74) ( #194 )

This, the commit [Loading YAML Safely](https://github.com/Cloud-CV/EvalAI/pull/1983/commits/4a5353eb966f4886cb2f50ac260b8d1df0d2dc63) in this PR deals with this.