### PR TITLE
API fixes for RL submission worker

### DIFF
--- a/apps/base/utils.py
+++ b/apps/base/utils.py
@@ -154,7 +154,7 @@ def get_boto3_client(resource, aws_keys):
         logger.exception(e)
 
 
-def get_sqs_queue_object():
+def get_sqs_queue_object(queue_name):
     if settings.DEBUG or settings.TEST:
         queue_name = "evalai_submission_queue"
         sqs = boto3.resource(
@@ -212,21 +212,18 @@ def send_slack_notification(webhook=settings.SLACK_WEB_HOOK_URL, message=""):
     try:
         data = {
             "text": message["text"],
-            "attachments": [
-                {
-                    "color": "ffaf4b",
-                    "fields": message["fields"]
-                }
-            ]
+            "attachments": [{"color": "ffaf4b", "fields": message["fields"]}],
         }
         return requests.post(
             webhook,
             data=json.dumps(data),
-            headers={"Content-Type": "application/json"}
+            headers={"Content-Type": "application/json"},
         )
     except Exception as e:
         logger.exception(
-            "Exception raised while sending slack notification. \n Exception message: {}".format(e)
+            "Exception raised while sending slack notification. \n Exception message: {}".format(
+                e
+            )
         )
 
 
@@ -235,4 +232,5 @@ def mock_if_non_prod_aws(aws_mocker):
         if not (settings.DEBUG or settings.TEST):
             return func
         return aws_mocker(func)
+
     return decorator

--- a/apps/base/utils.py
+++ b/apps/base/utils.py
@@ -154,7 +154,7 @@ def get_boto3_client(resource, aws_keys):
         logger.exception(e)
 
 
-def get_sqs_queue_object(queue_name):
+def get_or_create_sqs_queue_object(queue_name):
     if settings.DEBUG or settings.TEST:
         queue_name = "evalai_submission_queue"
         sqs = boto3.resource(

--- a/apps/jobs/admin.py
+++ b/apps/jobs/admin.py
@@ -72,18 +72,25 @@ class SubmissionAdmin(ImportExportTimeStampedAdmin):
             message = {
                 "challenge_pk": challenge_id,
                 "phase_pk": challenge_phase_id,
-                "submission_pk": submission.id
+                "submission_pk": submission.id,
             }
 
             if submission.challenge_phase.challenge.is_docker_based:
                 try:
-                    response = requests.get(submission.input_file)
+                    response = requests.get(submission.input_file.url)
                 except Exception as e:
-                    messages.error(request, "Failed to get input_file with exception: {0}".format(e))
+                    messages.error(
+                        request,
+                        "Failed to get input_file with exception: {0}".format(
+                            e
+                        ),
+                    )
                     return
 
                 if response and response.status_code == 200:
-                    message["submitted_image_uri"] = response.json()["submitted_image_uri"]
+                    message["submitted_image_uri"] = response.json()[
+                        "submitted_image_uri"
+                    ]
 
             publish_submission_message(message)
             queryset.update(status=Submission.SUBMITTED)

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -30,7 +30,7 @@ from accounts.permissions import HasVerifiedEmail
 from base.utils import (
     paginated_queryset,
     StandardResultSetPagination,
-    get_sqs_queue_object,
+    get_or_create_sqs_queue_object,
     get_boto3_client,
 )
 from challenges.models import (
@@ -1145,7 +1145,7 @@ def get_submission_message_from_queue(request, queue_name):
         }
         return Response(response_data, status=status.HTTP_401_UNAUTHORIZED)
 
-    queue = get_sqs_queue_object(queue_name)
+    queue = get_or_create_sqs_queue_object(queue_name)
     try:
         messages = queue.receive_messages()
         if len(messages):
@@ -1201,7 +1201,7 @@ def delete_submission_message_from_queue(request, queue_name):
         }
         return Response(response_data, status=status.HTTP_401_UNAUTHORIZED)
 
-    queue = get_sqs_queue_object(queue_name)
+    queue = get_or_create_sqs_queue_object(queue_name)
     try:
         message = queue.Message(receipt_handle)
         message.delete()

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -279,17 +279,19 @@ def challenge_submission(request, challenge_id, challenge_phase_id):
         )
         message = {
             "challenge_pk": challenge_id,
-            "phase_pk": challenge_phase_id
+            "phase_pk": challenge_phase_id,
         }
         if challenge.is_docker_based:
             try:
-                file_content = json.loads(
-                    request.FILES['input_file'].read()
-                )
-                message["submitted_image_uri"] = file_content["submitted_image_uri"]
-            except:
+                file_content = json.loads(request.FILES["input_file"].read())
+                message["submitted_image_uri"] = file_content[
+                    "submitted_image_uri"
+                ]
+            except Exception as ex:
                 response_data = {
-                    "error": "Error in deserializing submitted_image_uri from submission file"
+                    "error": "Error {} in submitted_image_uri from submission file".format(
+                        ex
+                    )
                 }
                 return Response(
                     response_data, status=status.HTTP_400_BAD_REQUEST
@@ -1047,7 +1049,7 @@ def re_run_submission(request, submission_pk):
     message = {
         "challenge_pk": challenge.pk,
         "phase_pk": challenge_phase.pk,
-        "submission_pk": submission.pk
+        "submission_pk": submission.pk,
     }
 
     if submission.challenge_phase.challenge.is_docker_based:
@@ -1055,12 +1057,18 @@ def re_run_submission(request, submission_pk):
             response = requests.get(submission.input_file)
         except Exception as e:
             response_data = {
-                "error": "Failed to get submission input file with error: {0}".format(e)
+                "error": "Failed to get submission input file with error: {0}".format(
+                    e
+                )
             }
-            return Response(response_data, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                response_data, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
         if response and response.status_code == 200:
-            message["submitted_image_uri"] = response.json()["submitted_image_uri"]
+            message["submitted_image_uri"] = response.json()[
+                "submitted_image_uri"
+            ]
 
     publish_submission_message(message)
     response_data = {
@@ -1137,7 +1145,7 @@ def get_submission_message_from_queue(request, queue_name):
         }
         return Response(response_data, status=status.HTTP_401_UNAUTHORIZED)
 
-    queue = get_sqs_queue_object()
+    queue = get_sqs_queue_object(queue_name)
     try:
         messages = queue.receive_messages()
         if len(messages):

--- a/scripts/workers/worker_util.py
+++ b/scripts/workers/worker_util.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 URLS = {
     "get_message_from_sqs_queue": "/api/jobs/challenge/queues/{}/",
-    "delete_message_from_sqs_queue": "/api/jobs/queues/{}/receipt/{}/",
+    "delete_message_from_sqs_queue": "/api/jobs/queues/{}/",
     "get_submission_by_pk": "/api/jobs/submission/{}",
     "get_challenge_phases_by_challenge_pk": "/api/challenges/{}/phases/",
     "get_challenge_by_queue_name": "/api/challenges/challenge/queues/{}/",
@@ -51,11 +51,10 @@ class EvalAI_Interface:
         return response
 
     def delete_message_from_sqs_queue(self, receipt_handle):
-        url = URLS.get("delete_message_from_sqs_queue").format(
-            self.QUEUE_NAME, receipt_handle
-        )
+        url = URLS.get("delete_message_from_sqs_queue").format(self.QUEUE_NAME)
         url = self.return_url_per_environment(url)
-        response = self.make_request(url, "GET")  # noqa
+        data = {"receipt_handle": receipt_handle}
+        response = self.make_request(url, "POST", data)  # noqa
         return response.status_code
 
     def get_submission_by_pk(self, submission_pk):


### PR DESCRIPTION
Changes in this PR-
- Add fixes for delete SQS message in worker_util file as the API is changed.
- Pass queue_name as a parameter while get_or_create_SQS_queue.
- update name for `get_sqs_queue_object` function to `get_or_create_sqs_object`.
- Fix submission re-run for docker based challenges.