### PR TITLE
Fixes Month Change Bug in Unit Tests for #1690

### DIFF
--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -570,12 +570,12 @@ class GetRemainingSubmissionTest(BaseAPITestClass):
         self.challenge.save()
         self.submission1.submitted_at = timezone.now() - timedelta(days=3)
         self.submission1.save()
-        remaining_submissions_this_month_count = 18
+        expected_remaining_submissions_this_month_count = 18
         if 1 <= timezone.now().day <= 3:
-            remaining_submissions_this_month_count = 19
+            expected_remaining_submissions_this_month_count = 19
         expected = {
             'remaining_submissions_today_count': 9,
-            'remaining_submissions_this_month_count': remaining_submissions_this_month_count,
+            'remaining_submissions_this_month_count': expected_remaining_submissions_this_month_count,
             'remaining_submissions': 98
         }
         response = self.client.get(self.url, {})

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -571,7 +571,7 @@ class GetRemainingSubmissionTest(BaseAPITestClass):
         self.submission1.submitted_at = timezone.now() - timedelta(days=3)
         self.submission1.save()
         remaining_submissions_this_month_count = 18
-        if timezone.now().day in range(1, 4):
+        if 1 <= timezone.now().day <= 3:
             remaining_submissions_this_month_count = 19
         expected = {
             'remaining_submissions_today_count': 9,

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -566,16 +566,18 @@ class GetRemainingSubmissionTest(BaseAPITestClass):
                                     'challenge_phase_pk': self.challenge_phase.pk,
                                     'challenge_pk': self.challenge.pk
                                 })
-        expected = {
-            'remaining_submissions_today_count': 9,
-            'remaining_submissions_this_month_count': 18,
-            'remaining_submissions': 98
-        }
-
         self.challenge.participant_teams.add(self.participant_team)
         self.challenge.save()
         self.submission1.submitted_at = timezone.now() - timedelta(days=3)
         self.submission1.save()
+        remaining_submissions_this_month_count = 18
+        if timezone.now().day in range(1, 4):
+            remaining_submissions_this_month_count = 19
+        expected = {
+            'remaining_submissions_today_count': 9,
+            'remaining_submissions_this_month_count': remaining_submissions_this_month_count,
+            'remaining_submissions': 98
+        }
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
Fixes: #2064  
The Test `test_get_remaining_submission_when_submission_made_three_days_back` was failing for expected `remaining_submissions_this_month_count` as change in month because of 
```python
self.submission1.submitted_at = timezone.now() - timedelta(days=3)
```
The change in month was not taken into account while making the Tests for [Fix #1690: Add support for setting submission limit per month per team for a challenge](https://github.com/Cloud-CV/EvalAI/pull/2005).
```sh
GetRemainingSubmissionTest.test_get_remaining_submission_when_submission_made_three_days_back 
self = <tests.unit.jobs.test_views.GetRemainingSubmissionTest testMethod=test_get_remaining_submission_when_submission_made_three_days_back>
    def test_get_remaining_submission_when_submission_made_three_days_back(self):
        self.url = reverse_lazy('jobs:get_remaining_submissions',
                                kwargs={
                                    'challenge_phase_pk': self.challenge_phase.pk,
                                    'challenge_pk': self.challenge.pk
                                })
        expected = {
            'remaining_submissions_today_count': 9,
            'remaining_submissions_this_month_count': 18,
            'remaining_submissions': 98
        }
    
        self.challenge.participant_teams.add(self.participant_team)
        self.challenge.save()
        self.submission1.submitted_at = timezone.now() - timedelta(days=3)
        self.submission1.save()
        response = self.client.get(self.url, {})
>       self.assertEqual(response.data, expected)
E       AssertionError: {'rem[15 chars]ons_this_month_count': 19, 'remaining_submissi[44 chars]: 98} != {'rem[15 chars]ons_today_count': 9, 'remaining_submissions_th[44 chars]: 98}
E         {'remaining_submissions': 98,
E       -  'remaining_submissions_this_month_count': 19,
E       ?                                             ^
E       
E       +  'remaining_submissions_this_month_count': 18,
E       ?                                             ^
E       
E          'remaining_submissions_today_count': 9}
```
The Issue is resolved by 
```python
expected_remaining_submissions_this_month_count = 18
if 1 <= timezone.now().day <= 3:
            expected_remaining_submissions_this_month_count = 19
```
This ensures that if because of `timedelta(days=3)`, `self.submission1.submitted_at.month` is still the last month, `expected_remaining_submissions_this_month_count` will not take `submission1` into count.

Thank You!