### PR TITLE
Frontend: Fix lint error in challenge controller

### DIFF
--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -1495,7 +1495,7 @@
 
         // Edit Evaluation Script
         vm.evaluationScriptDialog = function(ev) {
-        	vm.tempEvaluationCriteria = vm.page.evaluation_details;
+            vm.tempEvaluationCriteria = vm.page.evaluation_details;
             $mdDialog.show({
                 scope: $scope,
                 preserveScope: true,


### PR DESCRIPTION
- [x] Correcting Lint error while running gulp.
```sh
EvalAI/frontend/src/js/controllers/challengeCtrl.js
  1498:2  error  Mixed spaces and tabs  no-mixed-spaces-and-tabs

✖ 1 problem (1 error, 0 warnings)
```