### PR TITLE
Sort leaderboard entries in descending order by created_at

### DIFF
--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -461,7 +461,7 @@ def leaderboard(request, challenge_phase_split_id):
         challenge_phase_split=challenge_phase_split,
         submission__is_flagged=False,
         submission__status=Submission.FINISHED,
-    ).order_by("created_at")
+    ).order_by("-created_at")
 
     leaderboard_data = leaderboard_data.annotate(
         filtering_score=RawSQL(


### PR DESCRIPTION
**Why is this needed?**
So, we now have `error bars` to be displayed on the leaderboard and hence after re-running the submissions the accuracy is same but the leaderboard is taking old result values which don't contain the error bars value.
Hence, we're sorting it in descending order of `created by`.