### PR TITLE
Fix #1705: Add support for editing the challenge start end end date

### DIFF
--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -2058,7 +2058,7 @@
                         }
                     };
                 } else {
-                    $rootScope.notify("error", "The challenge start date is the same or greater than end date.");
+                    $rootScope.notify("error", "The challenge start date cannot be same or greater than end date.");
                 }
                 utilities.showLoader();
                 utilities.sendRequest(parameters);

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -2010,10 +2010,8 @@
 
         // Edit Challenge Start and End Date
         vm.challengeDateDialog = function(ev) {
-            vm.challengeStartDate = vm.page.start_date;
-            vm.challengeStartDate = moment(vm.challengeStartDate);
-            vm.challengeEndDate = vm.page.end_date;
-            vm.challengeEndDate = moment(vm.challengeEndDate);
+            vm.challengeStartDate = moment(vm.page.start_date);
+            vm.challengeEndDate = moment(vm.page.end_date);
             $mdDialog.show({
                 scope: $scope,
                 preserveScope: true,

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -2032,27 +2032,30 @@
                 }
                 parameters.url = "challenges/challenge_host_team/" + vm.challengeHostId + "/challenge/" + vm.challengeId;
                 parameters.method = 'PATCH';
-                parameters.data = {
-                    "start_date": vm.page.start_date,
-                    "end_date": vm.page.end_date,
-                };
-                parameters.callback = {
-                    onSuccess: function(response) {
-                        var status = response.status;
-                        if (status === 200) {
+                if (new Date(vm.page.start_date).valueOf() < new Date(vm.page.end_date).valueOf()) {
+                    parameters.data = {
+                        "start_date": vm.page.start_date,
+                        "end_date": vm.page.end_date,
+                    };
+                    parameters.callback = {
+                        onSuccess: function(response) {
+                            var status = response.status;
+                            if (status === 200) {
+                                $mdDialog.hide();
+                                $rootScope.notify("success", "The challenge start and end date is successfully updated!");
+                            }
+                        },
+                        onError: function(response) {
                             $mdDialog.hide();
-                            $rootScope.notify("success", "The challenge start and end date is successfully updated!");
+                            vm.page.start_date = vm.tempChallengeStartDate;
+                            vm.page.end_date = vm.tempChallengeEndDate;
+                            var error = response.data;
+                            $rootScope.notify("error", error);
                         }
-                    },
-                    onError: function(response) {
-                        $mdDialog.hide();
-                        vm.page.start_date = vm.tempChallengeStartDate;
-                        vm.page.end_date = vm.tempChallengeEndDate;
-                        var error = response.data;
-                        $rootScope.notify("error", error);
-                    }
-                };
-
+                    };
+                } else {
+                    $rootScope.notify("error", "The challenge start date is the same or greater than end date.");
+                }
                 utilities.sendRequest(parameters);
             } else {
                 vm.page.start_date = vm.tempChallengeStartDate;

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -2008,7 +2008,7 @@
             });
         };
 
-        // Edit Challenge Start Date
+        // Edit Challenge Start and End Date
         vm.challengeDateDialog = function(ev) {
             vm.tempChallengeStartDate = vm.page.start_date;
             vm.tempChallengeEndDate = vm.page.end_date;

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -2044,6 +2044,8 @@
                             var status = response.status;
                             utilities.hideLoader();
                             if (status === 200) {
+                                vm.page.start_date = vm.challengeStartDate.format("MMM D, YYYY h:mm:ss A");
+                                vm.page.end_date = vm.challengeEndDate.format("MMM D, YYYY h:mm:ss A");
                                 $mdDialog.hide();
                                 $rootScope.notify("success", "The challenge start and end date is successfully updated!");
                             }

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -2034,7 +2034,7 @@
                 }
                 parameters.url = "challenges/challenge_host_team/" + vm.challengeHostId + "/challenge/" + vm.challengeId;
                 parameters.method = 'PATCH';
-                if (new Date(vm.page.start_date).valueOf() < new Date(vm.page.end_date).valueOf()) {
+                if (new Date(vm.challengeStartDate).valueOf() < new Date(vm.challengeEndDate).valueOf()) {
                     parameters.data = {
                         "start_date": vm.challengeStartDate,
                         "end_date": vm.challengeEndDate

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -2008,6 +2008,59 @@
             });
         };
 
+        // Edit Challenge Start Date
+        vm.challengeDateDialog = function(ev) {
+            vm.tempChallengeStartDate = vm.page.start_date;
+            vm.tempChallengeEndDate = vm.page.end_date;
+            $mdDialog.show({
+                scope: $scope,
+                preserveScope: true,
+                targetEvent: ev,
+                templateUrl: 'dist/views/web/challenge/edit-challenge/edit-challenge-date.html',
+                escapeToClose: false
+            });
+        };
+
+        vm.editChallengeDate = function(editChallengeDateForm) {
+            if (editChallengeDateForm) {
+                var challengeHostList = utilities.getData("challengeCreator");
+                for (var challenge in challengeHostList) {
+                    if (challenge == vm.challengeId) {
+                        vm.challengeHostId = challengeHostList[challenge];
+                        break;
+                    }
+                }
+                parameters.url = "challenges/challenge_host_team/" + vm.challengeHostId + "/challenge/" + vm.challengeId;
+                parameters.method = 'PATCH';
+                parameters.data = {
+                    "start_date": vm.page.start_date,
+                    "end_date": vm.page.end_date,
+                };
+                parameters.callback = {
+                    onSuccess: function(response) {
+                        var status = response.status;
+                        if (status === 200) {
+                            $mdDialog.hide();
+                            $rootScope.notify("success", "The challenge start and end date is successfully updated!");
+                        }
+                    },
+                    onError: function(response) {
+                        $mdDialog.hide();
+                        vm.page.start_date = vm.tempChallengeStartDate;
+                        vm.page.end_date = vm.tempChallengeEndDate;
+                        var error = response.data;
+                        $rootScope.notify("error", error);
+                    }
+                };
+
+                utilities.sendRequest(parameters);
+            } else {
+                vm.page.start_date = vm.tempChallengeStartDate;
+                vm.page.end_date = vm.tempChallengeEndDate;
+                $mdDialog.hide();
+            }
+        };
+
         $scope.$on('$destroy', function() {
             vm.stopFetchingSubmissions();
             vm.stopLeaderboard();

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -2057,11 +2057,11 @@
                             $rootScope.notify("error", error);
                         }
                     };
+                    utilities.showLoader();
+                    utilities.sendRequest(parameters);
                 } else {
                     $rootScope.notify("error", "The challenge start date cannot be same or greater than end date.");
                 }
-                utilities.showLoader();
-                utilities.sendRequest(parameters);
             } else {
                 $mdDialog.hide();
             }

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -2010,8 +2010,10 @@
 
         // Edit Challenge Start and End Date
         vm.challengeDateDialog = function(ev) {
-            vm.tempChallengeStartDate = vm.page.start_date;
-            vm.tempChallengeEndDate = vm.page.end_date;
+            vm.challengeStartDate = vm.page.start_date;
+            vm.challengeStartDate = moment(vm.challengeStartDate);
+            vm.challengeEndDate = vm.page.end_date;
+            vm.challengeEndDate = moment(vm.challengeEndDate);
             $mdDialog.show({
                 scope: $scope,
                 preserveScope: true,
@@ -2034,21 +2036,21 @@
                 parameters.method = 'PATCH';
                 if (new Date(vm.page.start_date).valueOf() < new Date(vm.page.end_date).valueOf()) {
                     parameters.data = {
-                        "start_date": vm.page.start_date,
-                        "end_date": vm.page.end_date,
+                        "start_date": vm.challengeStartDate,
+                        "end_date": vm.challengeEndDate
                     };
                     parameters.callback = {
                         onSuccess: function(response) {
                             var status = response.status;
+                            utilities.hideLoader();
                             if (status === 200) {
                                 $mdDialog.hide();
                                 $rootScope.notify("success", "The challenge start and end date is successfully updated!");
                             }
                         },
                         onError: function(response) {
+                            utilities.hideLoader();
                             $mdDialog.hide();
-                            vm.page.start_date = vm.tempChallengeStartDate;
-                            vm.page.end_date = vm.tempChallengeEndDate;
                             var error = response.data;
                             $rootScope.notify("error", error);
                         }
@@ -2056,10 +2058,9 @@
                 } else {
                     $rootScope.notify("error", "The challenge start date is the same or greater than end date.");
                 }
+                utilities.showLoader();
                 utilities.sendRequest(parameters);
             } else {
-                vm.page.start_date = vm.tempChallengeStartDate;
-                vm.page.end_date = vm.tempChallengeEndDate;
                 $mdDialog.hide();
             }
         };

--- a/frontend/src/views/web/challenge/challenge-page.html
+++ b/frontend/src/views/web/challenge/challenge-page.html
@@ -45,17 +45,24 @@
 
                         <br>
                         <span>
+                            <strong class="text-light-black">Starts on:</strong>
+                            {{ challenge.page.start_date | date:'medium' }}
+                        </span>
+                        &nbsp;
+                        <span>
                             <a class="pointer" ng-click="challenge.challengeDateDialog($event)">
-                                <strong class="text-light-black">Starts on:</strong>
-                                {{ challenge.page.start_date | date:'medium' }}
                                 <i class="fa fa-pencil" aria-hidden="true"></i>
                             </a>
                         </span>
+
                         <br>
                         <span>
+                            <strong class="text-light-black">Ends on:</strong>
+                            {{ challenge.page.end_date | date:'medium' }}
+                        </span>
+                        &nbsp;
+                        <span>
                             <a class="pointer" ng-click="challenge.challengeDateDialog($event)">
-                                <strong class="text-light-black">Ends on:</strong>
-                                {{ challenge.page.end_date | date:'medium' }}
                                 <i class="fa fa-pencil" aria-hidden="true"></i>
                             </a>
                         </span>

--- a/frontend/src/views/web/challenge/challenge-page.html
+++ b/frontend/src/views/web/challenge/challenge-page.html
@@ -42,6 +42,23 @@
                                 </a>
                             </span>
                         </span>
+
+                        <br>
+                        <span>
+                            <a class="pointer" ng-click="challenge.challengeDateDialog($event)">
+                                <strong class="text-light-black">Starts on:</strong>
+                                {{ challenge.page.start_date | date:'medium' }}
+                                <i class="fa fa-pencil" aria-hidden="true"></i>
+                            </a>
+                        </span>
+                        <br>
+                        <span>
+                            <a class="pointer" ng-click="challenge.challengeDateDialog($event)">
+                                <strong class="text-light-black">Ends on:</strong>
+                                {{ challenge.page.end_date | date:'medium' }}
+                                <i class="fa fa-pencil" aria-hidden="true"></i>
+                            </a>
+                        </span>
                     </p>
                 </div>
             </div>

--- a/frontend/src/views/web/challenge/challenge-page.html
+++ b/frontend/src/views/web/challenge/challenge-page.html
@@ -42,7 +42,6 @@
                                 </a>
                             </span>
                         </span>
-
                         <br>
                         <span>
                             <strong class="text-light-black">Starts on:</strong>
@@ -54,7 +53,6 @@
                                 <i class="fa fa-pencil" aria-hidden="true"></i>
                             </a>
                         </span>
-
                         <br>
                         <span>
                             <strong class="text-light-black">Ends on:</strong>

--- a/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
+++ b/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
@@ -5,7 +5,8 @@
             <div class="col s12">
                 <div class="input-field align-left">
                     <span class="text-med-black w-400 fs-16">Start date and time</span>
-                    <input id="start_date" name="start_date" format="MM-DD-YYYY hh:mm a" locale="en"
+                    <input id="start_date" name="start_date" autocomplete="off"
+                           format="MM-DD-YYYY hh:mm a" locale="en"
                            value="{{ challenge.page.start_date }}" ng-model="challenge.page.start_date"
                            start-view="year" ng-model-options="{ updateOn: 'blur' }" placeholder="Start date"
                            moment-picker="challenge.page.start_date"
@@ -16,7 +17,8 @@
             <div class="col s12">
                 <div class="input-field align-left">
                     <span class="text-med-black w-400 fs-16">End date and time</span>
-                    <input id="end_date" name="end_date" format="MM-DD-YYYY hh:mm a" locale="en"
+                    <input id="end_date" name="end_date" autocomplete="off"
+                           format="MM-DD-YYYY hh:mm a" locale="en"
                            value="{{ challenge.page.end_date }}" ng-model="challenge.page.end_date"
                            start-view="year" ng-model-options="{ updateOn: 'blur' }" placeholder="End date"
                            moment-picker="challenge.page.end_date" min-date="challenge.page.start_date"

--- a/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
+++ b/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
@@ -2,6 +2,7 @@
     <div class="row">
         <form name="editChallengeDateForm"
             ng-submit="challenge.editChallengeDate(editChallengeDateForm.$valid)">
+            <div class="pass-title font-size-16">Edit Challenge Start and End Date</div>
             <div class="col s12">
                 <div class="input-field align-left">
                     <span class="text-med-black w-400 fs-16">Start date and time</span>

--- a/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
+++ b/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
@@ -1,9 +1,9 @@
 <section class="ev-md-container text-center rm-overflow-y">
     <div class="row">
-        <form name="editChallengeDateForm"
-            ng-submit="challenge.editChallengeDate(editChallengeDateForm.$valid)">
-            <div class="pass-title font-size-16">Edit Challenge Start and End Date</div>
-            <div class="col s12">
+        <div class="col s12 m12">
+            <form name="editChallengeDateForm"
+                ng-submit="challenge.editChallengeDate(editChallengeDateForm.$valid)">
+                <div class="pass-title font-size-16">Edit Challenge Start and End Date</div>
                 <div class="input-field align-left">
                     <span class="text-med-black w-400 fs-16">Start date and time</span>
                     <input id="start_date" name="start_date" autocomplete="off"
@@ -14,8 +14,6 @@
                         required>
                     <span class="form-icon"><i class="fa fa-text"></i></span>
                 </div>
-            </div>
-            <div class="col s12">
                 <div class="input-field align-left">
                     <span class="text-med-black w-400 fs-16">End date and time</span>
                     <input id="end_date" name="end_date" autocomplete="off"
@@ -26,8 +24,6 @@
                         required>
                     <span class="form-icon"><i class="fa fa-text"></i></span>
                 </div>
-            </div>
-            <div class="col s12">
                 <div class="align-left text-med-black w-400">
                     <ul class="inline-list pointer">
                         <li>
@@ -41,7 +37,7 @@
                         </li>
                     </ul>
                 </div>
-            </div>
-        </form>
+            </form>
+        </div>
     </div>
 </section>

--- a/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
+++ b/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
@@ -8,9 +8,9 @@
                     <span class="text-med-black w-400 fs-16">Start date and time</span>
                     <input id="start_date" name="start_date" autocomplete="off"
                         format="MM-DD-YYYY hh:mm a" locale="en"
-                        value="{{ challenge.page.start_date }}" ng-model="challenge.page.start_date"
+                        value="{{ challenge.challengeStartDate }}" ng-model="challenge.challengeStartDate"
                         start-view="year" ng-model-options="{ updateOn: 'blur' }" placeholder="Start date"
-                        moment-picker="challenge.page.start_date"
+                        moment-picker="challenge.challengeStartDate"
                         required>
                     <span class="form-icon"><i class="fa fa-text"></i></span>
                 </div>
@@ -20,9 +20,9 @@
                     <span class="text-med-black w-400 fs-16">End date and time</span>
                     <input id="end_date" name="end_date" autocomplete="off"
                         format="MM-DD-YYYY hh:mm a" locale="en"
-                        value="{{ challenge.page.end_date }}" ng-model="challenge.page.end_date"
+                        value="{{ challenge.challengeEndDate }}" ng-model="challenge.challengeEndDate"
                         start-view="year" ng-model-options="{ updateOn: 'blur' }" placeholder="End date"
-                        moment-picker="challenge.page.end_date" min-date="challenge.page.start_date"
+                        moment-picker="challenge.challengeEndDate" min-date="challenge.challengeEndDate"
                         required>
                     <span class="form-icon"><i class="fa fa-text"></i></span>
                 </div>

--- a/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
+++ b/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
@@ -22,7 +22,7 @@
                         format="MM-DD-YYYY hh:mm a" locale="en"
                         value="{{ challenge.challengeEndDate }}" ng-model="challenge.challengeEndDate"
                         start-view="year" ng-model-options="{ updateOn: 'blur' }" placeholder="End date"
-                        moment-picker="challenge.challengeEndDate" min-date="challenge.challengeEndDate"
+                        moment-picker="challenge.challengeEndDate" min-date="challenge.challengeStartDate"
                         required>
                     <span class="form-icon"><i class="fa fa-text"></i></span>
                 </div>

--- a/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
+++ b/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
@@ -20,7 +20,7 @@
                         format="MM-DD-YYYY hh:mm a" locale="en"
                         value="{{ challenge.challengeEndDate }}" ng-model="challenge.challengeEndDate"
                         start-view="year" ng-model-options="{ updateOn: 'blur' }" placeholder="End date"
-                        moment-picker="challenge.challengeEndDate" min-date="challenge.challengeStartDate"
+                        moment-picker="challenge.challengeEndDate"
                         required>
                     <span class="form-icon"><i class="fa fa-text"></i></span>
                 </div>

--- a/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
+++ b/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
@@ -1,16 +1,16 @@
 <section class="ev-md-container text-center rm-overflow-y">
     <div class="row">
         <form name="editChallengeDateForm"
-              ng-submit="challenge.editChallengeDate(editChallengeDateForm.$valid)">
+            ng-submit="challenge.editChallengeDate(editChallengeDateForm.$valid)">
             <div class="col s12">
                 <div class="input-field align-left">
                     <span class="text-med-black w-400 fs-16">Start date and time</span>
                     <input id="start_date" name="start_date" autocomplete="off"
-                           format="MM-DD-YYYY hh:mm a" locale="en"
-                           value="{{ challenge.page.start_date }}" ng-model="challenge.page.start_date"
-                           start-view="year" ng-model-options="{ updateOn: 'blur' }" placeholder="Start date"
-                           moment-picker="challenge.page.start_date"
-                           required>
+                        format="MM-DD-YYYY hh:mm a" locale="en"
+                        value="{{ challenge.page.start_date }}" ng-model="challenge.page.start_date"
+                        start-view="year" ng-model-options="{ updateOn: 'blur' }" placeholder="Start date"
+                        moment-picker="challenge.page.start_date"
+                        required>
                     <span class="form-icon"><i class="fa fa-text"></i></span>
                 </div>
             </div>
@@ -18,11 +18,11 @@
                 <div class="input-field align-left">
                     <span class="text-med-black w-400 fs-16">End date and time</span>
                     <input id="end_date" name="end_date" autocomplete="off"
-                           format="MM-DD-YYYY hh:mm a" locale="en"
-                           value="{{ challenge.page.end_date }}" ng-model="challenge.page.end_date"
-                           start-view="year" ng-model-options="{ updateOn: 'blur' }" placeholder="End date"
-                           moment-picker="challenge.page.end_date" min-date="challenge.page.start_date"
-                           required>
+                        format="MM-DD-YYYY hh:mm a" locale="en"
+                        value="{{ challenge.page.end_date }}" ng-model="challenge.page.end_date"
+                        start-view="year" ng-model-options="{ updateOn: 'blur' }" placeholder="End date"
+                        moment-picker="challenge.page.end_date" min-date="challenge.page.start_date"
+                        required>
                     <span class="form-icon"><i class="fa fa-text"></i></span>
                 </div>
             </div>
@@ -35,7 +35,7 @@
                         </li>
                         <li>
                             <button class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-16"
-                                    type="submit" value="submit">Submit
+                                type="submit" value="submit">Submit
                             </button>
                         </li>
                     </ul>

--- a/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
+++ b/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
@@ -41,5 +41,4 @@
             </div>
         </form>
     </div>
-
 </section>

--- a/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
+++ b/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
@@ -29,7 +29,7 @@
             </div>
             <div class="col s12">
                 <div class="align-left text-med-black w-400">
-                    <ul class="inline-list hide-on-med-and-down">
+                    <ul class="inline-list pointer">
                         <li>
                             <a ng-click="challenge.editChallengeDate(false)"
                                class="dark-link pointer"><strong>Cancel</strong></a>

--- a/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
+++ b/frontend/src/views/web/challenge/edit-challenge/edit-challenge-date.html
@@ -1,0 +1,45 @@
+<section class="ev-md-container text-center rm-overflow-y">
+    <div class="row">
+        <form name="editChallengeDateForm"
+              ng-submit="challenge.editChallengeDate(editChallengeDateForm.$valid)">
+            <div class="col s12">
+                <div class="input-field align-left">
+                    <span class="text-med-black w-400 fs-16">Start date and time</span>
+                    <input id="start_date" name="start_date" format="MM-DD-YYYY hh:mm a" locale="en"
+                           value="{{ challenge.page.start_date }}" ng-model="challenge.page.start_date"
+                           start-view="year" ng-model-options="{ updateOn: 'blur' }" placeholder="Start date"
+                           moment-picker="challenge.page.start_date"
+                           required>
+                    <span class="form-icon"><i class="fa fa-text"></i></span>
+                </div>
+            </div>
+            <div class="col s12">
+                <div class="input-field align-left">
+                    <span class="text-med-black w-400 fs-16">End date and time</span>
+                    <input id="end_date" name="end_date" format="MM-DD-YYYY hh:mm a" locale="en"
+                           value="{{ challenge.page.end_date }}" ng-model="challenge.page.end_date"
+                           start-view="year" ng-model-options="{ updateOn: 'blur' }" placeholder="End date"
+                           moment-picker="challenge.page.end_date" min-date="challenge.page.start_date"
+                           required>
+                    <span class="form-icon"><i class="fa fa-text"></i></span>
+                </div>
+            </div>
+            <div class="col s12">
+                <div class="align-left text-med-black w-400">
+                    <ul class="inline-list hide-on-med-and-down">
+                        <li>
+                            <a ng-click="challenge.editChallengeDate(false)"
+                               class="dark-link pointer"><strong>Cancel</strong></a>
+                        </li>
+                        <li>
+                            <button class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-16"
+                                    type="submit" value="submit">Submit
+                            </button>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </form>
+    </div>
+
+</section>


### PR DESCRIPTION
Fixes #1705.

## [The corresponding GCI task](https://codein.withgoogle.com/dashboard/task-instances/4707065461735424/)

## Figures
- Overview page
![overview](https://user-images.githubusercontent.com/57856193/70859042-6b85d880-1f50-11ea-85b0-a145c20e905f.png)
- Moment-picker
![moment-picker](https://user-images.githubusercontent.com/57856193/70859046-7fc9d580-1f50-11ea-823a-a8f4c38e9373.png)
- Error message when the value of `Starts on` is the same or later than that of `Ends on`
![validation](https://user-images.githubusercontent.com/57856193/70859060-bc95cc80-1f50-11ea-9772-599665e3090e.png)

