### PR TITLE
Fix field error of invalid lookup icontains in 'admin/challenges/challenge`

### DIFF
--- a/apps/challenges/admin.py
+++ b/apps/challenges/admin.py
@@ -43,7 +43,7 @@ class ChallengeAdmin(ImportExportTimeStampedAdmin):
         "start_date",
         "end_date",
     )
-    search_fields = ("title", "creator", "creator__team_name", "slug")
+    search_fields = ("title", "creator__team_name", "slug")
 
 
 @admin.register(ChallengeConfiguration)


### PR DESCRIPTION
**Issue:**

Field error while searching in the challenge admin

**Issue:**

Removed the `ForeignKey` field from the Challenge Admin `search_fields`

