### PR TITLE
Fix update submission API for TypeError in result

### DIFF
--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -778,9 +778,10 @@ def update_submission(request, challenge_pk):
         if successful_submission:
             try:
                 results = json.loads(submission_result)
-            except ValueError:
+            except (ValueError, TypeError) as exc:
                 response_data = {
-                    "error": "`result` key contains invalid data. Please try again with correct format!"
+                    "message": "`result` key contains invalid data. Please try again with correct format.",
+                    "error": str(exc),
                 }
                 return Response(
                     response_data, status=status.HTTP_400_BAD_REQUEST

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -780,8 +780,8 @@ def update_submission(request, challenge_pk):
                 results = json.loads(submission_result)
             except (ValueError, TypeError) as exc:
                 response_data = {
-                    "message": "`result` key contains invalid data. Please try again with correct format.",
-                    "error": str(exc),
+                    "error": "`result` key contains invalid data with error {}."
+                    "Please try again with correct format.".format(str(exc))
                 }
                 return Response(
                     response_data, status=status.HTTP_400_BAD_REQUEST

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -1983,15 +1983,23 @@ class UpdateSubmissionTest(BaseAPITestClass):
             "submission_status": "FINISHED",
             "stdout": "qwerty",
             "stderr": "qwerty",
-            "result": "qwerty",
+            "result": [
+                {
+                    "split": "split1",
+                    "accuracies": {"score": 100},
+                    "show_to_participant": True,
+                }
+            ],
         }
 
         expected = {
-            "message": "`result` key contains invalid data. Please try again with correct format."
+            "error": "`result` key contains invalid data with error "
+            "the JSON object must be str, bytes or bytearray, not 'list'."
+            "Please try again with correct format."
         }
         self.client.force_authenticate(user=self.challenge_host.user)
         response = self.client.put(self.url, self.data)
-        self.assertEqual(response.data["message"], expected["message"])
+        self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_update_submission_when_challenge_phase_split_not_exist(self):

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -1987,11 +1987,11 @@ class UpdateSubmissionTest(BaseAPITestClass):
         }
 
         expected = {
-            "error": "`result` key contains invalid data. Please try again with correct format!"
+            "message": "`result` key contains invalid data. Please try again with correct format."
         }
         self.client.force_authenticate(user=self.challenge_host.user)
         response = self.client.put(self.url, self.data)
-        self.assertEqual(response.data, expected)
+        self.assertEqual(response.data["message"], expected["message"])
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_update_submission_when_challenge_phase_split_not_exist(self):


### PR DESCRIPTION
**Description:**

The update submission API will give an error if the data in the `result` key is not of type string.