### PR TITLE
Restrict challenge start and end date edit option to challenge host only

### DIFF
--- a/frontend/src/views/web/challenge/challenge-page.html
+++ b/frontend/src/views/web/challenge/challenge-page.html
@@ -48,7 +48,7 @@
                             {{ challenge.page.start_date | date:'medium' }}
                         </span>
                         &nbsp;
-                        <span>
+                        <span ng-if="challenge.isChallengeHost">
                             <a class="pointer" ng-click="challenge.challengeDateDialog($event)">
                                 <i class="fa fa-pencil" aria-hidden="true"></i>
                             </a>
@@ -59,7 +59,7 @@
                             {{ challenge.page.end_date | date:'medium' }}
                         </span>
                         &nbsp;
-                        <span>
+                        <span ng-if="challenge.isChallengeHost">
                             <a class="pointer" ng-click="challenge.challengeDateDialog($event)">
                                 <i class="fa fa-pencil" aria-hidden="true"></i>
                             </a>


### PR DESCRIPTION
Minor fixes to #1705 .

I have added the functionality to restrict the date edit option so it will only show for the challenge host.

I used an `ng-if` conditional to ensure that this change works.

