### PR TITLE
Modify participation for host in docker based challenges

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -922,23 +922,23 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
         zip_config = ChallengeConfiguration.objects.get(
             pk=uploaded_zip_file.pk)
         if zip_config:
-
-            # Add the Challenge Host as a test participant.
-            emails = challenge_host_team.get_all_challenge_host_email()
-            team_name = "Host_{}_Team".format(random.randint(1, 100000))
-            participant_host_team = ParticipantTeam(
-                team_name=team_name,
-                created_by=challenge_host_team.created_by,)
-            participant_host_team.save()
-            for email in emails:
-                user = User.objects.get(email=email)
-                host = Participant(
-                            user=user,
-                            status=Participant.ACCEPTED,
-                            team=participant_host_team,
-                    )
-                host.save()
-            challenge.participant_teams.add(participant_host_team)
+            if not challenge.is_docker_based:
+                # Add the Challenge Host as a test participant.
+                emails = challenge_host_team.get_all_challenge_host_email()
+                team_name = "Host_{}_Team".format(random.randint(1, 100000))
+                participant_host_team = ParticipantTeam(
+                    team_name=team_name,
+                    created_by=challenge_host_team.created_by,)
+                participant_host_team.save()
+                for email in emails:
+                    user = User.objects.get(email=email)
+                    host = Participant(
+                                user=user,
+                                status=Participant.ACCEPTED,
+                                team=participant_host_team,
+                        )
+                    host.save()
+                challenge.participant_teams.add(participant_host_team)
 
             zip_config.challenge = challenge
             zip_config.save()


### PR DESCRIPTION
**Problem**
If a challenge is docker based then the challenge host automatically participates using the challenge creation API which should not be the case as the ECR repository isn't created for the host.

**Fix:**
So, the challenge host will automatically participate in the challenge when the challenge is not docker based and for docker based challenge host will participate manually by clicking the `Participate` button on the UI.

There is one more potential solution that adding the ECR repository code here but it'll create a problem for us when a single user tries to create copies of a single challenge and all of them are docker based challenge. Since out of all these only one will be approved but it'll create useless repositories in our ECR which I think we should avoid. 
