### PR TITLE
Fix #2248: Disable edit for uploaded submission filename

### DIFF
--- a/frontend/src/views/web/challenge/submission.html
+++ b/frontend/src/views/web/challenge/submission.html
@@ -169,7 +169,7 @@
                                                     name="challenge.input_file" accept=".json, .zip, .txt">
                                             </div>
                                             <div class="file-path-wrapper">
-                                                <input class="file-path validate" type="text">
+                                                <input class="file-path validate" type="text" readonly>
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
Fix #2248 
Prevents the user from editing the file name or entering any text in the input field (by making input field "readonly").