### PR TITLE
Fix #2127: Update the Django version

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -2,7 +2,7 @@ asgi-redis==1.4.3
 boto3==1.9.88
 botocore==1.12.0
 commonmark==0.5.4
-django==1.11.18
+django==1.11.20
 django-import-export==0.5.1
 djangorestframework==3.7.7
 djangorestframework-expiring-authtoken==0.1.4


### PR DESCRIPTION
Fixes #2127 .

Django version
old 1.11.18
new 1.11.20

I have confirmed that there is no part in the code base to display decimal numbers exceeding 200 digits.

I hasten to send you the PR..