### PR TITLE
Fix issue of showing error message when selecting phase in leader-board as a anonymous user

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -1573,7 +1573,7 @@ def create_challenge_phase_split(request):
 
 @api_view(["GET", "PATCH"])
 @throttle_classes([UserRateThrottle])
-@permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))
+@permission_classes((permissions.IsAuthenticatedOrReadOnly, HasVerifiedEmail))
 @authentication_classes((ExpiringTokenAuthentication,))
 def get_or_update_challenge_phase_split(request, challenge_phase_split_pk):
     """


### PR DESCRIPTION
**Issue:**

Getting error when accessing leader-board as a anonymous user

**Fix:**

- Changed the permissions of API `get_or_update_challenge_phase_split` to `read or authenticated`.

