### PR TITLE
Fix:#2087 Requirements incompatability issue

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,6 +1,6 @@
 asgi-redis==1.4.3
 boto3==1.7.31
-botocore==1.10.12
+botocore==1.11.0
 commonmark==0.5.4
 django==1.11.18
 django-import-export==0.5.1
@@ -9,7 +9,7 @@ djangorestframework-expiring-authtoken==0.1.4
 django-cors-headers==1.3.1
 django-rest-auth[with_social]==0.9.2
 django-ses==0.8.5
-docker-compose==1.21.0
+docker-compose==1.23.2
 drfdocs==0.0.11
 drf-yasg==1.11.0
 pika==0.10.0


### PR DESCRIPTION
This PR addresses #2087 . There are some requirements which are compatible with other's. As one package being updated leads to usage of compatible/ child requirements maybe outdated and need to be updated with parent process.

 In EvalAI involves updation of above requirements:
 - botocore 
 - docker-compose

There are some packages which are not yet upto date with latest releases like `djangorestframework-expiring-authtoken`

