### PR TITLE
Fix #2241: Allow unverified user to view the challenge

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -460,7 +460,6 @@ def get_challenges_based_on_teams(request):
 @permission_classes(
     (
         permissions.IsAuthenticatedOrReadOnly,
-        HasVerifiedEmail,
         IsChallengeCreator,
     )
 )

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -20,6 +20,8 @@
         vm.publicationUrl = "";
         vm.wrnMsg = {};
         vm.page = {};
+         // message for not verified users
+        vm.emailError = "Please verify your email first!";
         vm.isParticipated = false;
         vm.isActive = false;
         vm.phases = {};

--- a/frontend/src/views/web/challenge/participate.html
+++ b/frontend/src/views/web/challenge/participate.html
@@ -1,4 +1,4 @@
-<div ng-if="isAuth">
+<div ng-if="isAuth && isMail">
     <section ng-if="challenge.isActive" class="ev-sm-container ev-view challenge-container">
         <div ng-if="challenge.isParticipated" class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view">
             <p><strong>You have already participated in the challenge with a team!</strong></p>
@@ -91,6 +91,23 @@
         </div>
     </section>
 </div>
+<section ng-if="!isMail" class="ev-sm-container ev-view ">
+    <div class="row">
+        <div class="col s12 m6 offset-m3">
+            <div class="card horizontal ev-md-container ev-card-panel ev-z-depth-5 ">
+                <div class="card-image">
+                    <img src="dist/images/email.png" height="100">
+                </div>
+                <div class="card-stacked">
+                    <div class="card-content">
+                        <p><strong>Unable to participate in the challenge.</strong>
+                            <br> {{challenge.emailError}}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
 <section ng-if="!isAuth" class="ev-sm-container ev-view challenge-container">
     <div class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view">
         <p ng-if="!isAuth">Please <a ui-sref="auth.login" class="blue-text" ui-sref-active="active-auth" ng-click="auth.resetForm()">log in</a> to participate in this challenge.</p>


### PR DESCRIPTION
IMPORTANT NOTES (please read, then delete):

Fix #2241
Allows a registered user with unverified email address to navigate to the challenge page but prevents him to access the participate section.