### PR TITLE
Remote Worker: Add tests for download_and_extract_file

### DIFF
--- a/tests/unit/remoteworker/test_remote_worker.py
+++ b/tests/unit/remoteworker/test_remote_worker.py
@@ -1,5 +1,6 @@
 import mock
 import os
+import responses
 import shutil
 import tempfile
 
@@ -170,3 +171,42 @@ class CreateDirAsPythonPackageTest(BaseTestClass):
 
         shutil.rmtree(self.temp_directory)
         self.assertFalse(os.path.exists(self.temp_directory))
+
+
+class DownloadAndExtractFileTest(BaseTestClass):
+    def setUp(self):
+        super(DownloadAndExtractFileTest, self).setUp()
+        self.req_url = "{}{}".format(self.testserver, self.make_request_url())
+        self.file_content = b'file content'
+
+        self.temp_directory = tempfile.mkdtemp()
+        self.download_location = join(self.temp_directory, "dummy_file")
+
+    def tearDown(self):
+        if os.path.exists(self.temp_directory):
+            shutil.rmtree(self.temp_directory)
+
+    @responses.activate
+    def test_download_and_extract_file_success(self):
+        responses.add(responses.GET, self.req_url,
+                      body=self.file_content,
+                      content_type='application/octet-stream',
+                      status=200)
+
+        download_and_extract_file(self.req_url, self.download_location)
+
+        self.assertTrue(os.path.exists(self.download_location))
+        with open(self.download_location, "rb") as f:
+            self.assertEqual(f.read(), self.file_content)
+
+    @responses.activate
+    @mock.patch("scripts.workers.remote_submission_worker.logger.error")
+    def test_download_and_extract_file_when_download_fails(self, mock_logger):
+        error = "ExampleError: Example Error description"
+        responses.add(responses.GET, self.req_url, body=Exception(error))
+        expected = "Failed to fetch file from {}, error {}".format(self.req_url, error)
+
+        download_and_extract_file(self.req_url, self.download_location)
+
+        mock_logger.assert_called_with(expected)
+        self.assertFalse(os.path.exists(self.download_location))

--- a/tests/unit/remoteworker/test_remote_worker.py
+++ b/tests/unit/remoteworker/test_remote_worker.py
@@ -13,6 +13,7 @@ from scripts.workers.remote_submission_worker import (
     make_request,
     get_message_from_sqs_queue,
     delete_message_from_sqs_queue,
+    download_and_extract_file,
     get_submission_by_pk,
     get_challenge_phases_by_challenge_pk,
     get_challenge_by_queue_name,

--- a/tests/unit/remoteworker/test_remote_worker.py
+++ b/tests/unit/remoteworker/test_remote_worker.py
@@ -31,6 +31,7 @@ class BaseTestClass(TestCase):
         self.challenge_phase_pk = 1
         self.data = {"test": "data"}
         self.headers = {"Authorization": "Token test_token"}
+        self.testserver = "http://testserver"
 
     def make_request_url(self):
         return "/test/url"


### PR DESCRIPTION
Additions proposed:

1.  Add unit test for `download_and_extract_file` function (from remote_submission_worker) when the function works as expected.
2. Add unit test for `download_and_extract_file` when downloading fails with an exception.
