### PR TITLE
Fix EvalAI travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     packages:
     - postgresql-10
     - postgresql-client-10
-    - oracle-java8-set-default
+    - oracle-java9-set-default # Java9 is used for elasticmq
 env:
   global:
   - PGPORT=5432


### PR DESCRIPTION
Fix #2289 

- [x]  Change oracle-java-8 version to Oracle-java-9 version
 https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038 