### PR TITLE
Fix#2067: Disable team to participate if user has unverified email

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -312,8 +312,8 @@ def add_participant_team_to_challenge(
             continue
 
     if unverified_emails:
-        message = "All team members need to have verified emails in order to participate. \
-        Users with the following email addresses have unverified emails:\n{}".format(
+        message = "Sorry, all team members must be verified through Email before participating. \
+        The following users have unverified email address:\n{}".format(
             "\n".join(unverified_emails)
         )
         response_data = {"error": message}

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -269,19 +269,6 @@ def add_participant_team_to_challenge(
                     response_data, status=status.HTTP_406_NOT_ACCEPTABLE
                 )
 
-    # Check if all participants have verified emails
-    unverified_users = []
-    for user in participant_team_user_ids:
-        if EmailAddress.objects.filter(user=user, verified=False).exists():
-            unverified_users.append(user)
-    if unverified_users:
-        message = "All team members need to have verified emails in order to participate. \
-        Users with the following user ids have unverified emails:\n{}".format(
-            "\n".join(unverified_users)
-        )
-        response_data = {"error": message}
-        return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
-
     # Check if user is in allowed list.
     user_email = request.user.email
     if len(challenge.allowed_email_domains) > 0:
@@ -314,6 +301,23 @@ def add_participant_team_to_challenge(
         .filter(team__id=participant_team_pk)
         .values_list("user", flat=True)
     )
+
+    # Check if all participants have verified emails
+    unverified_emails = []
+    for user in participant_team_user_ids:
+        try:
+            unverified_user = EmailAddress.objects.get(user=user, verified=False)
+            unverified_emails.append(unverified_user)
+        except EmailAddress.DoesNotExist:
+            continue
+
+    if unverified_emails:
+        message = "All team members need to have verified emails in order to participate. \
+        Users with the following email addresses have unverified emails:\n{}".format(
+            "\n".join(unverified_emails)
+        )
+        response_data = {"error": message}
+        return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     for user in participant_team_user_ids:
         if has_user_participated_in_challenge(user, challenge_pk):

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -269,6 +269,19 @@ def add_participant_team_to_challenge(
                     response_data, status=status.HTTP_406_NOT_ACCEPTABLE
                 )
 
+    # Check if all participants have verified emails
+    unverified_users = []
+    for user in participant_team_user_ids:
+        if EmailAddress.objects.filter(user=user, verified=False).exists():
+            unverified_users.append(user)
+    if unverified_users:
+        message = "All team members need to have verified emails in order to participate. \
+        Users with the following user ids have unverified emails:\n{}".format(
+            "\n".join(unverified_users)
+        )
+        response_data = {"error": message}
+        return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
+
     # Check if user is in allowed list.
     user_email = request.user.email
     if len(challenge.allowed_email_domains) > 0:

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -307,7 +307,7 @@ def add_participant_team_to_challenge(
     for user in participant_team_user_ids:
         try:
             unverified_user = EmailAddress.objects.get(user=user, verified=False)
-            unverified_emails.append(unverified_user)
+            unverified_emails.append(unverified_user.email)
         except EmailAddress.DoesNotExist:
             continue
 

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -793,8 +793,8 @@ class MapChallengeAndParticipantTeam(BaseAPITestClass):
         )
 
         response = self.client.post(self.url, {})
-        message = "All team members need to have verified emails in order to participate. \
-        Users with the following email addresses have unverified emails:\n{}"
+        message = message = "Sorry, all team members must be verified through Email before participating. \
+        The following users have unverified email address:\n{}"
         expected = {"error": message.format(self.user4.email)}
 
         self.assertEqual(response.data, expected)

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -616,7 +616,7 @@ class MapChallengeAndParticipantTeam(BaseAPITestClass):
 
         self.user4_email = EmailAddress.objects.create(
             user=self.user4,
-            email=user3.email,
+            email=self.user4.email,
             primary=True,
             verified=True,
         )


### PR DESCRIPTION
Fix #2067 

Changes proposed:
* Throw a HTTP `406 NOT ACCEPTABLE` error when one or more of team members have unverified emails
* List the members with unverified emails so that they can be informed

PR used for reference: https://github.com/Cloud-CV/EvalAI/pull/2078

Edit: Added unit tests for the mentioned changes

@gautamjajoo @KhalidRmb @Ram81 Please have a look.