### PR TITLE
Fix error response case when returning the selected phase in leaderboard page and a typo in get_or_update_challenge_phase_split API

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -1571,7 +1571,7 @@ def get_or_update_challenge_phase_split(request, challenge_phase_split_pk):
             serializer.save()
             response_data = serializer.data
             return Response(response_data, status=status.HTTP_200_OK)
-        return Response(serializer.erros, status=status.HTTP_400_BAD_REQUEST)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     if request.method == "GET":
         serializer = ZipChallengePhaseSplitSerializer(challenge_phase_split)

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -580,8 +580,11 @@
                 onSuccess: function (response) {
                     vm.selectedPhaseSplit = response.data;
                 },
-                onError: function () {
+                onError: function (response) {
+                    var error = response.data;
                     vm.stopLoader();
+                    $rootScope.notify("error", error);
+                    return false;
                 }
             };
             utilities.sendRequest(parameters);

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -580,9 +580,7 @@
                 onSuccess: function (response) {
                     vm.selectedPhaseSplit = response.data;
                 },
-                onError: function (response) {
-                    var error = response.data;
-                    vm.leaderboard.error = error;
+                onError: function () {
                     vm.stopLoader();
                 }
             };


### PR DESCRIPTION
**Issue:**

This line (https://github.com/Cloud-CV/EvalAI/blob/master/frontend/src/js/controllers/challengeCtrl.js#L585) will give error as the leaderboard variable isn't defined yet. This PR will fix this issue.

Also a type in `get_or_update_challenge_phase_split` API

**Fix:**

Removed the line of setting the error to controller leaderboard variable as it is not yet initialized.

