### PR TITLE
Add specific version for django-allauth in common.txt

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -4,6 +4,7 @@ botocore==1.12.88
 celery[sqs]==4.3.0
 commonmark==0.5.4
 django==1.11.23
+django-allauth==0.40.0
 django-filter==2.1.0
 django-import-export==0.5.1
 djangorestframework==3.9.3


### PR DESCRIPTION
The `django-rest-auth` package installs the latest version of `django-allauth` and the latest version of `django-allauth` [released yesterday](https://github.com/pennersr/django-allauth/tree/0.41.0) requires the `django version>=2.0` as shown [here](https://travis-ci.org/Cloud-CV/EvalAI/builds/627303971#L579).

Since we're still using django `1.11.23`, hence `django-allauth==0.40.0` is added specifically to fix the master and PR builds here:  https://travis-ci.org/Cloud-CV/EvalAI/builds/627303971#L1344