### PR TITLE
Add feature to export field affiliation in the csv for each of the participant under view all submissions

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -1308,8 +1308,6 @@ def download_all_submissions(
                     ]
                 )
                 for submission in submissions.data:
-                    for user in submission["participant_team_members_affiliations"]:
-                        print(user)
                     writer.writerow(
                         [
                             submission["id"],

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -1293,6 +1293,7 @@ def download_all_submissions(
                         "Team Name",
                         "Team Members",
                         "Team Members Email Id",
+                        "Team Members Affiliaton",
                         "Challenge Phase",
                         "Status",
                         "Created By",
@@ -1307,6 +1308,8 @@ def download_all_submissions(
                     ]
                 )
                 for submission in submissions.data:
+                    for user in submission["participant_team_members_affiliations"]:
+                        print(user)
                     writer.writerow(
                         [
                             submission["id"],
@@ -1320,6 +1323,12 @@ def download_all_submissions(
                             ",".join(
                                 email["email"]
                                 for email in submission["participant_team_members"]
+                            ),
+                            ",".join(
+                                affiliation
+                                for affiliation in submission[
+                                    "participant_team_members_affiliations"
+                                ]
                             ),
                             submission["challenge_phase"],
                             submission["status"],
@@ -1402,6 +1411,7 @@ def download_all_submissions(
                     'participant_team': 'Team Name',
                     'participant_team_members': 'Team Members',
                     'participant_team_members_email': 'Team Members Email Id',
+                    'participant_team_members_affiliation': 'Team Members Affiliation',
                     'challenge_phase': 'Challenge Phase',
                     'status': 'Status',
                     'created_by': 'Created By',
@@ -1441,6 +1451,13 @@ def download_all_submissions(
                                 ",".join(
                                     email['email']
                                     for email in submission['participant_team_members']
+                                )
+                            )
+                        elif field == 'participant_team_members_affiliation':
+                            row.append(
+                                ",".join(
+                                    affiliation
+                                    for affiliation in submission['participant_team_members_affiliations']
                                 )
                             )
                         elif field == 'created_at':

--- a/apps/jobs/serializers.py
+++ b/apps/jobs/serializers.py
@@ -90,6 +90,7 @@ class ChallengeSubmissionManagementSerializer(serializers.ModelSerializer):
     challenge_phase = serializers.SerializerMethodField()
     created_by = serializers.SerializerMethodField()
     participant_team_members_email_ids = serializers.SerializerMethodField()
+    participant_team_members_affiliations = serializers.SerializerMethodField()
     created_at = serializers.SerializerMethodField()
     participant_team_members = serializers.SerializerMethodField()
 
@@ -112,6 +113,7 @@ class ChallengeSubmissionManagementSerializer(serializers.ModelSerializer):
             "submission_result_file",
             "submission_metadata_file",
             "participant_team_members_email_ids",
+            "participant_team_members_affiliations",
             "created_at",
             "method_name",
             "participant_team_members",
@@ -162,6 +164,25 @@ class ChallengeSubmissionManagementSerializer(serializers.ModelSerializer):
                 "username", "email"
             )
         )
+
+    def get_participant_team_members_affiliations(self, obj):
+        try:
+            participant_team = ParticipantTeam.objects.get(
+                team_name=obj.participant_team.team_name
+            )
+        except ParticipantTeam.DoesNotExist:
+            return "Participant team does not exist"
+
+        participant_ids = Participant.objects.filter(
+            team=participant_team
+        ).values_list("user_id", flat=True)
+        users = User.objects.filter(id__in=participant_ids)
+        participant_team_members_affiliation = list()
+        for user in users:
+            participant_team_members_affiliation.append(
+                user.profile.affiliation
+            )
+        return participant_team_members_affiliation
 
 
 class SubmissionCount(object):

--- a/apps/jobs/serializers.py
+++ b/apps/jobs/serializers.py
@@ -177,14 +177,7 @@ class ChallengeSubmissionManagementSerializer(serializers.ModelSerializer):
             team=participant_team
         ).values_list("user_id", flat=True)
         users = User.objects.filter(id__in=participant_ids)
-        participant_team_members_affiliation = list()
-        for user in users:
-            if user.profile.affiliation == "":
-                affiliation = "None"
-            else:
-                affiliation = user.profile.affiliation
-            participant_team_members_affiliation.append(affiliation)
-        return participant_team_members_affiliation
+        return [user.profile.affiliation for user in users]
 
 
 class SubmissionCount(object):

--- a/apps/jobs/serializers.py
+++ b/apps/jobs/serializers.py
@@ -179,9 +179,11 @@ class ChallengeSubmissionManagementSerializer(serializers.ModelSerializer):
         users = User.objects.filter(id__in=participant_ids)
         participant_team_members_affiliation = list()
         for user in users:
-            participant_team_members_affiliation.append(
-                user.profile.affiliation
-            )
+            if user.profile.affiliation == "":
+                affiliation = "None"
+            else:
+                affiliation = user.profile.affiliation
+            participant_team_members_affiliation.append(affiliation)
         return participant_team_members_affiliation
 
 

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -1300,6 +1300,9 @@
             'label': 'Team Members Email Id',
             'id': 'participant_team_members_email' 
         },{
+            'label': 'Team Members Affiliation',
+            'id': 'participant_team_members_affiliation' 
+        },{
             'label': 'Challenge Phase',
             'id': 'challenge_phase' 
         },{

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -3085,7 +3085,7 @@ class GetAllSubmissionsTest(BaseAPITestClass):
                     "submission_result_file": None,
                     "submission_metadata_file": None,
                     "participant_team_members_email_ids": ["user6@test.com"],
-                    "participant_team_members_affiliations": ["participants affiliation"],
+                    "participant_team_members_affiliations": ["None"],
                     "participant_team_members": [
                         {"username": "participant", "email": "user6@test.com"}
                     ],

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -3085,6 +3085,7 @@ class GetAllSubmissionsTest(BaseAPITestClass):
                     "submission_result_file": None,
                     "submission_metadata_file": None,
                     "participant_team_members_email_ids": ["user6@test.com"],
+                    "participant_team_members_affiliations": ["participants affiliation"],
                     "participant_team_members": [
                         {"username": "participant", "email": "user6@test.com"}
                     ],

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -3085,7 +3085,7 @@ class GetAllSubmissionsTest(BaseAPITestClass):
                     "submission_result_file": None,
                     "submission_metadata_file": None,
                     "participant_team_members_email_ids": ["user6@test.com"],
-                    "participant_team_members_affiliations": ["None"],
+                    "participant_team_members_affiliations": [""],
                     "participant_team_members": [
                         {"username": "participant", "email": "user6@test.com"}
                     ],


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Added new function in `ChallengeSubmissionManagementSerializer` to get all the participants affiliation.

- Updated tests and also the API for download submission data API with the field affiliation.

