### PR TITLE
Add tests for start_workers in aws_utils

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -222,9 +222,6 @@ service_definition = """
         }}
     }},
     "schedulingStrategy":"REPLICA",
-    "deploymentController":{{
-        "type": "ECS"
-    }},
 }}
 """
 

--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -222,6 +222,9 @@ service_definition = """
         }}
     }},
     "schedulingStrategy":"REPLICA",
+    "deploymentController":{{
+        "type": "ECS"
+    }},
 }}
 """
 

--- a/tests/unit/challenges/test_aws_utils.py
+++ b/tests/unit/challenges/test_aws_utils.py
@@ -19,8 +19,6 @@ from challenges.aws_utils import (
 
 class BaseTestClass(APITestCase):
     def setUp(self):
-        COMMON_SETTINGS_DICT["EXECUTION_ROLE_ARN"] = "arn:aws:iam::us-east-1:012345678910:role/ecsTaskExecutionRole"
-
         self.client = APIClient(enforce_csrf_checks=True)
 
         self.ecs_client = boto3.client(

--- a/tests/unit/challenges/test_aws_utils.py
+++ b/tests/unit/challenges/test_aws_utils.py
@@ -11,13 +11,16 @@ from challenges.models import Challenge
 from hosts.models import ChallengeHostTeam
 
 from challenges.aws_utils import (
+    COMMON_SETTINGS_DICT,
     create_service_by_challenge_pk,
-    start_workers
+    start_workers,
 )
 
 
 class BaseTestClass(APITestCase):
     def setUp(self):
+        COMMON_SETTINGS_DICT["EXECUTION_ROLE_ARN"] = "arn:aws:iam::us-east-1:012345678910:role/ecsTaskExecutionRole"
+
         self.client = APIClient(enforce_csrf_checks=True)
 
         self.ecs_client = boto3.client(

--- a/tests/unit/challenges/test_aws_utils.py
+++ b/tests/unit/challenges/test_aws_utils.py
@@ -1,0 +1,81 @@
+import boto3
+import os
+
+from moto import mock_ecs
+
+from django.contrib.auth.models import User
+
+from rest_framework.test import APITestCase, APIClient
+
+from challenges.models import Challenge
+from hosts.models import ChallengeHostTeam
+
+from challenges.aws_utils import (
+    create_service_by_challenge_pk,
+    start_workers
+)
+
+
+class BaseTestClass(APITestCase):
+    def setUp(self):
+        self.client = APIClient(enforce_csrf_checks=True)
+
+        self.ecs_client = boto3.client(
+            "ecs",
+            region_name=os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
+            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID")
+        )
+        self.ecs_client.create_cluster(clusterName="cluster")
+
+        self.ecs_client_token = "abc123"
+
+        self.user = User.objects.create(
+            username="someuser",
+            email="user@test.com",
+            password="secret_password"
+        )
+
+        self.challenge_host_team = ChallengeHostTeam.objects.create(
+            team_name="Test Challenge Host Team",
+            created_by=self.user
+        )
+
+        for i in range(3):
+            Challenge.objects.create(
+                pk=i,
+                title="Test Challenge {}".format(i),
+                creator=self.challenge_host_team,
+            )
+
+
+@mock_ecs
+class TestStartWorkers(BaseTestClass):
+    def test_start_workers_when_all_challenges_have_no_worker(self):
+        challenges = Challenge.objects.all()
+
+        expected_workers = [None, None, None]
+        self.assertEqual(list(c.workers for c in challenges), expected_workers)
+
+        expected_response = {"count": 3, "failures": []}
+        response = start_workers(challenges)
+        self.assertEqual(response, expected_response)
+
+        expected_workers = [1, 1, 1]
+        self.assertEqual(list(c.workers for c in challenges), expected_workers)
+
+    def test_start_workers_when_second_challenge_already_has_a_worker(self):
+        challenges = Challenge.objects.order_by("pk").all()
+        second_challenge = challenges[1]
+
+        create_service_by_challenge_pk(self.ecs_client, second_challenge, self.ecs_client_token)
+        expected_workers = [None, 1, None]
+        self.assertEqual(list(c.workers for c in challenges), expected_workers)
+
+        expected_failures = [{
+            "message": "Please select challenge with inactive workers only.",
+            "challenge_pk": 1
+        }]
+        expected_response = {"count": 2, "failures": expected_failures}
+        response = start_workers(challenges)
+        self.assertEqual(response, expected_response)


### PR DESCRIPTION
## [The Corresponding GCI Task](https://codein.withgoogle.com/dashboard/task-instances/6478188339789824/)

## Clarification
- Add tests for `start_workers` to confirm it is working correctly when all challenges have no worker.
- Add tests for `start_workers` to confirm it is working correctly when some challenges have workers.