### PR TITLE
Fix #2443, Update submission tests

### DIFF
--- a/apps/jobs/utils.py
+++ b/apps/jobs/utils.py
@@ -140,7 +140,7 @@ def get_remaining_submission_for_a_phase(
 
 def is_url_possible(url):
     """ Uses urllib.urlparse to determine whether a string qualifies as a valid URL string """
-    o = urlparse(string)
+    o = urlparse(url)
     if o.scheme and o.netloc:
         return True
     return False

--- a/apps/jobs/utils.py
+++ b/apps/jobs/utils.py
@@ -9,6 +9,7 @@ from challenges.utils import get_challenge_model, get_challenge_phase_model
 from django.utils import timezone
 from participants.utils import get_participant_team_id_of_user_for_a_challenge
 from rest_framework import status
+from urllib.parse import urlparse
 from .constants import submission_status_to_exclude
 from .models import Submission
 
@@ -135,6 +136,14 @@ def get_remaining_submission_for_a_phase(
             "remaining_submissions_count": remaining_submission_count,
         }
         return response_data, status.HTTP_200_OK
+
+
+def is_url_possible(url):
+    """ Uses urllib.urlparse to determine whether a string qualifies as a valid URL string """
+    o = urlparse(string)
+    if o.scheme and o.netloc:
+        return True
+    return False
 
 
 def is_url_valid(url):

--- a/apps/jobs/utils.py
+++ b/apps/jobs/utils.py
@@ -9,7 +9,6 @@ from challenges.utils import get_challenge_model, get_challenge_phase_model
 from django.utils import timezone
 from participants.utils import get_participant_team_id_of_user_for_a_challenge
 from rest_framework import status
-from urllib.parse import urlparse
 from .constants import submission_status_to_exclude
 from .models import Submission
 
@@ -136,14 +135,6 @@ def get_remaining_submission_for_a_phase(
             "remaining_submissions_count": remaining_submission_count,
         }
         return response_data, status.HTTP_200_OK
-
-
-def is_url_possible(url):
-    """ Uses urllib.urlparse to determine whether a string qualifies as a valid URL string """
-    o = urlparse(url)
-    if o.scheme and o.netloc:
-        return True
-    return False
 
 
 def is_url_valid(url):

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -64,7 +64,6 @@ from .tasks import download_file_and_publish_submission_message
 from .utils import (
     get_submission_model,
     get_remaining_submission_for_a_phase,
-    is_url_possible,
     is_url_valid
 )
 

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -64,6 +64,7 @@ from .tasks import download_file_and_publish_submission_message
 from .utils import (
     get_submission_model,
     get_remaining_submission_for_a_phase,
+    is_url_possible,
     is_url_valid
 )
 
@@ -246,6 +247,9 @@ def challenge_submission(request, challenge_id, challenge_phase_id):
             )
 
         if not request.FILES:
+            if not is_url_possible(request.data['file_url']):
+                response_data = {'error': 'The file URL submitted is not valid.'}
+                return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
             if not is_url_valid(request.data['file_url']):
                 response_data = {'error': 'The file URL does not exists!'}
                 return Response(response_data, status=status.HTTP_400_BAD_REQUEST)

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -247,22 +247,20 @@ def challenge_submission(request, challenge_id, challenge_phase_id):
             )
 
         if not request.FILES:
-            if not is_url_possible(request.data['file_url']):
-                response_data = {'error': 'The file URL submitted is not valid.'}
-                return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
-            if not is_url_valid(request.data['file_url']):
-                response_data = {'error': 'The file URL does not exists!'}
-                return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
-            download_file_and_publish_submission_message.delay(
-                request.data,
-                request.user.id,
-                request.method,
-                challenge_phase_id
-            )
-            response_data = {
-                'message': 'Please wait while your submission being evaluated!'
-            }
-            return Response(response_data, status=status.HTTP_200_OK)
+            if 'file_url' in request.data.keys:
+                if not is_url_valid(request.data['file_url']):
+                    response_data = {'error': 'The file URL does not exists!'}
+                    return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
+                download_file_and_publish_submission_message.delay(
+                    request.data,
+                    request.user.id,
+                    request.method,
+                    challenge_phase_id
+                )
+                response_data = {
+                    'message': 'Please wait while your submission being evaluated!'
+                }
+                return Response(response_data, status=status.HTTP_200_OK)
         serializer = SubmissionSerializer(
             data=request.data,
             context={

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -246,7 +246,7 @@ def challenge_submission(request, challenge_id, challenge_phase_id):
             )
 
         if not request.FILES:
-            if 'file_url' in request.data.keys:
+            if 'file_url' in request.data.keys():
                 if not is_url_valid(request.data['file_url']):
                     response_data = {'error': 'The file URL does not exists!'}
                     return Response(response_data, status=status.HTTP_400_BAD_REQUEST)

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -497,6 +497,7 @@ class BaseAPITestClass(APITestCase):
             },
         )
 
+        self.challenge.participant_teams.add(self.participant_team)
         self.challenge.banned_email_ids = ["user1@test.com"]
         self.challenge.save()
 
@@ -532,6 +533,7 @@ class BaseAPITestClass(APITestCase):
             {"status": Submission.SUBMITTING, "input_file": self.input_file},
             format="multipart",
         )
+        self.assertEqual(response_1.data, None)
         self.assertEqual(response_1.status_code, status.HTTP_201_CREATED)
         response_2 = self.client.post(
             self.url,
@@ -612,7 +614,7 @@ class BaseAPITestClass(APITestCase):
             response = self.client.post(
                 self.url,
                 {"status": "submitting", "file_url": self.input_file_url},
-                format=multipart,
+                format="multipart",
             )
 
         self.assertEqual(response.data, expected)

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -4,7 +4,6 @@ import mock
 import os
 import shutil
 
-import jobs.tasks
 import jobs.views
 
 from datetime import timedelta
@@ -620,7 +619,7 @@ class BaseAPITestClass(APITestCase):
             'message': 'Please wait while your submission being evaluated!'
         }
 
-        with mock.patch('jobs.tasks.download_file_and_publish_submission_message.delay') as mocked_function:
+        with mock.patch('jobs.views.download_file_and_publish_submission_message.delay') as mocked_function:
             self.input_file_url = "http://testserver/{}".format(self.input_file.name)
 
             response = self.client.post(

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -5,7 +5,7 @@ import os
 import shutil
 
 import jobs.tasks
-import jobs.utils
+import jobs.views
 
 from datetime import timedelta
 
@@ -602,7 +602,7 @@ class BaseAPITestClass(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-    @mock.patch('jobs.utils.is_url_valid', mock.MagicMock(return_value=True))
+    @mock.patch('jobs.views.is_url_valid', mock.MagicMock(return_value=True))
     def test_challenge_submission_for_successful_submission_with_file_url(self):
         self.url = reverse_lazy(
             "jobs:challenge_submission",

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -175,10 +175,6 @@ class BaseAPITestClass(APITestCase):
             "dummy_input.txt", b"file_content", content_type="text/plain"
         )
 
-        self.input_file_2 = SimpleUploadedFile(
-            "dummy_input_2.txt", b"file_content_2", content_type="text/plain"
-        )
-
     def tearDown(self):
         shutil.rmtree("/tmp/evalai")
 
@@ -534,17 +530,9 @@ class BaseAPITestClass(APITestCase):
         self.challenge.participant_teams.add(self.participant_team)
         self.challenge.save()
 
-        response_1 = self.client.post(
+        response = self.client.post(
             self.url,
             {"status": Submission.SUBMITTING, "input_file": self.input_file},
-            format="multipart",
-        )
-        self.assertEqual(response_1.data, None)
-        self.assertEqual(response_1.status_code, status.HTTP_201_CREATED)
-
-        response_2 = self.client.post(
-            self.url,
-            {"status": Submission.SUBMITTING, "input_file": self.input_file_2},
             format="multipart",
         )
 
@@ -554,8 +542,8 @@ class BaseAPITestClass(APITestCase):
             "error" : message
         }
 
-        self.assertEqual(response_2.data, expected)
-        self.assertEqual(response_2.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
         self.challenge_phase.max_concurrent_submissions_allowed = actual_max_concurrent_submissions
         self.challenge_phase.save()
 
@@ -636,7 +624,7 @@ class BaseAPITestClass(APITestCase):
                 request_data_qdict,
                 self.user1.pk,
                 "POST",
-                self.challenge_phase.pk,
+                str(self.challenge_phase.pk),
             )
 
         self.assertEqual(response.data, expected)

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -629,7 +629,7 @@ class BaseAPITestClass(APITestCase):
                 format="multipart",
             )
 
-            request_data_qdict = QueryDict('')
+            request_data_qdict = QueryDict('', mutable=True)
             request_data_qdict.update({"status": "submitting", "file_url": self.input_file_url})
             mocked_function.assert_called_with(
                 request_data_qdict,

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -506,7 +506,7 @@ class BaseAPITestClass(APITestCase):
         response = self.client.post(
             self.url,
             {"status":"submitting", "input_file":self.input_file},
-            format=multipart,
+            format="multipart",
         )
 
         self.assertEqual(response.data, expected)
@@ -607,7 +607,7 @@ class BaseAPITestClass(APITestCase):
         }
 
         with mock.patch('jobs.tasks.download_file_and_publish_submission_message'):
-            self.input_file_url = "http://testserver{}".format(self.input_file.url)
+            self.input_file_url = "http://testserver{}".format(self.input_file.name)
 
             response = self.client.post(
                 self.url,

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -523,7 +523,7 @@ class BaseAPITestClass(APITestCase):
         )
 
         actual_max_concurrent_submissions = self.challenge_phase.max_concurrent_submissions_allowed
-        self.challenge_phase.max_concurrent_submissions_allowed = 1
+        self.challenge_phase.max_concurrent_submissions_allowed = 2
         self.challenge_phase.save()
         self.challenge.participant_teams.add(self.participant_team)
         self.challenge.save()
@@ -541,8 +541,11 @@ class BaseAPITestClass(APITestCase):
             format="multipart",
         )
 
-        expected = {"error" : "You have 1 submissions that are being processed. \
-        Please wait for them to finish and then try again."}
+        message = "You have 2 submissions that are being processed. \
+                   Please wait for them to finish and then try again."
+        expected = {
+            "error" : message
+        }
 
         self.assertEqual(response_2.data, expected)
         self.assertEqual(response_2.status_code, status.HTTP_406_NOT_ACCEPTABLE)
@@ -566,7 +569,9 @@ class BaseAPITestClass(APITestCase):
             format="multipart",
         )
 
-        expected = {"error":"The file URL does not exists!"}
+        expected = {
+            "error":"The file URL does not exists!"
+        }
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -4,8 +4,6 @@ import mock
 import os
 import shutil
 
-import jobs.views
-
 from datetime import timedelta
 
 from django.core.urlresolvers import reverse_lazy
@@ -508,7 +506,7 @@ class BaseAPITestClass(APITestCase):
 
         response = self.client.post(
             self.url,
-            {"status":"submitting", "input_file":self.input_file},
+            {"status": "submitting", "input_file": self.input_file},
             format="multipart",
         )
 
@@ -528,11 +526,11 @@ class BaseAPITestClass(APITestCase):
 
         response = self.client.post(
             self.url,
-            {"status": "submitting", "file_url": "http://www.google.com/secret/dummy_file.txt" },
+            {"status": "submitting", "file_url": "http://www.google.com/secret/dummy_file.txt"},
             format="multipart",
         )
         expected = {
-            "error":"The file URL does not exists!"
+            "error": "The file URL does not exists!"
         }
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -513,7 +513,29 @@ class BaseAPITestClass(APITestCase):
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_challenge_submission_with_url_when_url_is_invalid(self):
+    def test_challenge_submission_with_url_when_url_is_not_possible(self):
+        self.url = reverse_lazy(
+            "jobs:challenge_submission",
+            kwargs={
+                "challenge_id": self.challenge.pk,
+                "challenge_phase_id": self.challenge_phase.pk,
+            },
+        )
+        self.challenge.participant_teams.add(self.participant_team)
+        self.challenge.save()
+
+        response = self.client.post(
+            self.url,
+            {"status": "submitting", "file_url": "http://www/"},
+            format="multipart",
+        )
+        expected = {
+            "error": "The file URL submitted is not valid."
+        }
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_challenge_submission_with_url_when_url_is_unerachable(self):
         self.url = reverse_lazy(
             "jobs:challenge_submission",
             kwargs={

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -4,7 +4,7 @@ import mock
 import os
 import shutil
 
-import apps.jobs.tasks
+import jobs.tasks
 
 from datetime import timedelta
 
@@ -606,7 +606,7 @@ class BaseAPITestClass(APITestCase):
             'message': 'Please wait while your submission being evaluated!'
         }
 
-        with mock.patch('apps.jobs.tasks.download_file_and_publish_submission_message'):
+        with mock.patch('jobs.tasks.download_file_and_publish_submission_message'):
             self.input_file_url = "http://testserver{}".format(self.input_file.url)
 
             response = self.client.post(

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -590,6 +590,53 @@ class BaseAPITestClass(APITestCase):
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_challenge_submission_when_form_encoding_is_wrong(self):
+        self.url = reverse_lazy(
+            "jobs:challenge_submission",
+            kwargs={
+                "challenge_id": self.challenge.pk,
+                "challenge_phase_id": self.challenge_phase.pk,
+            },
+        )
+
+        self.challenge.participant_teams.add(self.participant_team)
+        self.challenge.save()
+
+        expected = {
+            "input_file": [
+                "The submitted data was not a file. Check the encoding type on the form."
+            ]
+        }
+
+        response = self.client.post(
+            self.url, {"status": "submitting", "input_file": self.input_file}
+        )
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+
+
+
+    def test_challenge_submission_when_status_and_file_is_not_submitted(self):
+        self.url = reverse_lazy(
+            "jobs:challenge_submission",
+            kwargs={
+                "challenge_id": self.challenge.pk,
+                "challenge_phase_id": self.challenge_phase.pk,
+            },
+        )
+
+        self.challenge.participant_teams.add(self.participant_team)
+        self.challenge.save()
+
+        expected = {
+            "status": ["This field is required."],
+            "input_file": ["No file was submitted."],
+        }
+
+        response = self.client.post(self.url, {})
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+
 
 class GetChallengeSubmissionTest(BaseAPITestClass):
     def setUp(self):

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -503,7 +503,7 @@ class BaseAPITestClass(APITestCase):
 
         message = "You're a part of Participant Team for Challenge team and it has been banned from this challenge. \
             Please contact the challenge host."
-        expected = {"error":}
+        expected = {"error": message}
 
         response = self.client.post(
             self.url,

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -531,7 +531,6 @@ class BaseAPITestClass(APITestCase):
             {"status": "submitting", "file_url": "http://www.google.com/secret/dummy_file.txt" },
             format="multipart",
         )
-
         expected = {
             "error":"The file URL does not exists!"
         }
@@ -550,13 +549,11 @@ class BaseAPITestClass(APITestCase):
         self.challenge.participant_teams.add(self.participant_team)
         self.challenge.is_docker_based = True
         self.challenge.save()
-
         response = self.client.post(
             self.url,
             {"status": "submitting", "input_file": self.input_file},
             format="multipart",
         )
-
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @mock.patch('jobs.views.is_url_valid', mock.MagicMock(return_value=True))
@@ -572,20 +569,17 @@ class BaseAPITestClass(APITestCase):
         self.challenge.participant_teams.add(self.participant_team)
         self.challenge.save()
 
-
         expected = {
             'message': 'Please wait while your submission being evaluated!'
         }
 
         with mock.patch('jobs.views.download_file_and_publish_submission_message.delay') as mocked_function:
             self.input_file_url = "http://testserver/{}".format(self.input_file.name)
-
             response = self.client.post(
                 self.url,
                 {"status": "submitting", "file_url": self.input_file_url},
                 format="multipart",
             )
-
             request_data_qdict = QueryDict('', mutable=True)
             request_data_qdict.update({"status": "submitting", "file_url": self.input_file_url})
             mocked_function.assert_called_with(

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -5,6 +5,7 @@ import os
 import shutil
 
 import jobs.tasks
+import jobs.utils
 
 from datetime import timedelta
 
@@ -505,7 +506,7 @@ class BaseAPITestClass(APITestCase):
         self.challenge.banned_email_ids = ["user1@test.com"]
         self.challenge.save()
 
-        message = "You're a part of Participant Team for Challenge team and it has been banned from this challenge. \
+        message = "You're a part of Participant Team for Challenge team and it has been banned from this challenge.     \
             Please contact the challenge host."
         expected = {"error": message}
 
@@ -601,6 +602,7 @@ class BaseAPITestClass(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    @mock.patch('jobs.utils.is_url_valid', mock.MagicMock(return_value=True))
     def test_challenge_submission_for_successful_submission_with_file_url(self):
         self.url = reverse_lazy(
             "jobs:challenge_submission",

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -539,6 +539,7 @@ class BaseAPITestClass(APITestCase):
             {"status": Submission.SUBMITTING, "input_file": self.input_file},
             format="multipart",
         )
+        self.assertEqual(response_1.data, None)
         self.assertEqual(response_1.status_code, status.HTTP_201_CREATED)
 
         response_2 = self.client.post(

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 from django.core.urlresolvers import reverse_lazy
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.contrib.auth.models import User
+from django.http import QueryDict
 from django.utils import timezone
 
 from allauth.account.models import EmailAddress
@@ -570,7 +571,7 @@ class BaseAPITestClass(APITestCase):
 
         response = self.client.post(
             self.url,
-            {"status": "submitting", "file_url": "http://www."},
+            {"status": "submitting", "file_url": "http://www.google.com/secret/dummy_file.txt" },
             format="multipart",
         )
 
@@ -627,8 +628,11 @@ class BaseAPITestClass(APITestCase):
                 {"status": "submitting", "file_url": self.input_file_url},
                 format="multipart",
             )
+
+            request_data_qdict = QueryDict('')
+            request_data_qdict.update({"status": "submitting", "file_url": self.input_file_url})
             mocked_function.assert_called_with(
-                {"status": "submitting", "file_url": self.input_file_url},
+                request_data_qdict,
                 self.user1.pk,
                 "POST",
                 self.challenge_phase.pk,

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -501,8 +501,9 @@ class BaseAPITestClass(APITestCase):
         self.challenge.banned_email_ids = ["user1@test.com"]
         self.challenge.save()
 
-        expected = {"error":"You're a part of Participant Team for Challenge team and it has been banned from this challenge. \
-        Please contact the challenge host."}
+        message = "You're a part of Participant Team for Challenge team and it has been banned from this challenge. \
+            Please contact the challenge host."
+        expected = {"error":}
 
         response = self.client.post(
             self.url,

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -513,28 +513,6 @@ class BaseAPITestClass(APITestCase):
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_challenge_submission_with_url_when_url_is_not_possible(self):
-        self.url = reverse_lazy(
-            "jobs:challenge_submission",
-            kwargs={
-                "challenge_id": self.challenge.pk,
-                "challenge_phase_id": self.challenge_phase.pk,
-            },
-        )
-        self.challenge.participant_teams.add(self.participant_team)
-        self.challenge.save()
-
-        response = self.client.post(
-            self.url,
-            {"status": "submitting", "file_url": "http://www/"},
-            format="multipart",
-        )
-        expected = {
-            "error": "The file URL submitted is not valid."
-        }
-        self.assertEqual(response.data, expected)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
     def test_challenge_submission_with_url_when_url_is_unerachable(self):
         self.url = reverse_lazy(
             "jobs:challenge_submission",
@@ -635,8 +613,6 @@ class BaseAPITestClass(APITestCase):
         )
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
-
-
 
     def test_challenge_submission_when_status_and_file_is_not_submitted(self):
         self.url = reverse_lazy(

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -534,8 +534,8 @@ class BaseAPITestClass(APITestCase):
             {"status": Submission.SUBMITTING, "input_file": self.input_file},
             format="multipart",
         )
-        self.assertEqual(response_1.data, None)
         self.assertEqual(response_1.status_code, status.HTTP_201_CREATED)
+
         response_2 = self.client.post(
             self.url,
             {"status": Submission.SUBMITTING, "input_file": self.input_file},
@@ -614,7 +614,7 @@ class BaseAPITestClass(APITestCase):
             'message': 'Please wait while your submission being evaluated!'
         }
 
-        with mock.patch('jobs.tasks.download_file_and_publish_submission_message'):
+        with mock.patch('jobs.tasks.download_file_and_publish_submission_message') as mock:
             self.input_file_url = "http://testserver{}".format(self.input_file.name)
 
             response = self.client.post(

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -515,38 +515,6 @@ class BaseAPITestClass(APITestCase):
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_challenge_submission_when_number_of_concurrent_submissions_greater_than_allowed(self):
-        self.url = reverse_lazy(
-            "jobs:challenge_submission",
-            kwargs={
-                "challenge_id": self.challenge.pk,
-                "challenge_phase_id": self.challenge_phase.pk,
-            },
-        )
-
-        actual_max_concurrent_submissions = self.challenge_phase.max_concurrent_submissions_allowed
-        self.challenge_phase.max_concurrent_submissions_allowed = 1
-        self.challenge_phase.save()
-        self.challenge.participant_teams.add(self.participant_team)
-        self.challenge.save()
-
-        response = self.client.post(
-            self.url,
-            {"status": Submission.SUBMITTING, "input_file": self.input_file},
-            format="multipart",
-        )
-
-        message = "You have 1 submissions that are being processed. \
-                       Please wait for them to finish and then try again."
-        expected = {
-            "error" : message
-        }
-
-        self.assertEqual(response.data, expected)
-        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
-        self.challenge_phase.max_concurrent_submissions_allowed = actual_max_concurrent_submissions
-        self.challenge_phase.save()
-
     def test_challenge_submission_with_url_when_url_is_invalid(self):
         self.url = reverse_lazy(
             "jobs:challenge_submission",


### PR DESCRIPTION
As per #2443

#### CL
* New tests for submission by user who belongs to a banned team.
* New tests for submissions made with URL:
  * When URL is unreachable
  * For successful submission
* Updated tests:
  * When form encoding is wrong
  * When status and file not submitted.

Moved here from https://github.com/Cloud-CV/EvalAI/pull/2470
(Moved changes from `nikochiko:master` to `nikochiko:update-submission-test`)