### PR TITLE
Fix #2210: Adds a feature to change the status of a submission by challenge host

### DIFF
--- a/apps/jobs/urls.py
+++ b/apps/jobs/urls.py
@@ -10,6 +10,13 @@ urlpatterns = [
         name="change_submission_data_and_visibility",
     ),
     url(
+        r"^challenge/(?P<challenge_pk>[0-9]+)/"
+        r"challenge_phase/(?P<challenge_phase_pk>[0-9]+)/submission/(?P<submission_pk>[0-9]+)/"
+        r"status/$",
+        views.change_submission_status,
+        name="change_submission_status"
+    ),
+    url(
         r"^challenge/(?P<challenge_id>[0-9]+)/"
         r"challenge_phase/(?P<challenge_phase_id>[0-9]+)/submission/$",
         views.challenge_submission,

--- a/frontend/src/css/modules/my-challenge-all-submission.scss
+++ b/frontend/src/css/modules/my-challenge-all-submission.scss
@@ -7,3 +7,27 @@
 .all-submission-table-scroll {
 	overflow-x: scroll;
 }
+
+.flex-display {
+	display: flex;
+}
+
+.flex-space-between {
+	justify-content: space-between;
+}
+
+.width-100 {
+	width: 100%;
+}
+
+.width-0 {
+	width: 0;
+}
+
+.mh-4 {
+	margin: 0 4px;
+}
+
+.m-0 {
+	margin: 0;
+}

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -41,6 +41,14 @@
         vm.sortColumn = 'rank';
         vm.reverseSort = false;
         vm.columnIndexSort = 0;
+        vm.availableStatus = [
+            "submitted",
+            "running",
+            "failed",
+            "cancelled",
+            "finished",
+            "submitting"
+        ];
         // save initial ranking
         vm.initial_ranking = {};
       // loader for existing teams
@@ -1067,6 +1075,28 @@
             parameters.callback = {
                 onSuccess: function() {},
                 onError: function() {}
+            };
+
+            utilities.sendRequest(parameters);
+        };
+
+        vm.changeSubmissionStatus = function(submission) {
+            submission.editStatus = false;
+
+            parameters.url = "jobs/challenge/" + vm.challengeId + "/challenge_phase/" + vm.phaseId + 
+                             "/submission/" + submission.id + "/status/";
+            parameters.method = 'PATCH';
+            parameters.data = {
+                "status": submission.selectedStatus
+            };
+            parameters.callback = {
+                onSuccess: function() {
+                    submission.status = submission.selectedStatus;
+                },
+                onError: function(response) {
+                    var error = response.data.error;
+                    $rootScope.notify("error", error);
+                }
             };
 
             utilities.sendRequest(parameters);

--- a/frontend/src/views/web/challenge/my-challenge-all-submission.html
+++ b/frontend/src/views/web/challenge/my-challenge-all-submission.html
@@ -65,7 +65,33 @@
 
                                         <td>{{key.created_by}}</td>
 
-                                        <td class="val-style capitalize" ng-class="key.status">{{key.status}}</td>
+                                        <td ng-if="!key.editStatus" class="val-style capitalize" ng-class="key.status">
+                                            <div class="flex-display flex-space-between">
+                                                <span>{{key.status}}</span>
+                                                <span>
+                                                    <a class="pointer" class="mh-4" ng-click="key.editStatus = true">
+                                                        <i class="fa fa-pencil" aria-hidden="true"></i>
+                                                    </a>
+                                                </span>
+                                            </div>
+                                        </td>
+                                        <td ng-if="key.editStatus" class="val-style capitalize width-0">
+                                            <div class="flex-display">
+                                                <span>
+                                                    <md-select ng-model="key.selectedStatus" placeholder="Status" class="m-0">
+                                                        <md-option class="capitalize" ng-repeat="status in challenge.availableStatus" value={{status}}>{{status}}</md-option>
+                                                    </md-select>
+                                                </span>
+                                                <span class="flex-display valign-wrapper">
+                                                    <a class="pointer mh-4" ng-click="challenge.changeSubmissionStatus(key)">
+                                                        <i class="fa fa-check green-text" aria-hidden="true"></i>
+                                                    </a>
+                                                    <a class="pointer mh-4" ng-click="key.editStatus = false">
+                                                        <i class="fa fa-times red-text" aria-hidden="true"></i>
+                                                    </a>
+                                                </span>
+                                            </div>
+                                        </td>
 
                                         <td class="align-center">{{key.execution_time}}</td>
 

--- a/tests/unit/jobs/test_urls.py
+++ b/tests/unit/jobs/test_urls.py
@@ -154,6 +154,26 @@ class TestJobsUrls(BaseAPITestClass):
             resolver.view_name, "jobs:change_submission_data_and_visibility"
         )
 
+    def test_change_submission_status_url(self):
+        self.url = reverse_lazy(
+            "jobs:change_submission_status",
+            kwargs={
+                "challenge_pk": self.challenge.pk,
+                "challenge_phase_pk": self.challenge_phase.pk,
+                "submission_pk": self.submission.pk,
+            },
+        )
+        self.assertEqual(
+            self.url,
+            "/api/jobs/challenge/{}/challenge_phase/{}/submission/{}/status/".format(
+                self.challenge.pk, self.challenge_phase.pk, self.submission.pk
+            ),
+        )
+        resolver = resolve(self.url)
+        self.assertEqual(
+            resolver.view_name, "jobs:change_submission_status"
+        )
+
     def test_challenge_submisson_url(self):
         self.url = reverse_lazy(
             "jobs:challenge_submission",

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -1568,6 +1568,221 @@ class ChangeSubmissionDataAndVisibilityTest(BaseAPITestClass):
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
+class ChangeSubmissionStatus(BaseAPITestClass):
+    def setUp(self):
+        super(ChangeSubmissionStatus, self).setUp()
+
+        self.submission = Submission.objects.create(
+            participant_team=self.participant_team,
+            challenge_phase=self.challenge_phase,
+            created_by=self.challenge_host_team.created_by,
+            status="submitted",
+            input_file=self.challenge_phase.test_annotation,
+            method_name="Test Method",
+            method_description="Test Description",
+            project_url="http://testserver/",
+            publication_url="http://testserver/",
+            is_public=True,
+            when_made_public=timezone.now(),
+        )
+
+        self.url = reverse_lazy(
+            "jobs:change_submission_status",
+            kwargs={
+                "challenge_pk": self.challenge.pk,
+                "challenge_phase_pk": self.challenge_phase.pk,
+                "submission_pk": self.submission.pk,
+            },
+        )
+
+    def test_change_submission_status_when_challenge_does_not_exist(
+        self
+    ):
+        self.url = reverse_lazy(
+            "jobs:change_submission_status",
+            kwargs={
+                "challenge_pk": self.challenge.pk + 10,
+                "challenge_phase_pk": self.challenge_phase.pk,
+                "submission_pk": self.submission.pk,
+            },
+        )
+
+        expected = {
+            "detail": "Challenge {} does not exist".format(
+                self.challenge.pk + 10
+            )
+        }
+
+        response = self.client.patch(self.url, {})
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_change_submission_status_when_challenge_phase_does_not_exist(
+        self
+    ):
+        self.url = reverse_lazy(
+            "jobs:change_submission_status",
+            kwargs={
+                "challenge_pk": self.challenge.pk,
+                "challenge_phase_pk": self.challenge_phase.pk + 10,
+                "submission_pk": self.submission.pk,
+            },
+        )
+
+        expected = {
+            "detail": "ChallengePhase {} does not exist".format(
+                self.challenge_phase.pk + 10
+            )
+        }
+
+        response = self.client.patch(self.url, {})
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_change_submission_status_when_challenge_is_not_active(
+        self
+    ):
+        self.url = reverse_lazy(
+            "jobs:change_submission_status",
+            kwargs={
+                "challenge_pk": self.challenge.pk,
+                "challenge_phase_pk": self.challenge_phase.pk,
+                "submission_pk": self.submission.pk,
+            },
+        )
+        self.data = {"status": "running"}
+        self.challenge.end_date = timezone.now() - timedelta(days=1)
+        self.challenge.save()
+
+        expected = {
+            "error": "Challenge is not active"
+        }
+        response = self.client.patch(self.url, self.data)
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_change_submission_status_when_user_is_not_host(
+        self
+    ):
+        self.url = reverse_lazy(
+            "jobs:change_submission_status",
+            kwargs={
+                "challenge_pk": self.challenge.pk,
+                "challenge_phase_pk": self.challenge_phase.pk,
+                "submission_pk": self.submission.pk,
+            },
+        )
+
+        self.data = {"status": "running"}
+        expected = {
+            "error": "Submission status can only be changed by a host of the challenge"
+        }
+        response = self.client.patch(self.url, self.data)
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_change_submission_status_when_submission_does_not_exist(
+        self
+    ):
+        self.url = reverse_lazy(
+            "jobs:change_submission_status",
+            kwargs={
+                "challenge_pk": self.challenge.pk,
+                "challenge_phase_pk": self.challenge_phase.pk,
+                "submission_pk": self.submission.pk + 10,
+            },
+        )
+
+        self.data = {"status": "running"}
+        expected = {
+            "error": "Submission does not exist"
+        }
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(self.url, self.data)
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_change_submission_status_when_submission_status_not_sent(
+        self
+    ):
+        self.url = reverse_lazy(
+            "jobs:change_submission_status",
+            kwargs={
+                "challenge_pk": self.challenge.pk,
+                "challenge_phase_pk": self.challenge_phase.pk,
+                "submission_pk": self.submission.pk,
+            },
+        )
+
+        expected = {
+            "error": "Submission status not received"
+        }
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(self.url, {})
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_change_submission_status_when_submission_exists_and_user_is_host(
+        self
+    ):
+        self.url = reverse_lazy(
+            "jobs:change_submission_status",
+            kwargs={
+                "challenge_pk": self.challenge.pk,
+                "challenge_phase_pk": self.challenge_phase.pk,
+                "submission_pk": self.submission.pk,
+            },
+        )
+
+        self.data = {"status": "running"}
+        expected = {
+            "id": self.submission.id,
+            "participant_team": self.submission.participant_team.pk,
+            "participant_team_name": self.submission.participant_team.team_name,
+            "execution_time": self.submission.execution_time,
+            "challenge_phase": self.submission.challenge_phase.pk,
+            "created_by": self.submission.created_by.pk,
+            "status": self.data["status"],
+            "input_file": "http://testserver%s"
+            % (self.submission.input_file.url),
+            "method_name": self.submission.method_name,
+            "method_description": self.submission.method_description,
+            "project_url": self.submission.project_url,
+            "publication_url": self.submission.publication_url,
+            "stdout_file": None,
+            "stderr_file": None,
+            "submission_result_file": None,
+            "submitted_at": "{0}{1}".format(
+                self.submission.submitted_at.isoformat(), "Z"
+            ).replace("+00:00", ""),
+            "is_public": self.submission.is_public,
+            "when_made_public": "{0}{1}".format(
+                self.submission.when_made_public.isoformat(), "Z"
+            ).replace("+00:00", ""),
+        }
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(self.url, self.data)
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_change_submission_status_when_submission_status_is_not_one_of_the_choices(
+        self
+    ):
+        self.url = reverse_lazy(
+            "jobs:change_submission_status",
+            kwargs={
+                "challenge_pk": self.challenge.pk,
+                "challenge_phase_pk": self.challenge_phase.pk,
+                "submission_pk": self.submission.pk,
+            },
+        )
+
+        self.data = {"status": "status_not_in_choices"}
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(self.url, self.data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
 class ChallengeLeaderboardTest(BaseAPITestClass):
     def setUp(self):
         super(ChallengeLeaderboardTest, self).setUp()


### PR DESCRIPTION
Resolves #2210 

### Description
This is a feature that enables the *host* of a challenge to edit the status of a submission using the UI. 

### Tasks
- [x] Create an API endpoint in the backend that allows changing the submission status.
- [x] Write unit tests for the API endpoint.
- [x] Provide a layout on the frontend to allow the host to change the status of any submission on the "View All Submissions" page.

### Screenshots
![Initial state of the submission](https://user-images.githubusercontent.com/23053790/54814175-33997f80-4cb5-11e9-86f9-80997ce4e88d.png)
Initial state

![Clicking the edit button](https://user-images.githubusercontent.com/23053790/54814160-2aa8ae00-4cb5-11e9-9640-c58e16c05535.png)
Clicking the edit button

![Selecting a new status](https://user-images.githubusercontent.com/23053790/54814164-2f6d6200-4cb5-11e9-8520-1d14c8bf1b4a.png)
Selecting the new status

![Status updated](https://user-images.githubusercontent.com/23053790/54814172-31372580-4cb5-11e9-8914-eef6aa79aa99.png)
Status updated
