### PR TITLE
Settings: Change default timezone to be ET timezone

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -131,7 +131,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'America/New_York'
 
 USE_I18N = True
 


### PR DESCRIPTION
Currently, we have the default timezone to be set to UTC which makes it harder for EvalAI Admin to see when a particular entry was created in the database since there is a conversion from UTC to ET involved in this process. This PR solves this issue where it visualizes the time in ET instead of UTC on Django Admin. 