### PR TITLE
Add search field in participant team admin

### DIFF
--- a/apps/participants/admin.py
+++ b/apps/participants/admin.py
@@ -22,7 +22,7 @@ class ParticipantAdmin(ImportExportTimeStampedAdmin):
 
     list_display = ("user", "status", "team")
     search_fields = ("user__username", "status", "team__team_name")
-    list_filter = ("status", "team")
+    list_filter = ("status",)
     resource_class = ParticipantResource
 
 
@@ -34,4 +34,4 @@ class ParticipantTeamAdmin(ImportExportTimeStampedAdmin):
     """
 
     list_display = ("team_name", "get_all_participants_email", "team_url")
-    list_filter = ("team_name",)
+    search_fields = ("team_name", "team_url", "created_by__username")


### PR DESCRIPTION
Minor fixes in participants app -
1. Add search field in the `ParticipantTeam` admin.
2. Remove the `team` field from `list_filer` in Participant admin. 