### PR TITLE
Submissions: Add API to get signed URL of a file in S3 bucket

### DIFF
--- a/apps/jobs/urls.py
+++ b/apps/jobs/urls.py
@@ -40,15 +40,18 @@ urlpatterns = [
         views.get_submissions_for_challenge,
         name="get_submissions_for_challenge",
     ),
-    url(r"^queues/(?P<queue_name>[\w-]+)/receipt/(?P<receipt_handle>[\w-]+)/$",
+    url(
+        r"^queues/(?P<queue_name>[\w-]+)/receipt/(?P<receipt_handle>[\w-]+)/$",
         views.delete_submission_message_from_queue,
         name="delete_submission_message_from_queue",
     ),
-    url(r"^challenge/queues/(?P<queue_name>[\w-]+)/$",
+    url(
+        r"^challenge/queues/(?P<queue_name>[\w-]+)/$",
         views.get_submission_message_from_queue,
         name="get_submission_message_from_queue",
     ),
-    url(r"^submission_files/$",
+    url(
+        r"^submission_files/$",
         views.get_signed_url_for_submission_related_file,
         name="get_signed_url_for_submission_related_file",
     ),

--- a/apps/jobs/urls.py
+++ b/apps/jobs/urls.py
@@ -50,4 +50,6 @@ urlpatterns = [
         views.get_submission_message_from_queue,
         name="get_submission_message_from_queue",
     ),
+    url(r'^submission_files/$',
+        views.get_signed_url, name='get_signed_url_for_submission_related_file'),
 ]

--- a/apps/jobs/urls.py
+++ b/apps/jobs/urls.py
@@ -40,16 +40,16 @@ urlpatterns = [
         views.get_submissions_for_challenge,
         name="get_submissions_for_challenge",
     ),
-    url(
-        r"^queues/(?P<queue_name>[\w-]+)/receipt/(?P<receipt_handle>[\w-]+)/$",
+    url(r"^queues/(?P<queue_name>[\w-]+)/receipt/(?P<receipt_handle>[\w-]+)/$",
         views.delete_submission_message_from_queue,
         name="delete_submission_message_from_queue",
     ),
-    url(
-        r"^challenge/queues/(?P<queue_name>[\w-]+)/$",
+    url(r"^challenge/queues/(?P<queue_name>[\w-]+)/$",
         views.get_submission_message_from_queue,
         name="get_submission_message_from_queue",
     ),
-    url(r'^submission_files/$',
-        views.get_signed_url, name='get_signed_url_for_submission_related_file'),
+    url(r"^submission_files/$",
+        views.get_signed_url_for_submission_related_file,
+        name="get_signed_url_for_submission_related_file",
+    ),
 ]

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -29,11 +29,8 @@ from accounts.permissions import HasVerifiedEmail
 from base.utils import (
     paginated_queryset,
     StandardResultSetPagination,
-<<<<<<< HEAD
     get_sqs_queue_object,
-=======
     get_boto3_client,
->>>>>>> Add query params check and modified conditions in API
 )
 from challenges.models import (
     ChallengePhase,
@@ -1044,7 +1041,7 @@ def delete_submission_message_from_queue(request, queue_name, receipt_handle):
         return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
 
-@api_view(['GET'])
+@api_view(["GET"])
 @throttle_classes([UserRateThrottle])
 @permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))
 @authentication_classes((ExpiringTokenAuthentication,))

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -46,7 +46,7 @@ from participants.models import ParticipantTeam
 from participants.utils import (
     get_participant_team_id_of_user_for_a_challenge,
     get_participant_team_of_user_for_a_challenge,
-)
+    is_user_part_of_participant_team,)
 
 from .models import Submission
 from .sender import publish_submission_message
@@ -1041,7 +1041,7 @@ def delete_submission_message_from_queue(request, queue_name, receipt_handle):
 @throttle_classes([UserRateThrottle])
 @permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))
 @authentication_classes((ExpiringTokenAuthentication,))
-def get_submission_related_files(request):
+def get_signed_url(request):
     '''Returns S3 signed URL for a particular file residing on S3 bucket
 
     Arguments:

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -3,6 +3,8 @@ import datetime
 import json
 import logging
 
+import boto3
+
 from rest_framework import permissions, status
 from rest_framework.decorators import (
     api_view,

--- a/apps/participants/utils.py
+++ b/apps/participants/utils.py
@@ -1,6 +1,9 @@
 from challenges.models import Challenge
 
+from base.utils import get_model_object
 from .models import Participant, ParticipantTeam
+
+get_participant_team_model = get_model_object(ParticipantTeam)
 
 
 def is_user_part_of_participant_team(user, participant_team):

--- a/frontend/src/js/controllers/SubmissionFilesCtrl.js
+++ b/frontend/src/js/controllers/SubmissionFilesCtrl.js
@@ -1,0 +1,40 @@
+// Invoking IIFE
+(function () {
+
+    'use strict';
+
+    angular
+        .module('evalai')
+        .controller('SubmissionFilesCtrl', SubmissionFilesCtrl);
+
+    SubmissionFilesCtrl.$inject = ['utilities', 'loaderService', '$scope', '$rootScope', '$state', '$http', '$stateParams'];
+
+    function SubmissionFilesCtrl(utilities, loaderService, $scope, $rootScope, $state, $http, $stateParams) {
+
+        var vm = this;
+        vm.bucket = $stateParams.bucket;
+        vm.key = $stateParams.key;
+        var userKey = utilities.getData('userKey');
+        var parameters = {};
+        parameters.url = 'jobs/submission_files/?bucket=' + vm.bucket + '&key=' + vm.key;
+        parameters.method = 'GET';
+        parameters.token = userKey;
+        parameters.callback = {
+            onSuccess: function (response) {
+                vm.data = response.data;
+                var status = response.status;
+                if (status === 200) {
+                    window.location.href = vm.data.signed_url;
+                } else {
+                    $state.go('error-404');
+                }
+            },
+            onError: function (response) {
+                vm.data = response.data;
+                $state.go('error-404');
+                $rootScope.notify('error', vm.data.error);
+            }
+        };
+        utilities.sendRequest(parameters);
+    }
+})();

--- a/frontend/src/js/route-config/route-config.js
+++ b/frontend/src/js/route-config/route-config.js
@@ -443,6 +443,13 @@
             title: "Accept challenge invitation"
         };
 
+        var get_submission_related_files = {
+            name: "get-submission-related-files",
+            url: "/:bucket/*key",
+            controller: "SubmissionFilesCtrl",
+            controllerAs: "submission_files",
+        };
+
         // call all states here
         $stateProvider.state(home);
         $stateProvider.state(privacy_policy);
@@ -507,6 +514,7 @@
         $stateProvider.state(update_profile);
         $stateProvider.state(contact_us);
         $stateProvider.state(challenge_invitation);
+        $stateProvider.state(get_submission_related_files);
 
         $urlRouterProvider.otherwise(function($injector, $location) {
             var state = $injector.get('$state');


### PR DESCRIPTION
### Example API Format

#### Request URL

```
https://evalapi.cloudcv.org/api/jobs/submission_files/?bucket=<bucket_name>&key=team_{id}/submission_{id}/...../file.log
```

#### Response

Response codes:
1. 200 -- When signed url is returned
2. 400 -- When file path is invalid
3. 403 -- When user is not part of the participant team
4. 404 -- File not found in S3 bucket

Remaining todos (that should come as a separate PR):

- [x] Create a controller that makes API call to this endpoint
        - If it receives 200 response code from backend server, then redirects to the signed URL
        - Else, Display 404 or appropriate response page
- [x] Create a angular router.