### PR TITLE
Remove unnecessary condition from submissions API

### DIFF
--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -152,13 +152,6 @@ def challenge_submission(request, challenge_id, challenge_phase_id):
                     }
                     return Response(response_data, status=status.HTTP_403_FORBIDDEN)
 
-        # check if challenge is docker based
-        if challenge.is_docker_based:
-            response_data = {
-                'error': '{0} requires uploading docker image. \
-                    Please use evalai-cli to make submissions.'.format(challenge.title)}
-            return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
-
         participant_team_id = get_participant_team_id_of_user_for_a_challenge(
             request.user, challenge_id)
         try:

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -416,11 +416,8 @@ class BaseAPITestClass(APITestCase):
 
         response = self.client.post(self.url, {
                                         'status': 'submitting', 'input_file': self.input_file}, format="multipart")
-        expected = {
-                'error': '{0} requires uploading docker image. \
-                    Please use evalai-cli to make submissions.'.format(self.challenge.title)}
-        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
-        self.assertEqual(response.data, expected)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
 
 class GetChallengeSubmissionTest(BaseAPITestClass):


### PR DESCRIPTION
Removes an unnecessary condition from the submissions API for checking the docker based challenges. We already handle this case while creating federated users and for non-docker based challenges federated user won't get created.
