### PR TITLE
Fix #2079 Invoking invalidate_cache to ensure dynamically created modules are visible to worker

### DIFF
--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -213,6 +213,7 @@ def extract_challenge_data(challenge, phases):
 
     try:
         # import the challenge after everything is finished
+        importlib.invalidate_caches()
         challenge_module = importlib.import_module(CHALLENGE_IMPORT_STRING.format(challenge_id=challenge.id))
         EVALUATION_SCRIPTS[challenge.id] = challenge_module
     except:


### PR DESCRIPTION
This PR addresses #2079 

Invoking `importlib.invalidate_caches()` [is recommended](https://docs.python.org/3/library/importlib.html#importlib.invalidate_caches) when loading modules that are created while the program is running, which is the case of the worker. Adding the line solved the issue #2079 
