### PR TITLE
Fix #2110: Add test for the add_participant_team_to_challenge API

### DIFF
--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -11,7 +11,8 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import override_settings
 from django.utils import timezone
-import mock
+from moto import mock_ecr
+import boto3
 
 from allauth.account.models import EmailAddress
 from rest_framework import status


### PR DESCRIPTION
Fix #2110 
Add tests for adding participant team to the challenge API if the challenge is docker based.