### PR TITLE
Fix #1486: Deleting the challenges config entry when not used

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -498,6 +498,10 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
         uploaded_zip_file_path = serializer.data['zip_configuration']
     else:
         response_data = serializer.errors
+        try:
+            uploaded_zip_file.delete()
+        except Exception as e:
+            pass
         return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
     # All files download and extract location.
@@ -520,6 +524,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                 'error': message
             }
             logger.exception(message)
+            uploaded_zip_file.delete()
             return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
     except requests.exceptions.RequestException:
@@ -529,6 +534,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
             'error': message
         }
         logger.exception(message)
+        uploaded_zip_file.delete()
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     # Extract zip file
@@ -542,6 +548,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
         response_data = {
             'error': message
         }
+        uploaded_zip_file.delete()
         return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
     # Search for yaml file
@@ -559,6 +566,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
             'error': message
         }
         logger.info(message)
+        uploaded_zip_file.delete()
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     if yaml_file_count > 1:
@@ -567,6 +575,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
             'error': message
         }
         logger.info(message)
+        uploaded_zip_file.delete()
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     try:
@@ -578,6 +587,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
             'error': message
         }
         logger.exception(exc)
+        uploaded_zip_file.delete()
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     # Check for evaluation script path in yaml file.
@@ -594,6 +604,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
             'error': message
         }
         logger.exception(message)
+        uploaded_zip_file.delete()
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     # Check for evaluation script file in extracted zip folder.
@@ -608,6 +619,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
             'error': message
         }
         logger.exception(message)
+        uploaded_zip_file.delete()
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     # Check for test annotation file path in yaml file.
@@ -620,6 +632,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
             'error': message
         }
         logger.exception(message)
+        uploaded_zip_file.delete()
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     for data in challenge_phases_data:
@@ -637,6 +650,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                 'error': message
             }
             logger.exception(message)
+            uploaded_zip_file.delete()
             return Response(
                 response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
@@ -648,6 +662,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                 'error': message
             }
             logger.exception(message)
+            uploaded_zip_file.delete()
             return Response(
                 response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
@@ -684,6 +699,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
             'error': message
         }
         logger.exception(message)
+        uploaded_zip_file.delete()
         return Response(response_data, status.HTTP_406_NOT_ACCEPTABLE)
 
     # check for evaluation details file
@@ -708,6 +724,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
             'error': message
         }
         logger.exception(message)
+        uploaded_zip_file.delete()
         return Response(response_data, status.HTTP_406_NOT_ACCEPTABLE)
 
     # check for terms and conditions file
@@ -730,6 +747,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
             'error': message
         }
         logger.exception(message)
+        uploaded_zip_file.delete()
         return Response(response_data, status.HTTP_406_NOT_ACCEPTABLE)
 
     # check for submission guidelines file
@@ -753,6 +771,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
             'error': message
         }
         logger.exception(message)
+        uploaded_zip_file.delete()
         return Response(response_data, status.HTTP_406_NOT_ACCEPTABLE)
 
     # Check for leaderboard schema in YAML file
@@ -777,6 +796,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                 'error': message
             }
             logger.exception(message)
+            uploaded_zip_file.delete()
             return Response(response_data, status.HTTP_406_NOT_ACCEPTABLE)
         if 'labels' not in leaderboard_schema[0].get('schema'):
             message = ('There is no \'labels\' key in leaderboard '
@@ -785,6 +805,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                 'error': message
             }
             logger.exception(message)
+            uploaded_zip_file.delete()
             return Response(response_data, status.HTTP_406_NOT_ACCEPTABLE)
     else:
         message = ('There is no key \'leaderboard\' '
@@ -793,6 +814,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
             'error': message
         }
         logger.exception(message)
+        uploaded_zip_file.delete()
         return Response(response_data, status.HTTP_406_NOT_ACCEPTABLE)
 
     try:
@@ -898,6 +920,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                     'error': message
                 }
                 logger.exception(message)
+                uploaded_zip_file.delete()
                 return Response(response_data, status.HTTP_406_NOT_ACCEPTABLE)
 
             for data in challenge_phase_splits_data:
@@ -953,10 +976,18 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
         try:
             if response_data:
                 response_data = {'error': response_data.values()[0]}
+                try:
+                    uploaded_zip_file.delete()
+                except Exception as e:
+                    pass
                 return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
         except:
             response_data = {
                 'error': 'Error in creating challenge. Please check the yaml configuration!'}
+            try:
+                uploaded_zip_file.delete()
+            except Exception as e:
+                pass
             return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
         finally:
             try:


### PR DESCRIPTION
Fixes #1486 : Deletes the unnecessary entry created of challenges config when error occurs

## Fixed issues checklist
* [x]  When a user tries to create a challenge, if he uploads an invalid file ( zip without YAML) or any other format, the user gets an error but the files are stored in challenge configurations.
* [x]  This can result in large consumption of disk space and can be exploited by the users.