### PR TITLE
Add check to stop sending invite to participant team if user's email is in blocked email domains

### DIFF
--- a/apps/challenges/utils.py
+++ b/apps/challenges/utils.py
@@ -189,3 +189,20 @@ def create_federated_user(name, repository, aws_keys):
         DurationSeconds=43200,
     )
     return response
+
+
+def check_if_user_is_in_allowed_email_domains(email, challenge_pk):
+    challenge = get_challenge_model(challenge_pk)
+    for domain in challenge.allowed_email_domains:
+        if domain.lower() in email.lower():
+            return True
+    return False
+
+
+def check_if_user_is_in_blocked_email_domains(email, challenge_pk):
+    challenge = get_challenge_model(challenge_pk)
+    for domain in challenge.blocked_email_domains:
+        domain = "@" + domain
+        if domain.lower() in email.lower():
+            return True
+    return False

--- a/apps/challenges/utils.py
+++ b/apps/challenges/utils.py
@@ -191,7 +191,7 @@ def create_federated_user(name, repository, aws_keys):
     return response
 
 
-def check_if_user_is_in_allowed_email_domains(email, challenge_pk):
+def is_user_in_allowed_email_domains(email, challenge_pk):
     challenge = get_challenge_model(challenge_pk)
     for domain in challenge.allowed_email_domains:
         if domain.lower() in email.lower():
@@ -199,7 +199,7 @@ def check_if_user_is_in_allowed_email_domains(email, challenge_pk):
     return False
 
 
-def check_if_user_is_in_blocked_email_domains(email, challenge_pk):
+def is_user_in_blocked_email_domains(email, challenge_pk):
     challenge = get_challenge_model(challenge_pk)
     for domain in challenge.blocked_email_domains:
         domain = "@" + domain

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -52,6 +52,8 @@ from challenges.utils import (
     get_challenge_phase_split_model,
     get_dataset_split_model,
     get_leaderboard_model,
+    check_if_user_is_in_allowed_email_domains,
+    check_if_user_is_in_blocked_email_domains
 )
 from hosts.models import ChallengeHost, ChallengeHostTeam
 from hosts.utils import (
@@ -273,12 +275,7 @@ def add_participant_team_to_challenge(
     # Check if user is in allowed list.
     user_email = request.user.email
     if len(challenge.allowed_email_domains) > 0:
-        present = False
-        for domain in challenge.allowed_email_domains:
-            if domain.lower() in user_email.lower():
-                present = True
-                break
-        if not present:
+        if not check_if_user_is_in_allowed_email_domains(user_email, challenge_pk):
             message = "Sorry, users with {} email domain(s) are only allowed to participate in this challenge."
             domains = ""
             for domain in challenge.allowed_email_domains:
@@ -290,18 +287,16 @@ def add_participant_team_to_challenge(
             )
 
     # Check if user is in blocked list.
-    for domain in challenge.blocked_email_domains:
-        domain = "@" + domain
-        if domain.lower() in user_email.lower():
-            message = "Sorry, users with {} email domain(s) are not allowed to participate in this challenge."
-            domains = ""
-            for domain in challenge.blocked_email_domains:
-                domains = "{}{}{}".format(domains, "/", domain)
-            domains = domains[1:]
-            response_data = {"error": message.format(domains)}
-            return Response(
-                response_data, status=status.HTTP_406_NOT_ACCEPTABLE
-            )
+    if check_if_user_is_in_blocked_email_domains(user_email, challenge_pk):
+        message = "Sorry, users with {} email domain(s) are not allowed to participate in this challenge."
+        domains = ""
+        for domain in challenge.blocked_email_domains:
+            domains = "{}{}{}".format(domains, "/", domain)
+        domains = domains[1:]
+        response_data = {"error": message.format(domains)}
+        return Response(
+            response_data, status=status.HTTP_406_NOT_ACCEPTABLE
+        )
 
     # check to disallow the user if he is a Challenge Host for this challenge
     participant_team_user_ids = set(

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -52,8 +52,8 @@ from challenges.utils import (
     get_challenge_phase_split_model,
     get_dataset_split_model,
     get_leaderboard_model,
-    check_if_user_is_in_allowed_email_domains,
-    check_if_user_is_in_blocked_email_domains
+    is_user_in_allowed_email_domains,
+    is_user_in_blocked_email_domains
 )
 from hosts.models import ChallengeHost, ChallengeHostTeam
 from hosts.utils import (
@@ -275,7 +275,7 @@ def add_participant_team_to_challenge(
     # Check if user is in allowed list.
     user_email = request.user.email
     if len(challenge.allowed_email_domains) > 0:
-        if not check_if_user_is_in_allowed_email_domains(user_email, challenge_pk):
+        if not is_user_in_allowed_email_domains(user_email, challenge_pk):
             message = "Sorry, users with {} email domain(s) are only allowed to participate in this challenge."
             domains = ""
             for domain in challenge.allowed_email_domains:
@@ -287,7 +287,7 @@ def add_participant_team_to_challenge(
             )
 
     # Check if user is in blocked list.
-    if check_if_user_is_in_blocked_email_domains(user_email, challenge_pk):
+    if is_user_in_blocked_email_domains(user_email, challenge_pk):
         message = "Sorry, users with {} email domain(s) are not allowed to participate in this challenge."
         domains = ""
         for domain in challenge.blocked_email_domains:

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -195,10 +195,8 @@ def invite_participant_to_team(request, pk):
                 for participant_email in participant_team.get_all_participants_email():
                     if participant_email in challenge.banned_email_ids:
                         message = "You cannot invite as you're a part of {} team and it has been banned "
-                        "from this challenge. Please contact the challenge host.".format(
-                            participant_team.team_name
-                        )
-                        response_data = {"error": message}
+                        "from this challenge. Please contact the challenge host."
+                        response_data = {"error": message.format(participant_team.team_name)}
                         return Response(
                             response_data, status=status.HTTP_406_NOT_ACCEPTABLE
                         )

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -194,8 +194,8 @@ def invite_participant_to_team(request, pk):
                 # Check if team participants emails are banned
                 for participant_email in participant_team.get_all_participants_email():
                     if participant_email in challenge.banned_email_ids:
-                        message = "You cannot invite as you're a part of {} team and it has been banned \
-                        from this challenge. Please contact the challenge host.".format(
+                        message = "You cannot invite as you're a part of {} team and it has been banned "
+                        "from this challenge. Please contact the challenge host.".format(
                             participant_team.team_name
                         )
                         response_data = {"error": message}
@@ -205,8 +205,8 @@ def invite_participant_to_team(request, pk):
 
                 # Check if invited user is banned
                 if email in challenge.banned_email_ids:
-                    message = "You cannot invite as the invited user has been banned \
-                    from this challenge. Please contact the challenge host."
+                    message = "You cannot invite as the invited user has been banned "
+                    "from this challenge. Please contact the challenge host."
                     response_data = {"error": message}
                     return Response(
                         response_data, status=status.HTTP_406_NOT_ACCEPTABLE

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -206,6 +206,7 @@ def invite_participant_to_team(request, pk):
                             participant_team.team_name
                         )
                         is_user_banned = True
+                        break
 
                 if is_user_banned:
                     response_data = {"error": message}

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -186,6 +186,22 @@ def invite_participant_to_team(request, pk):
         [participant_team]
     ).values_list("id", flat=True)
 
+    if set(invited_user_participated_challenges) & set(
+        team_participated_challenges
+    ):
+        """
+        Check if the user has already participated in
+        challenges where the inviting participant has participated.
+        If this is the case, then the user cannot be invited since
+        he cannot participate in a challenge via two teams.
+        """
+        response_data = {
+            "error": "Sorry, the invited user has already participated"
+            " in atleast one of the challenges which you are already a"
+            " part of. Please try creating a new team and then invite."
+        }
+        return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
+
     if len(team_participated_challenges) > 0:
         for challenge_pk in team_participated_challenges:
             challenge = get_challenge_model(challenge_pk)
@@ -234,22 +250,6 @@ def invite_participant_to_team(request, pk):
                 return Response(
                     response_data, status=status.HTTP_406_NOT_ACCEPTABLE
                 )
-
-    if set(invited_user_participated_challenges) & set(
-        team_participated_challenges
-    ):
-        """
-        Check if the user has already participated in
-        challenges where the inviting participant has participated.
-        If this is the case, then the user cannot be invited since
-        he cannot participate in a challenge via two teams.
-        """
-        response_data = {
-            "error": "Sorry, the invited user has already participated"
-            " in atleast one of the challenges which you are already a"
-            " part of. Please try creating a new team and then invite."
-        }
-        return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     serializer = InviteParticipantToTeamSerializer(
         data=request.data,

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -190,14 +190,7 @@ def invite_participant_to_team(request, pk):
         for challenge_pk in team_participated_challenges:
             challenge = get_challenge_model(challenge_pk)
 
-            is_user_banned = False
             if len(challenge.banned_email_ids) > 0:
-                # Check if invited user is banned
-                if email in challenge.banned_email_ids:
-                    message = "You cannot invite as the invited user has been banned \
-                    from this challenge. Please contact the challenge host."
-                    is_user_banned = True
-
                 # Check if team participants emails are banned
                 for participant_email in participant_team.get_all_participants_email():
                     if participant_email in challenge.banned_email_ids:
@@ -205,10 +198,15 @@ def invite_participant_to_team(request, pk):
                         from this challenge. Please contact the challenge host.".format(
                             participant_team.team_name
                         )
-                        is_user_banned = True
-                        break
+                        response_data = {"error": message}
+                        return Response(
+                            response_data, status=status.HTTP_406_NOT_ACCEPTABLE
+                        )
 
-                if is_user_banned:
+                # Check if invited user is banned
+                if email in challenge.banned_email_ids:
+                    message = "You cannot invite as the invited user has been banned \
+                    from this challenge. Please contact the challenge host."
                     response_data = {"error": message}
                     return Response(
                         response_data, status=status.HTTP_406_NOT_ACCEPTABLE

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -18,8 +18,8 @@ from base.utils import paginated_queryset
 from challenges.models import Challenge
 from challenges.serializers import ChallengeSerializer
 from challenges.utils import (
-    check_if_user_is_in_allowed_email_domains,
-    check_if_user_is_in_blocked_email_domains
+    is_user_in_allowed_email_domains,
+    is_user_in_blocked_email_domains
 )
 from hosts.utils import is_user_a_host_of_challenge
 
@@ -190,7 +190,7 @@ def invite_participant_to_team(request, pk):
             challenge = Challenge.objects.get(pk=challenge_pk)
             # Check if user is in allowed list.
             if len(challenge.allowed_email_domains) > 0:
-                if not check_if_user_is_in_allowed_email_domains(email, challenge_pk):
+                if not is_user_in_allowed_email_domains(email, challenge_pk):
                     message = "Sorry, users with {} email domain(s) are only allowed to participate in this challenge."
                     domains = ""
                     for domain in challenge.allowed_email_domains:
@@ -202,7 +202,7 @@ def invite_participant_to_team(request, pk):
                     )
 
             # Check if user is in blocked list.
-            if check_if_user_is_in_blocked_email_domains(email, challenge_pk):
+            if is_user_in_blocked_email_domains(email, challenge_pk):
                 message = "Sorry, users with {} email domain(s) are not allowed to participate in this challenge."
                 domains = ""
                 for domain in challenge.blocked_email_domains:

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -18,6 +18,7 @@ from base.utils import paginated_queryset
 from challenges.models import Challenge
 from challenges.serializers import ChallengeSerializer
 from challenges.utils import (
+    get_challenge_model,
     is_user_in_allowed_email_domains,
     is_user_in_blocked_email_domains
 )
@@ -187,7 +188,7 @@ def invite_participant_to_team(request, pk):
 
     if len(team_participated_challenges) > 0:
         for challenge_pk in team_participated_challenges:
-            challenge = Challenge.objects.get(pk=challenge_pk)
+            challenge = get_challenge_model(challenge_pk)
             # Check if user is in allowed list.
             if len(challenge.allowed_email_domains) > 0:
                 if not is_user_in_allowed_email_domains(email, challenge_pk):

--- a/tests/unit/participants/test_views.py
+++ b/tests/unit/participants/test_views.py
@@ -399,15 +399,14 @@ class InviteParticipantToTeamTest(BaseAPITestClass):
         )
 
         response = self.client.post(self.url, self.data)
-        message = "You cannot invite as you're a part of {} team and it has been banned \
-        from this challenge. Please contact the challenge host.".format(
-            self.participant_team.team_name
-        )
-        expected = {"error": message}
+        message = "You cannot invite as you're a part of {} team and it has been banned from this challenge. "
+        + "Please contact the challenge host."
+        expected = {"error": message.format(self.participant_team.team_name)}
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
 
     def test_invitation_when_invited_user_is_banned(self):
+        self.challenge.banned_email_ids = []
         self.challenge.banned_email_ids.extend(["other@platform.com", "some@platform.com"])
         self.challenge.save()
         self.url = reverse_lazy(
@@ -418,14 +417,15 @@ class InviteParticipantToTeamTest(BaseAPITestClass):
         )
 
         response = self.client.post(self.url, self.data)
-        message = "You cannot invite as the invited user has been banned \
-        from this challenge. Please contact the challenge host."
+        message = "You cannot invite as the invited user has been banned from this challenge."
+        + " Please contact the challenge host."
         expected = {"error": message}
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
 
     def test_invitation_when_invited_user_is_in_blocked_list(self):
-        self.challenge.blocked_email_domains.extend(["test", "test1"])
+        self.challenge.banned_email_ids = []
+        self.challenge.blocked_email_domains.extend(["platform", "test1"])
         self.challenge.save()
         self.url = reverse_lazy(
             "participants:invite_participant_to_team",
@@ -436,11 +436,13 @@ class InviteParticipantToTeamTest(BaseAPITestClass):
 
         response = self.client.post(self.url, self.data)
         message = "Sorry, users with {} email domain(s) are not allowed to participate in this challenge."
-        expected = {"error": message.format("test/test1")}
+        expected = {"error": message.format("platform/test1")}
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
 
     def test_invitation_when_invited_user_is_not_in_allowed_list(self):
+        self.challenge.banned_email_ids = []
+        self.challenge.blocked_email_domains = []
         self.challenge.allowed_email_domains.extend(["example1", "example2"])
         self.challenge.save()
         self.url = reverse_lazy(

--- a/tests/unit/participants/test_views.py
+++ b/tests/unit/participants/test_views.py
@@ -447,6 +447,7 @@ class InviteParticipantToTeamTest(BaseAPITestClass):
         user2: participant 2
         """
         self.challenge1.allowed_email_domains = []
+        self.challenge1.blocked_email_domains = []
         self.challenge1.save()
         self.user2 = User.objects.create(
             username="user2",

--- a/tests/unit/participants/test_views.py
+++ b/tests/unit/participants/test_views.py
@@ -283,24 +283,6 @@ class InviteParticipantToTeamTest(BaseAPITestClass):
             team_name="Host Team 1", created_by=self.user1
         )
 
-        self.challenge1 = Challenge.objects.create(
-            title="Test Challenge 1",
-            short_description="Short description for test challenge 1",
-            description="Description for test challenge 1",
-            terms_and_conditions="Terms and conditions for test challenge 1",
-            submission_guidelines="Submission guidelines for test challenge 1",
-            creator=self.challenge_host_team,
-            published=False,
-            is_registration_open=True,
-            enable_forum=True,
-            leaderboard_description="Lorem ipsum dolor sit amet, consectetur adipiscing elit",
-            anonymous_leaderboard=False,
-            start_date=timezone.now() - timedelta(days=2),
-            end_date=timezone.now() + timedelta(days=1),
-        )
-
-        self.challenge1.participant_teams.add(self.participant_team1)
-
         self.data = {"email": self.invite_user.email}
         self.url = reverse_lazy(
             "participants:invite_participant_to_team",
@@ -361,9 +343,25 @@ class InviteParticipantToTeamTest(BaseAPITestClass):
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_invitation_when_team_participants_emails_are_banned(self):
-        self.challenge1.banned_email_ids.extend(["user1@platform.com"])
-        self.challenge1.save()
+    def test_invite_when_team_participants_emails_are_banned(self):
+        self.challenge1 = Challenge.objects.create(
+            title="Test Challenge 1",
+            short_description="Short description for test challenge 1",
+            description="Description for test challenge 1",
+            terms_and_conditions="Terms and conditions for test challenge 1",
+            submission_guidelines="Submission guidelines for test challenge 1",
+            creator=self.challenge_host_team,
+            published=False,
+            is_registration_open=True,
+            enable_forum=True,
+            banned_email_ids=["user1@platform.com"],
+            leaderboard_description="Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+            anonymous_leaderboard=False,
+            start_date=timezone.now() - timedelta(days=2),
+            end_date=timezone.now() + timedelta(days=1),
+        )
+
+        self.challenge1.participant_teams.add(self.participant_team1)
         self.data = {"email": self.invite_user.email}
         self.client.force_authenticate(user=self.user1)
         self.url = reverse_lazy(
@@ -380,10 +378,24 @@ class InviteParticipantToTeamTest(BaseAPITestClass):
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
 
-    def test_invitation_when_invited_user_is_banned(self):
-        self.challenge1.banned_email_ids = []
-        self.challenge1.banned_email_ids.extend(["other@platform.com"])
-        self.challenge1.save()
+    def test_invite_when_invited_user_is_banned(self):
+        self.challenge1 = Challenge.objects.create(
+            title="Test Challenge 1",
+            short_description="Short description for test challenge 1",
+            description="Description for test challenge 1",
+            terms_and_conditions="Terms and conditions for test challenge 1",
+            submission_guidelines="Submission guidelines for test challenge 1",
+            creator=self.challenge_host_team,
+            published=False,
+            is_registration_open=True,
+            enable_forum=True,
+            banned_email_ids=["other@platform.com"],
+            leaderboard_description="Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+            anonymous_leaderboard=False,
+            start_date=timezone.now() - timedelta(days=2),
+            end_date=timezone.now() + timedelta(days=1),
+        )
+        self.challenge1.participant_teams.add(self.participant_team1)
         self.data = {"email": self.invite_user.email}
         self.client.force_authenticate(user=self.user1)
         self.url = reverse_lazy(
@@ -399,10 +411,24 @@ class InviteParticipantToTeamTest(BaseAPITestClass):
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
 
-    def test_invitation_when_invited_user_is_in_blocked_domains(self):
-        self.challenge1.banned_email_ids = []
-        self.challenge1.blocked_email_domains.extend(["platform"])
-        self.challenge1.save()
+    def test_invite_when_invited_user_is_in_blocked_domains(self):
+        self.challenge1 = Challenge.objects.create(
+            title="Test Challenge 1",
+            short_description="Short description for test challenge 1",
+            description="Description for test challenge 1",
+            terms_and_conditions="Terms and conditions for test challenge 1",
+            submission_guidelines="Submission guidelines for test challenge 1",
+            creator=self.challenge_host_team,
+            published=False,
+            is_registration_open=True,
+            enable_forum=True,
+            blocked_email_domains=["platform"],
+            leaderboard_description="Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+            anonymous_leaderboard=False,
+            start_date=timezone.now() - timedelta(days=2),
+            end_date=timezone.now() + timedelta(days=1),
+        )
+        self.challenge1.participant_teams.add(self.participant_team1)
         self.data = {"email": self.invite_user.email}
         self.client.force_authenticate(user=self.user1)
         self.url = reverse_lazy(
@@ -418,11 +444,24 @@ class InviteParticipantToTeamTest(BaseAPITestClass):
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
 
-    def test_invitation_when_invited_user_is_not_in_allowed_domains(self):
-        self.challenge1.banned_email_ids = []
-        self.challenge1.blocked_email_domains = []
-        self.challenge1.allowed_email_domains.extend(["example1"])
-        self.challenge1.save()
+    def test_invite_when_invited_user_is_not_in_allowed_domains(self):
+        self.challenge1 = Challenge.objects.create(
+            title="Test Challenge 1",
+            short_description="Short description for test challenge 1",
+            description="Description for test challenge 1",
+            terms_and_conditions="Terms and conditions for test challenge 1",
+            submission_guidelines="Submission guidelines for test challenge 1",
+            creator=self.challenge_host_team,
+            published=False,
+            is_registration_open=True,
+            enable_forum=True,
+            allowed_email_domains=["example1"],
+            leaderboard_description="Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+            anonymous_leaderboard=False,
+            start_date=timezone.now() - timedelta(days=2),
+            end_date=timezone.now() + timedelta(days=1),
+        )
+        self.challenge1.participant_teams.add(self.participant_team1)
         self.data = {"email": self.invite_user.email}
         self.client.force_authenticate(user=self.user1)
         self.url = reverse_lazy(
@@ -446,9 +485,6 @@ class InviteParticipantToTeamTest(BaseAPITestClass):
         user1: participant 1
         user2: participant 2
         """
-        self.challenge1.allowed_email_domains = []
-        self.challenge1.blocked_email_domains = []
-        self.challenge1.save()
         self.user2 = User.objects.create(
             username="user2",
             email="user2@platform.com",


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Added checks in `challenges/utils.py` for `blocked email domains` and `allowed email domains`.
- Updated `add_participant_to_team` with these common checks.
- Added checks in `invite_participant_to_team` api with these checks.
- Added unit tests for the added checks in `participants/test_views.py`

