### PR TITLE
Fix filtering bug in the leaderboard entries

### DIFF
--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -350,13 +350,13 @@ def leaderboard(request, challenge_phase_split_id):
         submission__is_flagged=False,
         submission__status=Submission.FINISHED).order_by('created_at')
 
-    if not challenge_host_user:
-        leaderboard_data = leaderboard_data.filter(submission__is_public=True)
-
     leaderboard_data = leaderboard_data.annotate(
         filtering_score=RawSQL('result->>%s', (default_order_by, ), output_field=FloatField())).values(
             'id', 'submission__participant_team__team_name',
             'challenge_phase_split', 'result', 'filtering_score', 'leaderboard__schema', 'submission__submitted_at')
+
+    if not challenge_host_user:
+        leaderboard_data = leaderboard_data.filter(submission__is_public=True)
 
     sorted_leaderboard_data = sorted(leaderboard_data, key=lambda k: float(k['filtering_score']), reverse=True)
 


### PR DESCRIPTION
## What is the bug?

Let us suppose the default filtering for a leaderboard is `x`.

1. Now, make two submissions to a challenge phase `Z` named as A & B. Keep A as private and B as public. Also, the value of x is higher (in magnitude) for submission A than for B.

2. Now, if we view the leaderboard by logging in as a challenge host then we'll see the entry A on the leaderboard whereas, in case of a normal user (who is not a challenge host), we will see entry B on the leaderboard which creates inconsistency.

## Expected behavior:

The entries on the leaderboard viewed by the challenge host and the normal user should be the same (if they are public). i.e for this case challenge host should be able to see entry A whereas normal users should neither see A or B.