### PR TITLE
Fix code coverage for front-end tests

### DIFF
--- a/frontend/tests/controllers-test/ChallengeInviteCtrl.test.js
+++ b/frontend/tests/controllers-test/ChallengeInviteCtrl.test.js
@@ -15,7 +15,7 @@ describe('Unit tests for challenge invite controller', function () {
         createController = function () {
             return $controller('ChallengeInviteCtrl', {$scope: $scope});
         };
-        vm = createController();
+        vm = $controller('ChallengeInviteCtrl', { $scope: $scope });
     }));
 
     describe('Unit tests for registerChallengeParticipant function \

--- a/frontend/tests/controllers-test/SubmissionFilesCtrl.test.js
+++ b/frontend/tests/controllers-test/SubmissionFilesCtrl.test.js
@@ -16,7 +16,7 @@ describe('Unit tests for submission files controller', function () {
         createController = function () {
             return $controller('SubmissionFilesCtrl', {$scope: $scope});
         };
-        vm = createController();
+        vm = $controller('SubmissionFilesCtrl', { $scope: $scope });
     }));
 
     describe('Global variables', function () {

--- a/frontend/tests/controllers-test/analyticsCtrl.test.js
+++ b/frontend/tests/controllers-test/analyticsCtrl.test.js
@@ -138,7 +138,7 @@ describe('Unit tests for analytics controller', function() {
 	});
 
 	describe('Unit tests for `showChallengeAnalysis` function', function() {
-		var phaseDetailsSuccess, currentPhaseDetailsSuccess, teamsCountSuccess, success;
+		var phaseDetailsSuccess, currentPhaseDetailsSuccess, teamsCountSuccess;
 		var successResponse, participantTeamCount = 10;
 		var status;
 

--- a/frontend/tests/controllers-test/analyticsCtrl.test.js
+++ b/frontend/tests/controllers-test/analyticsCtrl.test.js
@@ -15,7 +15,7 @@ describe('Unit tests for analytics controller', function() {
         createController = function () {
         	return $controller('AnalyticsCtrl', { $scope: $scope });
         };
-        vm = createController();
+        vm = $controller('AnalyticsCtrl', { $scope: $scope });
 	}));
 
 	describe('Global Variables', function() {

--- a/frontend/tests/controllers-test/analyticsCtrl.test.js
+++ b/frontend/tests/controllers-test/analyticsCtrl.test.js
@@ -137,54 +137,178 @@ describe('Unit tests for analytics controller', function() {
 		});
 	});
 
-	describe('Unit tests for `showChallengeAnalysis` function `challenges/challenge/<challenge_id>/challenge_phase`', function() {
-		var success, participant_team_count = 10;
+	describe('Unit tests for `showChallengeAnalysis` function', function() {
+		var phaseDetailsSuccess, currentPhaseDetailsSuccess, teamsCountSuccess, success;
+		var successResponse, participantTeamCount = 10;
+		var status;
 
 		beforeEach(function() {
+			spyOn(window, 'alert');
+			spyOn(utilities, 'resetStorage');
+			spyOn($state, 'go');
+
             utilities.sendRequest = function(parameters) {
-                if (success) {
-                    parameters.callback.onSuccess({
-                    	status: 200,
-                    	data: {
-                    		participant_team_count: participant_team_count,
-                    		results: {
-                    			id: 4,
-                    			name: "test-dev",
-                    			description: "this is test-dev description"
-                    		}
-                    	}
-                    });
+				if ((phaseDetailsSuccess && parameters.url === 'challenges/challenge/2/challenge_phase') ||
+				(teamsCountSuccess && parameters.url === 'analytics/challenge/2/team/count') ||
+				(currentPhaseDetailsSuccess && parameters.url === 'analytics/challenge/2/challenge_phase/4/analytics')) {
+					parameters.callback.onSuccess({
+						status: 200,
+						data: successResponse
+					});
                 } else {
-                    parameters.callback.onError({
-                    	status: 403,
-                    	data: 'error',
-                    });
+					parameters.callback.onError({
+						status: status,
+						data: 'error'
+					});
                 }
             };
-        });
+		});
 
-        it('null challengeId', function() {
-        	success = false;
-        	vm.showChallengeAnalysis();
-        	expect(vm.challengeId).toEqual(null);
-        	expect(vm.isTeamSelected).toEqual(false);
-        });
-
-		it('backend error', function() {
-			success = false;
+		it('when challenge Id is null', function() {
+			phaseDetailsSuccess = null;
+			teamsCountSuccess = null;
+			currentPhaseDetailsSuccess = null;
+			vm.challengeId = null;
+			vm.showChallengeAnalysis();
+			expect(vm.isTeamSelected).toEqual(false);
+		});
+		
+		it('on success `challenges/challenge/<challenge_id>/challenge_phase`', function() {
+			phaseDetailsSuccess = true;
+			teamsCountSuccess = null;
+			currentPhaseDetailsSuccess = null;
 			vm.challengeId = 2;
+			successResponse = {
+				'participant_team_count': participantTeamCount,
+				'results': {
+					id: 4,
+					name: "test-dev",
+					description: "this is test-dev description"
+				}
+			}
 			vm.showChallengeAnalysis();
 			expect(vm.isTeamSelected).toEqual(true);
+		});
+
+		it('backend error with status 403 `challenges/challenge/<challenge_id>/challenge_phase`', function() {
+			phaseDetailsSuccess = false;
+			teamsCountSuccess = null;
+			currentPhaseDetailsSuccess = null;
+			status = 403;
+			vm.challengeId = 2;
+			successResponse = {
+				'participant_team_count': participantTeamCount,
+				'results': {
+					id: 4,
+					name: "test-dev",
+					description: "this is test-dev description"
+				}
+			}
+			vm.showChallengeAnalysis();
 			expect(vm.error).toEqual('error');
 		});
 
-		it('on success', function() {
-			success = true;
-			vm.showChallengeAnalysis();
+		it('backend error with status 401 `challenges/challenge/<challenge_id>/challenge_phase`', function() {
+			phaseDetailsSuccess = false;
+			teamsCountSuccess = null;
+			currentPhaseDetailsSuccess = null;
+			status = 401;
 			vm.challengeId = 2;
+			successResponse = {
+				'participant_team_count': participantTeamCount,
+				'results': {
+					id: 4,
+					name: "test-dev",
+					description: "this is test-dev description"
+				}
+			}
+			vm.showChallengeAnalysis();
+			expect(window.alert).toHaveBeenCalledWith('Timeout, Please login again to continue!');
+			expect(utilities.resetStorage).toHaveBeenCalled();
+			expect($state.go).toHaveBeenCalledWith('auth.login');
+			expect($rootScope.isAuth).toBeFalsy();
+		});
+
+		it('on success `analytics/challenge/<challenge_id>/team/count`', function() {
+			phaseDetailsSuccess = true;
+			teamsCountSuccess = true;
+			currentPhaseDetailsSuccess = null;
+			vm.challengeId = 2;
+			successResponse = {
+				'participant_team_count': participantTeamCount,
+				'results': {
+					id: 4,
+					name: "test-dev",
+					description: "this is test-dev description"
+				}
+			}
 			vm.showChallengeAnalysis();
 			expect(vm.isTeamSelected).toEqual(true);
-			expect(vm.totalChallengeTeams).toEqual(participant_team_count);
+			expect(vm.totalChallengeTeams).toEqual(participantTeamCount);
+		});
+
+		it('backend error with status 403 `analytics/challenge/<challenge_id>/team/count`', function() {
+			phaseDetailsSuccess = true;
+			teamsCountSuccess = false;
+			currentPhaseDetailsSuccess = null;
+			status = 403;
+			vm.challengeId = 2;
+			successResponse = {
+				'participant_team_count': participantTeamCount,
+				'results': {
+					id: 4,
+					name: "test-dev",
+					description: "this is test-dev description"
+				}
+			}
+			vm.showChallengeAnalysis();
+			expect(vm.error).toEqual('error');
+		});
+
+		it('backend error with status 401 `analytics/challenge/<challenge_id>/team/count`', function() {
+			phaseDetailsSuccess = true;
+			teamsCountSuccess = false;
+			currentPhaseDetailsSuccess = null;
+			status = 401;
+			vm.challengeId = 2;
+			successResponse = {
+				'participant_team_count': participantTeamCount,
+				'results': {
+					id: 4,
+					name: "test-dev",
+					description: "this is test-dev description"
+				}
+			}
+			vm.showChallengeAnalysis();
+			expect(window.alert).toHaveBeenCalledWith('Timeout, Please login again to continue!');
+			expect(utilities.resetStorage).toHaveBeenCalled();
+			expect($state.go).toHaveBeenCalledWith('auth.login');
+			expect($rootScope.isAuth).toBeFalsy();
+		});
+
+		it('backend error `analytics/challenge/<challenge_id>/challenge_phase/<current_phase_id>/analytics`',
+		function() {
+			phaseDetailsSuccess = true;
+			teamsCountSuccess = true;
+			currentPhaseDetailsSuccess = false;
+			status = 401;
+			vm.challengeId = 2;
+			successResponse = {
+				'participant_team_count': participantTeamCount,
+				'results': [
+					{
+						id: 4,
+						name: "test-dev",
+						description: "this is test-dev description"
+					}
+				]
+			}
+			vm.showChallengeAnalysis();
+			expect(vm.currentPhase).toEqual(successResponse.results);
+			expect(window.alert).toHaveBeenCalledWith('Timeout, Please login again to continue!');
+			expect(utilities.resetStorage).toHaveBeenCalled();
+			expect($state.go).toHaveBeenCalledWith('auth.login');
+			expect($rootScope.isAuth).toBeFalsy();
 		});
 	});
 });

--- a/frontend/tests/controllers-test/challengeHostTeamsCtrl.test.js
+++ b/frontend/tests/controllers-test/challengeHostTeamsCtrl.test.js
@@ -20,7 +20,7 @@ describe('Unit tests for challenge host team controller', function () {
         createController = function () {
             return $controller('ChallengeHostTeamsCtrl', {$scope: $scope});
         };
-        vm = createController();
+        vm = $controller('ChallengeHostTeamsCtrl', { $scope: $scope });
     }));
 
     describe('Global variables', function () {

--- a/frontend/tests/controllers-test/challengeListCtrl.test.js
+++ b/frontend/tests/controllers-test/challengeListCtrl.test.js
@@ -14,7 +14,7 @@ describe('Unit tests for challenge list controller', function () {
         createController = function () {
             return $controller('ChallengeListCtrl', {$scope: $scope});
         };
-        vm = createController();
+        vm = $controller('ChallengeListCtrl', { $scope: $scope });
     }));
 
     describe('Global variables', function () {

--- a/frontend/tests/controllers-test/changePwdCtrl.test.js
+++ b/frontend/tests/controllers-test/changePwdCtrl.test.js
@@ -15,7 +15,7 @@ describe('Unit tests for change password controller', function () {
         createController = function () {
             return $controller('ChangePwdCtrl', {$scope: $scope});
         };
-        vm = createController();
+        vm = $controller('ChangePwdCtrl', { $scope: $scope });
     }));
     
     describe('Global variables', function () {

--- a/frontend/tests/controllers-test/contactUsCtrl.test.js
+++ b/frontend/tests/controllers-test/contactUsCtrl.test.js
@@ -15,7 +15,7 @@ describe('Unit tests for ContactUs Controller', function () {
         createController = function () {
             return $controller('contactUsCtrl', {$scope: $scope});
         };
-        vm = createController();
+        vm = $controller('contactUsCtrl', { $scope: $scope });
     }));
 
     describe('Global variables', function () {

--- a/frontend/tests/controllers-test/dashCtrl.test.js
+++ b/frontend/tests/controllers-test/dashCtrl.test.js
@@ -15,7 +15,7 @@ describe('Unit tests for dashboard controller', function () {
         createController = function () {
             return $controller('DashCtrl', {$scope: $scope});
         };
-        vm = createController();
+        vm = $controller('DashCtrl', { $scope: $scope });
     }));
 
     describe('Global variables', function () {

--- a/frontend/tests/controllers-test/featuredChallengeCtrl.test.js
+++ b/frontend/tests/controllers-test/featuredChallengeCtrl.test.js
@@ -16,7 +16,7 @@ describe('Unit tests for featured challenge controller', function () {
         createController = function () {
             return $controller('FeaturedChallengeCtrl', {$scope: $scope});
         };
-        vm = createController();
+        vm = $controller('FeaturedChallengeCtrl', { $scope: $scope });
     }));
 
     describe('Global variables', function () {

--- a/frontend/tests/controllers-test/hostedChallengeCtrl.test.js
+++ b/frontend/tests/controllers-test/hostedChallengeCtrl.test.js
@@ -14,7 +14,7 @@ describe('Unit tests for hosted challenge controller', function () {
         createController = function () {
             return $controller('HostedChallengesCtrl', {$scope: $scope});
         };
-        vm = createController();
+        vm = $controller('HostedChallengesCtrl', { $scope: $scope });
     }));
 
     describe('Global variables', function () {

--- a/frontend/tests/controllers-test/mainCtrl.test.js
+++ b/frontend/tests/controllers-test/mainCtrl.test.js
@@ -15,7 +15,7 @@ describe('Unit tests for main controller', function () {
         createController = function () {
             return $controller('MainCtrl', {$scope: $scope});
         };
-        vm = createController();
+        vm = $controller('MainCtrl', { $scope: $scope });
     }));
 
     describe('Global variables', function () {

--- a/frontend/tests/controllers-test/ourteamCtrl.test.js
+++ b/frontend/tests/controllers-test/ourteamCtrl.test.js
@@ -14,7 +14,7 @@ describe('Unit tests for OurTeam Controller', function () {
         createController = function () {
             return $controller('ourTeamCtrl', {$scope: $scope});
         };
-        vm = createController();
+        vm = $controller('ourTeamCtrl', { $scope: $scope });
     }));
 
     describe('Unit tests for global backend call for listing the team `web/team/`', function () {

--- a/frontend/tests/controllers-test/permissionCtrl.test.js
+++ b/frontend/tests/controllers-test/permissionCtrl.test.js
@@ -14,6 +14,7 @@ describe('Unit tests for permission controller', function () {
         createController = function () {
             return $controller('PermCtrl', {$scope: $scope});
         };
+        vm = $controller('PermCtrl', { $scope: $scope });
     }));
 
     describe('Global variables', function () {

--- a/frontend/tests/controllers-test/profileCtrl.test.js
+++ b/frontend/tests/controllers-test/profileCtrl.test.js
@@ -15,7 +15,7 @@ describe('Unit tests for profile controller', function () {
         createController = function () {
             return $controller('profileCtrl', {$scope: $scope});
         };
-        vm = createController();
+        vm = $controller('profileCtrl', { $scope: $scope });
     }));
 
     describe('Global variables', function () {

--- a/frontend/tests/controllers-test/teamsCtrl.test.js
+++ b/frontend/tests/controllers-test/teamsCtrl.test.js
@@ -18,7 +18,7 @@ describe('Unit tests for teams controller', function () {
         createController = function () {
             return $controller('TeamsCtrl', {$scope: $scope});
         };
-        vm = createController();
+        vm = $controller('TeamsCtrl', { $scope: $scope });
     }));
 
     describe('Global variables', function () {

--- a/frontend/tests/controllers-test/webCtrl.test.js
+++ b/frontend/tests/controllers-test/webCtrl.test.js
@@ -16,6 +16,7 @@ describe('Unit tests for web controller', function () {
         createController = function () {
             return $controller('WebCtrl', {$scope: $scope});
         };
+        vm = $controller('WebCtrl', { $scope: $scope });
         utilities.storeData('userKey', 'encrypted');
     }));
 


### PR DESCRIPTION
This PR increases the code coverage for front-end tests

#### Changes proposed:

- Changed the way of initializing the controller, instead of calling through function, called directly at the start.

- Increased the coverage for `analyticsCtrl` by adding some more tests.