### PR TITLE
Add checks in challenge queue name and slug field

### DIFF
--- a/apps/base/utils.py
+++ b/apps/base/utils.py
@@ -3,6 +3,7 @@ import boto3
 import botocore
 import logging
 import os
+import re
 import sendgrid
 import uuid
 
@@ -179,3 +180,21 @@ def get_sqs_queue_object():
             logger.exception("Cannot get queue: {}".format(queue_name))
         queue = sqs.create_queue(QueueName=queue_name)
     return queue
+
+
+def get_slug(param):
+    slug = param.replace(" ", "-").lower()
+    slug = re.sub(r"\W+", "-", slug)
+    slug = slug[
+        :180
+    ]  # The max-length for slug is 200, but 180 is used here so as to append pk
+    return slug
+
+
+def get_queue_name(param):
+    queue_name = param.replace(" ", "-").lower()
+    queue_name = re.sub(r"\W+", "-", queue_name)
+    queue_name = "{}-{}".format(queue_name, uuid.uuid4())[
+        :80
+    ]  # The max-length for queue-name is 80 in SQS
+    return queue_name

--- a/apps/challenges/models.py
+++ b/apps/challenges/models.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import re
+
 from django.contrib.auth.models import User
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
@@ -20,9 +22,9 @@ from hosts.models import ChallengeHost
 
 @receiver(pre_save, sender="challenges.Challenge")
 def save_challenge_slug(sender, instance, **kwargs):
-    instance.slug = "{}-{}".format(
-        instance.title.replace(" ", "-").lower(), instance.pk
-    )[:199]
+    title = instance.title.replace(" ", "-").lower()
+    title = re.sub(r"\W+", "-", title)
+    instance.slug = "{}-{}".format(title, instance.pk)[:200]
 
 
 class Challenge(TimeStampedModel):

--- a/apps/challenges/models.py
+++ b/apps/challenges/models.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-import re
-
 from django.contrib.auth.models import User
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
@@ -15,16 +13,15 @@ from base.models import (
     model_field_name,
     create_post_model_field,
 )
-from base.utils import RandomFileName
+from base.utils import RandomFileName, get_slug
 from participants.models import ParticipantTeam
 from hosts.models import ChallengeHost
 
 
 @receiver(pre_save, sender="challenges.Challenge")
 def save_challenge_slug(sender, instance, **kwargs):
-    title = instance.title.replace(" ", "-").lower()
-    title = re.sub(r"\W+", "-", title)
-    instance.slug = "{}-{}".format(title, instance.pk)[:200]
+    title = get_slug(instance.title)
+    instance.slug = "{}-{}".format(title, instance.pk)
 
 
 class Challenge(TimeStampedModel):

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -2,7 +2,6 @@ import csv
 import logging
 import random
 import requests
-import re
 import shutil
 import string
 import tempfile
@@ -38,7 +37,12 @@ from yaml.scanner import ScannerError
 from allauth.account.models import EmailAddress
 from accounts.permissions import HasVerifiedEmail
 from accounts.serializers import UserDetailsSerializer
-from base.utils import paginated_queryset, send_email, get_url_from_hostname
+from base.utils import (
+    paginated_queryset,
+    send_email,
+    get_url_from_hostname,
+    get_queue_name,
+)
 from challenges.utils import (
     get_challenge_model,
     get_challenge_phase_model,
@@ -944,13 +948,8 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
             if serializer.is_valid():
                 serializer.save()
                 challenge = serializer.instance
-                challenge_title = challenge.title.replace(" ", "-").lower()
-                challenge_title = re.sub(r"\W+", "-", challenge_title)
-                random_challenge_id = uuid.uuid4()
-                challenge_queue_name = "{}-{}".format(
-                    challenge_title, random_challenge_id
-                )
-                challenge.queue = challenge_queue_name[:80]
+                queue_name = get_queue_name(challenge.title)
+                challenge.queue = queue_name
                 challenge.save()
             else:
                 response_data = serializer.errors

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -2,6 +2,7 @@ import csv
 import logging
 import random
 import requests
+import re
 import shutil
 import string
 import tempfile
@@ -943,13 +944,13 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
             if serializer.is_valid():
                 serializer.save()
                 challenge = serializer.instance
-                challenge_title = challenge.title.split(" ")
-                challenge_title = "-".join(challenge_title).lower()
+                challenge_title = challenge.title.replace(" ", "-").lower()
+                challenge_title = re.sub(r"\W+", "-", challenge_title)
                 random_challenge_id = uuid.uuid4()
                 challenge_queue_name = "{}-{}".format(
                     challenge_title, random_challenge_id
                 )
-                challenge.queue = challenge_queue_name
+                challenge.queue = challenge_queue_name[:80]
                 challenge.save()
             else:
                 response_data = serializer.errors


### PR DESCRIPTION
**Description**

1. This PR adds checks for the queue name according to SQS conditions as mentioned [here](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.html#SQS.Client.create_queue)
2. It also add conditions to check for valid slug according to django docs.