### PR TITLE
Fix: #2241 Allow unverified user to view the challenge 

### DIFF
--- a/apps/challenges/urls.py
+++ b/apps/challenges/urls.py
@@ -151,4 +151,9 @@ urlpatterns = [
         views.get_challenge_phase_by_slug,
         name="get_challenge_phase_by_slug",
     ),
+    url(
+        r"^participate/$",
+        views.participate_auth,
+        name="participateAuth",
+    ),
 ]

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -460,7 +460,6 @@ def get_challenges_based_on_teams(request):
 @permission_classes(
     (
         permissions.IsAuthenticatedOrReadOnly,
-        HasVerifiedEmail,
         IsChallengeCreator,
     )
 )
@@ -497,6 +496,18 @@ def challenge_phase_list(request, challenge_pk):
             response_data = serializer.data
             return Response(response_data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(["GET"])
+@throttle_classes([UserRateThrottle])
+@permission_classes(
+    (
+        HasVerifiedEmail,
+    )
+)
+@authentication_classes((ExpiringTokenAuthentication,))
+def participate_auth(request):
+    return Response(status=status.HTTP_202_ACCEPTED)
 
 
 @api_view(["GET", "PUT", "PATCH", "DELETE"])

--- a/frontend/src/js/controllers/participateCtrl.js
+++ b/frontend/src/js/controllers/participateCtrl.js
@@ -1,0 +1,31 @@
+// Invoking IIFE for participating
+(function() {
+
+    'use strict';
+
+    angular
+        .module('evalai')
+        .controller('ParticipateCtrl', ParticipateCtrl);
+
+    ParticipateCtrl.$inject = ['utilities', 'loaderService', '$scope', '$state', '$http', '$rootScope', '$mdDialog'];
+
+    function ParticipateCtrl(utilities, loaderService, $scope, $state) {
+        var userKey = utilities.getData('userKey');
+        var parameters = {};
+        parameters.url = 'challenges/participate/';
+        parameters.method = 'GET';
+        if (userKey) {
+            parameters.token = userKey;
+        }
+        parameters.callback = {
+            onError: function(response) {
+                var error = response.data;
+                utilities.storeData('emailError', error.detail);
+                $state.go('web.permission-denied');
+                utilities.hideLoader();
+            }
+        };
+        utilities.sendRequest(parameters);
+    }
+})();
+

--- a/frontend/src/js/route-config/route-config.js
+++ b/frontend/src/js/route-config/route-config.js
@@ -227,6 +227,8 @@
             parent: "web.challenge-main.challenge-page",
             url: "/participate",
             templateUrl: baseUrl + "/web/challenge/participate.html",
+            controller: 'ParticipateCtrl',
+            controllerAs: 'participateCtrl',
             title: 'Participate',
         };
 


### PR DESCRIPTION
Fix: #2241

Allows a registered user with unverified email address to navigate to the challenge page but prevents him to access the participate section through a  participate controller and a new view.
