### PR TITLE
Fix #2341: Update djangorestframework to v3.9.3

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -4,7 +4,7 @@ botocore==1.12.0
 commonmark==0.5.4
 django==1.11.20
 django-import-export==0.5.1
-djangorestframework==3.7.7
+djangorestframework==3.9.3
 djangorestframework-expiring-authtoken==0.1.4
 django-cors-headers==1.3.1
 django-rest-auth[with_social]==0.9.2 


### PR DESCRIPTION
Fixes #2341 
Updated `djangorestframework` from `3.7.7` to `3.9.3`.