### PR TITLE
Remove verbosity in challengeCtrl.js and fix a typo

### DIFF
--- a/apps/hosts/models.py
+++ b/apps/hosts/models.py
@@ -10,7 +10,7 @@ from base.models import TimeStampedModel
 
 class ChallengeHostTeam(TimeStampedModel):
     """
-    Model representing the Host Team for a partiuclar challenge
+    Model representing the Host Team for a particular challenge
     """
 
     team_name = models.CharField(max_length=100, unique=True)

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -1891,10 +1891,8 @@
         vm.challengePhaseDialog = function(ev, phase) {
             vm.page.challenge_phase = phase;
             vm.page.max_submissions_per_day = phase.max_submissions_per_day;
-            vm.phaseStartDate = phase.start_date;
-            vm.phaseStartDate = moment(vm.phaseStartDate);
-            vm.phaseEndDate = phase.end_date;
-            vm.phaseEndDate = moment(vm.phaseEndDate);
+            vm.phaseStartDate = moment(phase.start_date);
+            vm.phaseEndDate = moment(phase.end_date);
             vm.testAnnotationFile = null;
             vm.sanityCheckPass = true;
             vm.sanityCheck = "";


### PR DESCRIPTION
This PR removes verbosity when defining `vm.phaseStartDate` and `vm.phaseEndDate`.