### PR TITLE
Add is_flagged field in ChallengeSubmissionManagementSerializer

### DIFF
--- a/apps/jobs/serializers.py
+++ b/apps/jobs/serializers.py
@@ -102,6 +102,7 @@ class ChallengeSubmissionManagementSerializer(serializers.ModelSerializer):
             "created_by",
             "status",
             "is_public",
+            "is_flagged",
             "submission_number",
             "submitted_at",
             "execution_time",

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -2972,6 +2972,7 @@ class GetAllSubmissionsTest(BaseAPITestClass):
                 project_url="http://testserver2/",
                 publication_url="http://testserver2/",
                 is_public=True,
+                is_flagged=True,
             )
 
         with self.settings(MEDIA_ROOT="/tmp/evalai"):
@@ -2990,6 +2991,7 @@ class GetAllSubmissionsTest(BaseAPITestClass):
                 project_url="http://testserver3/",
                 publication_url="http://testserver3/",
                 is_public=True,
+                is_flagged=True,
             )
 
         self.client.force_authenticate(user=self.user6)
@@ -3055,6 +3057,7 @@ class GetAllSubmissionsTest(BaseAPITestClass):
                     "created_by": submission.created_by.username,
                     "status": submission.status,
                     "is_public": submission.is_public,
+                    "is_flagged": submission.is_flagged,
                     "submission_number": submission.submission_number,
                     "submitted_at": "{0}{1}".format(
                         submission.submitted_at.isoformat(), "Z"


### PR DESCRIPTION
- To get `is_flagged` field when we load all the submissions under view all submissions tab, added `is_flagged` field in `ChallengeSubmissionManagementSerializer`
