### PR TITLE
Add test for create_dir_as_python_package

### DIFF
--- a/tests/unit/remoteworker/test_remote_worker.py
+++ b/tests/unit/remoteworker/test_remote_worker.py
@@ -1,8 +1,14 @@
 import mock
+import os
+import shutil
+import tempfile
+
+from os.path import join
 
 from unittest import TestCase
 
 from scripts.workers.remote_submission_worker import (
+    create_dir_as_python_package,
     make_request,
     get_message_from_sqs_queue,
     delete_message_from_sqs_queue,
@@ -141,3 +147,20 @@ class URLFormatTestCase(BaseTestClass):
         expected_url = "http://testserver:80{}".format(url)
         returned_url = return_url_per_environment(url)
         self.assertEqual(returned_url, expected_url)
+
+
+class CreateDirAsPythonPackageTest(BaseTestClass):
+    def setUp(self):
+        super(CreateDirAsPythonPackageTest, self).setUp()
+
+        self.BASE_TEMP_DIR = tempfile.mkdtemp()
+        self.temp_directory = join(self.BASE_TEMP_DIR, "temp_dir")
+
+    def test_create_dir_as_python_package(self):
+        create_dir_as_python_package(self.temp_directory)
+        self.assertTrue(os.path.isfile(join(self.temp_directory, "__init__.py")))
+
+        with open(join(self.temp_directory, "__init__.py")) as f:
+            self.assertEqual(f.read(), "")
+
+        shutil.rmtree(self.temp_directory)

--- a/tests/unit/remoteworker/test_remote_worker.py
+++ b/tests/unit/remoteworker/test_remote_worker.py
@@ -164,3 +164,4 @@ class CreateDirAsPythonPackageTest(BaseTestClass):
             self.assertEqual(f.read(), "")
 
         shutil.rmtree(self.temp_directory)
+        self.assertFalse(os.path.exists(self.temp_directory))


### PR DESCRIPTION
## [The corresponding GCI task](https://codein.withgoogle.com/dashboard/task-instances/6489838874787840/)

## Clarification:
- Add a test to see `test_create_dir_as_python_package(directory)` creates new directory in the path `directory` and new empty file `__init__.py` in the path. 