### PR TITLE
Deployment: Assign name to containers while spawning

### DIFF
--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -76,7 +76,7 @@ case $opt in
             queue_name=($(echo ${queue_name//,/ } | tr -d '[]'))
             queue=$(echo $queue_name | tr -d '"')
             echo "Deploying worker for queue: " $queue
-            docker-compose -f docker-compose-${env}.yml run -e CHALLENGE_QUEUE=$queue -e CHALLENGE_PK=$challenge -d worker
+            docker-compose -f docker-compose-${env}.yml run --name=worker_${queue} -e CHALLENGE_QUEUE=$queue -e CHALLENGE_PK=$challenge -d worker
             echo "Deployed worker docker container for queue: " $queue
             ;;
         deploy-workers)
@@ -94,7 +94,7 @@ case $opt in
             do
                 queue=$(echo $queue_name | tr -d '"')
                 echo "Deploying worker for queue: " $queue
-                docker-compose -f docker-compose-${env}.yml run -e CHALLENGE_QUEUE=$queue -d worker
+                docker-compose -f docker-compose-${env}.yml run --name=worker_${queue} -e CHALLENGE_QUEUE=$queue -d worker
                 echo "Deployed worker docker container for queue: " $queue
              done
             ;;


### PR DESCRIPTION
This PR provides name to worker containers while spawning from the worker image. This will help in better debugging and tracking of worker containers. 

Related documentation: https://docs.docker.com/compose/reference/run/