### PR TITLE
Add citation bibentry on homepage under "Cite our work"

### DIFF
--- a/frontend/src/views/web/landing.html
+++ b/frontend/src/views/web/landing.html
@@ -281,6 +281,23 @@
                         <img src="dist/images/evalai-paper.jpg" alt="" width="100%" class="thumb">
                     </a>
                 </div>
+                <div class="row">
+                    <div class="col s12 m12 l12">
+                        <h5 class="w-400">Citation Bibentry:</h5>
+                        <span class="w-300 fs-16">
+                            <pre>
+@article{EvalAI,
+    title   =  {EvalAI: Towards Better Evaluation Systems for AI Agents},
+    author  =  {Deshraj Yadav and Rishabh Jain and Harsh Agrawal and Prithvijit
+                Chattopadhyay and Taranjeet Singh and Akash Jain and Shiv Baran
+                Singh and Stefan Lee and Dhruv Batra},
+    year    =  {2019},
+    volume  =  arXiv:1902.03570
+}
+                            </pre>
+                        </span>
+                    </div>
+                </div>
             </div>
         </section>
     </div>


### PR DESCRIPTION
**The corresponding GCI task**: https://codein.withgoogle.com/dashboard/task-instances/5953309093920768/

**Changes**:
- Add a citation bibentry copied from [reference](https://github.com/Cloud-CV/EvalAI#citing-evalai).

**Screencast**:
![Screenshot from 2020-01-08 18-17-09](https://user-images.githubusercontent.com/57856193/71965645-6e1fd900-3243-11ea-8113-609c99cb1317.png)

**CC**: @vkartik97 @Ram81 @RishabhJain2018 
