### PR TITLE
Add allowed hosts for the surge demo

### DIFF
--- a/settings/staging.py
+++ b/settings/staging.py
@@ -1,6 +1,6 @@
 from .prod import *  # noqa: ignore=F405
 
-ALLOWED_HOSTS = ["staging-evalai.cloudcv.org"]
+ALLOWED_HOSTS = ["staging-evalai.cloudcv.org", ".surge.sh"]
 
 CORS_ORIGIN_ALLOW_ALL = False
 


### PR DESCRIPTION
This PR adds `.surge.sh` in allowed hosts for EvalAI-ngx demos.
