### PR TITLE
FIX for issue 2149 (Fix Height of form input fields)

### DIFF
--- a/frontend/src/js/controllers/authCtrl.js
+++ b/frontend/src/js/controllers/authCtrl.js
@@ -11,6 +11,13 @@
 
     function AuthCtrl(utilities, $state, $rootScope) {
         var vm = this;
+        
+        vm.user_empty = true;
+        vm.user_min_length = false;
+        vm.user_msg = '';
+        vm.pass_empty = true;
+        vm.pass_min_length = false;
+        vm.pass_msg = '';
 
         vm.isRem = false;
         vm.isAuth = false;
@@ -288,5 +295,42 @@
         $rootScope.$on('$stateChangeStart', function() {
             vm.resetForm();
         });
+
+        vm.checkUserName = function(){
+            if(vm.getUser.name.length==0){
+                vm.user_empty=true;
+                vm.user_min_length=false;
+            }else if(vm.getUser.name.length<3){
+                vm.user_min_length=true;
+                vm.user_empty=false;
+            }else{
+                vm.user_min_length=false;
+                vm.user_empty=false;
+            }
+            if(vm.user_min_length)
+                vm.user_msg = 'Username is too short';
+            if(vm.user_empty)
+                vm.user_msg = 'Username is required';
+        }
+
+        vm.checkPassword = function(){
+            if(vm.getUser.password.length==0){
+                vm.pass_empty=true;
+                vm.pass_min_length=false;
+            }else if(vm.getUser.password.length<8){
+                vm.pass_min_length=true;
+                vm.pass_empty=false;
+            }else{
+                vm.pass_min_length=false;
+                vm.pass_empty=false;
+            }
+            if(vm.pass_min_length)
+                vm.pass_msg = 'Password is less than 8 characters.';
+            if(vm.pass_empty)
+                vm.pass_msg = 'Password is required.';
+            console.log(vm.getUser.password.length);
+            console.log(vm.pass_empty);
+            console.log(vm.pass_min_length);
+            }
     }
 })();

--- a/frontend/src/views/web/auth/login.html
+++ b/frontend/src/views/web/auth/login.html
@@ -10,22 +10,22 @@
     <form name="loginForm" ng-submit="auth.userLogin(loginForm.$valid)" id="log-in" novalidate>
         <!-- username -->
         <div class="input-field align-left">
-            <input type="text" id="name" class="dark-autofill" name="name" ng-model="auth.getUser.name" ng-minlength="3" required>
+            <input type="text" id="name" class="dark-autofill" name="name" ng-model="auth.getUser.name" ng-change="auth.checkUserName()">
             <span class="form-icon form-icon-dark"><i class="fa fa-user"></i></span>
             <label for="name">Username*</label>
-            <div class="wrn-msg text-highlight" ng-messages="loginForm.name.$error" ng-if="loginForm.name.$touched || loginForm.$submitted">
-                <p ng-message="minlength">Username is too short.</p>
-                <p ng-message="required">Username is required.</p>
+            <div class="wrn-msg text-highlight">
+                <p ng-if="auth.user_empty || auth.user_min_length">{{auth.user_msg}}</p>
+                <p ng-if="!auth.user_empty && !auth.user_min_length" style="visibility: hidden;">&nbsp;</p>
             </div>
         </div>
         <!-- password -->
         <div class="input-field align-left">
-            <input type="password" id="password" onpaste="return false;" class="dark-autofill" name="password" ng-model="auth.getUser.password" autocomplete="new-password" ng-minlength="8" required>
+            <input type="password" id="password" onpaste="return false;" class="dark-autofill" name="password" ng-model="auth.getUser.password" autocomplete="new-password" ng-change="auth.checkPassword()">
             <span class="form-icon form-icon-dark"><i class="fa fa-key"></i></span>
             <label for="password">Password (min 8 characters) *</label>
-            <div class="wrn-msg text-highlight" ng-messages="loginForm.password.$error" ng-if="loginForm.password.$touched || loginForm.$submitted">
-                <p ng-message="minlength">Password is less than 8 characters.</p>
-                <p ng-message="required">Password is required.</p>
+            <div class="wrn-msg text-highlight">
+                <p ng-if="auth.pass_empty || auth.pass_min_length">{{auth.pass_msg}}</p>
+                <p ng-if="!auth.pass_empty && !auth.pass_min_length" style="visibility: hidden;">&nbsp;</p>
             </div>
         </div>
         <div class="row">


### PR DESCRIPTION
**This is in regard to the issue-2149: Fix Height of form input fields**

I used Vanilla JavaScript as well as Angular JS events such as ng-onchange and ng-if to trigger when to display the paragraph tags. 

The CSS feature visibility allows us to hide paragraph tags so that height remains unchanged. Please refer to changes. 

This fix also allowed me to go through the code, understand and improve it.

Requesting you to please accept the changes.
<img width="536" alt="screen shot 2019-03-03 at 4 27 26 pm" src="https://user-images.githubusercontent.com/14856694/53749608-b8228a80-3ecd-11e9-8b31-0c7400fd7785.png">

