### PR TITLE
Allow unverified user to view the challenge

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -429,7 +429,7 @@ def get_challenge_by_pk(request, pk):
 
 @api_view(["GET"])
 @throttle_classes([UserRateThrottle])
-@permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))
+@permission_classes((permissions.IsAuthenticated,))
 @authentication_classes((ExpiringTokenAuthentication,))
 def get_challenges_based_on_teams(request):
     q_params = {"approved_by_admin": True, "published": True}

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -45,6 +45,7 @@
         vm.reverseSort = false;
         vm.columnIndexSort = 0;
         vm.disableSubmit = true;
+        vm.emailVerification = true;
         // save initial ranking
         vm.initial_ranking = {};
       // loader for existing teams
@@ -341,6 +342,10 @@
                             utilities.hideLoader();
                         },
                         onError: function() {
+                            var error = response.data;
+                            $rootScope.notify("error", error.detail);
+                            vm.emailVerification = false;
+                            vm.emailError = error.detail;
                             utilities.hideLoader();
                         }
                     };
@@ -1545,7 +1550,7 @@
                 },
                 onError: function(response) {
                     var error = response.data;
-                    $rootScope.notify("error", error);
+                    $rootScope.notify("error", error.detail);
                 }
             };
             utilities.sendRequest(parameters);

--- a/frontend/src/js/directives/directives.js
+++ b/frontend/src/js/directives/directives.js
@@ -334,3 +334,18 @@
         }
     }
 })();
+(function() {
+    'use strict';
+    angular.module('evalai').directive('permissionDenied', permissionDenied);
+
+    function permissionDenied() {
+        var directive = {
+            templateUrl: 'dist/views/web/permission-denied.html',
+            transclude: true,
+            restrict: 'EA',
+        };
+        return directive;
+
+
+    }
+})();

--- a/frontend/src/js/route-config/route-config.js
+++ b/frontend/src/js/route-config/route-config.js
@@ -227,6 +227,8 @@
             parent: "web.challenge-main.challenge-page",
             url: "/participate",
             templateUrl: baseUrl + "/web/challenge/participate.html",
+            controller: 'ChallengeCtrl',
+            controllerAs: 'challenge',
             title: 'Participate',
         };
 

--- a/frontend/src/views/web/challenge/participate.html
+++ b/frontend/src/views/web/challenge/participate.html
@@ -1,4 +1,4 @@
-<div ng-if="isAuth">
+<div ng-if="isAuth && challenge.emailVerification">
     <section ng-if="challenge.isActive" class="ev-sm-container ev-view challenge-container">
         <div ng-if="challenge.isParticipated" class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view">
             <p><strong>You have already participated in the challenge with a team!</strong></p>
@@ -91,6 +91,7 @@
         </div>
     </section>
 </div>
+<permission-Denied ng-if="!challenge.emailVerification"></permission-Denied>
 <section ng-if="!isAuth" class="ev-sm-container ev-view challenge-container">
     <div class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view">
         <p ng-if="!isAuth">Please <a ui-sref="auth.login" class="blue-text" ui-sref-active="active-auth" ng-click="auth.resetForm()">log in</a> to participate in this challenge.</p>

--- a/frontend/src/views/web/permission-denied.html
+++ b/frontend/src/views/web/permission-denied.html
@@ -7,8 +7,8 @@
                 </div>
                 <div class="card-stacked">
                     <div class="card-content">
-                        <p><strong>Unable to create or select a team.</strong>
-                            <br> {{perm.emailError}}</p>
+                        <p><strong>{{perm.emailError}}</strong></p>
+                        <p><strong>{{ challenge.emailError }}</strong></p>
                     </div>
                 </div>
             </div>

--- a/frontend/tests/controllers-test/challengeCtrl.test.js
+++ b/frontend/tests/controllers-test/challengeCtrl.test.js
@@ -15,7 +15,7 @@ describe('Unit tests for challenge controller', function () {
         $interval = _$interval_;
         $mdDialog = _$mdDialog_;
         moment = _moment_;
-        
+
         $scope = $rootScope.$new();
         createController = function () {
             return $controller('ChallengeCtrl', {$scope: $scope});
@@ -214,7 +214,7 @@ describe('Unit tests for challenge controller', function () {
         team_list.forEach(response => {
             it('pagination next is ' + response.next + ' and previous is ' + response.previous + '\
                 `participants/participant_team`', function () {;
-                challengeSuccess = true;    
+                challengeSuccess = true;
                 participantTeamChallengeSuccess = true;
                 participantTeamSuccess = true;
                 selectExistTeamSuccess = null;
@@ -446,7 +446,7 @@ describe('Unit tests for challenge controller', function () {
                 }
             };
             utilities.storeData('userKey', 'encrypted key');
-       
+
             vm = createController();
             spyOn(vm, 'startLoader');
             spyOn($http, 'get').and.callFake(function () {
@@ -1055,7 +1055,7 @@ describe('Unit tests for challenge controller', function () {
                 // get submissions response
                 next: "page=4",
                 previous: "page=2",
-            };      
+            };
             vm.getResults(phaseId);
             spyOn($http, 'get').and.callFake(function () {
                 var deferred = $injector.get('$q').defer();
@@ -2394,7 +2394,7 @@ describe('Unit tests for challenge controller', function () {
         });
 
         it('change challenge state from `public` to `private`', function () {
-            vm.isPublished = true; 
+            vm.isPublished = true;
             vm.publishChallenge(ev);
             expect(vm.publishDesc).toEqual(null);
             expect(ev.stopPropagation).toHaveBeenCalled();
@@ -2402,7 +2402,7 @@ describe('Unit tests for challenge controller', function () {
         });
 
         it('change challenge state from `private` to `public`', function () {
-            vm.isPublished = false; 
+            vm.isPublished = false;
             vm.publishChallenge(ev);
             expect(vm.publishDesc).toEqual(null);
             expect(ev.stopPropagation).toHaveBeenCalled();

--- a/frontend/tests/controllers-test/challengeCtrl.test.js
+++ b/frontend/tests/controllers-test/challengeCtrl.test.js
@@ -1777,7 +1777,7 @@ describe('Unit tests for challenge controller', function () {
         it('backend error', function () {
             success = false;
             vm.starChallenge();
-            expect($rootScope.notify).toHaveBeenCalledWith("error", errorResponse);
+            expect($rootScope.notify).toHaveBeenCalledWith("error", errorResponse.detail);
         });
     });
 

--- a/tests/unit/accounts/test_permissions.py
+++ b/tests/unit/accounts/test_permissions.py
@@ -3,6 +3,7 @@ from rest_framework.test import APITestCase
 from rest_framework import permissions
 
 from allauth.account.models import EmailAddress
+from django.contrib.auth.models import User, AnonymousUser
 from django.test.client import RequestFactory
 
 from accounts.permissions import HasVerifiedEmail
@@ -16,26 +17,35 @@ class HasVerifiedEmailTest(BaseAPITestClass):
         super(HasVerifiedEmailTest, self).setUp()
 
     def test_has_verified_email_when_request_user_is_anonymous(self):
-        test_request = self.factory.get('')
-        test_request.user.is_anonymous = True
+        test_request = self.factory.get('challenge/')
+        test_request.user = AnonymousUser()
         test_view = None
 
-        self.assertTrue(HasVerifiedEmail(test_request, test_view))
+        test_has_verified_email = HasVerifiedEmail()
+        self.assertTrue(test_has_verified_email.has_permission(test_request, test_view))
 
-    @mock.patch("accounts.permissions.EmailAddress.objects")
-    def test_has_verified_email_when_verified_email_address_objects_exist(self, mock_email_objects):
-        mock_email_objects.filter.return_value = mock_email_objects
-        mock_email_objects.exists.return_value = True
+    @mock.patch("allauth.account.models.EmailAddress.objects")
+    @mock.patch("allauth.account.models.EmailAddress.objects.filter")
+    @mock.patch("allauth.account.models.EmailAddress.objects.exists")
+    def test_has_verified_email_when_verified_email_address_objects_exist(self, mock_email_address_exists, mock_email_address_filter, mock_email_address_objects):
+        mock_email_address_filter.return_value = mock_email_address_objects
+        mock_email_address_exists.return_value = True
 
-        test_request = self.factory.get('/about')
+        test_request = self.factory.get('challenge/')
+        test_request.user = User()
         test_view = None
-        self.assertTrue(HasVerifiedEmail(test_requqest, test_view))
+        test_has_verified_email = HasVerifiedEmail()
+        self.assertTrue(test_has_verified_email.has_permission(test_request, test_view))
 
-    @mock.patch("accounts.permissions.EmailAddress.objects")
-    def test_has_verified_email_when_verified_email_address_objects_do_not_exist(self, mock_email_objects):
-        mock_email_objects.filter.return_value = mock_email_objects
-        mock_email_objects.exists.return_value = False
+    @mock.patch("allauth.account.models.EmailAddress.objects")
+    @mock.patch("allauth.account.models.EmailAddress.objects.filter")
+    @mock.patch("allauth.account.models.EmailAddress.objects.exists")
+    def test_has_verified_email_when_verified_email_address_objects_do_not_exist(self, mock_email_address_exists, mock_email_address_filter, mock_email_address_objects):
+        mock_email_address_filter.return_value = mock_email_address_objects
+        mock_email_address_exists.return_value = False
 
-        test_request = self.factory.get('/about')
+        test_request = self.factory.get('challenge/')
+        test_request.user = User()
         test_view = None
-        self.assertFalse(HasVerifiedEmail(test_requqest, test_view))
+        test_has_verified_email = HasVerifiedEmail()
+        self.assertFalse(test_has_verified_email.has_permission(test_request, test_view))

--- a/tests/unit/accounts/test_permissions.py
+++ b/tests/unit/accounts/test_permissions.py
@@ -1,9 +1,7 @@
-import unittest, mock
+import mock
 from mock import Mock
 from rest_framework.test import APITestCase
-from rest_framework import permissions
 
-from allauth.account.models import EmailAddress
 from django.contrib.auth.models import User, AnonymousUser
 from django.test.client import RequestFactory
 
@@ -13,9 +11,11 @@ class BaseAPITestClass(APITestCase):
     def setUp(self):
         self.factory = RequestFactory()
 
+
 class HasVerifiedEmailTest(BaseAPITestClass):
     def setUp(self):
         super(HasVerifiedEmailTest, self).setUp()
+
 
     def test_has_verified_email_when_request_user_is_anonymous(self):
         test_request = self.factory.get('challenge/')

--- a/tests/unit/accounts/test_permissions.py
+++ b/tests/unit/accounts/test_permissions.py
@@ -1,4 +1,5 @@
 import unittest, mock
+from mock import Mock
 from rest_framework.test import APITestCase
 from rest_framework import permissions
 
@@ -25,11 +26,10 @@ class HasVerifiedEmailTest(BaseAPITestClass):
         self.assertTrue(test_has_verified_email.has_permission(test_request, test_view))
 
     @mock.patch("allauth.account.models.EmailAddress.objects")
-    @mock.patch("allauth.account.models.EmailAddress.objects.filter")
-    @mock.patch("allauth.account.models.EmailAddress.objects.exists")
-    def test_has_verified_email_when_verified_email_address_objects_exist(self, mock_email_address_exists, mock_email_address_filter, mock_email_address_objects):
-        mock_email_address_filter.return_value = mock_email_address_objects
-        mock_email_address_exists.return_value = True
+    def test_has_verified_email_when_verified_email_address_objects_exist(self, mock_email_address_objects):
+        mock_email_address_objects_filter = Mock()
+        mock_email_address_objects.filter.return_value = mock_email_address_objects_filter
+        mock_email_address_objects_filter.exists.return_value = True
 
         test_request = self.factory.get('challenge/')
         test_request.user = User()
@@ -38,11 +38,10 @@ class HasVerifiedEmailTest(BaseAPITestClass):
         self.assertTrue(test_has_verified_email.has_permission(test_request, test_view))
 
     @mock.patch("allauth.account.models.EmailAddress.objects")
-    @mock.patch("allauth.account.models.EmailAddress.objects.filter")
-    @mock.patch("allauth.account.models.EmailAddress.objects.exists")
-    def test_has_verified_email_when_verified_email_address_objects_do_not_exist(self, mock_email_address_exists, mock_email_address_filter, mock_email_address_objects):
-        mock_email_address_filter.return_value = mock_email_address_objects
-        mock_email_address_exists.return_value = False
+    def test_has_verified_email_when_verified_email_address_objects_do_not_exist(self, mock_email_address_objects):
+        mock_email_address_objects_filter = Mock()
+        mock_email_address_objects.filter.return_value = mock_email_address_objects_filter
+        mock_email_address_objects_filter.exists.return_value = False
 
         test_request = self.factory.get('challenge/')
         test_request.user = User()

--- a/tests/unit/accounts/test_permissions.py
+++ b/tests/unit/accounts/test_permissions.py
@@ -1,0 +1,41 @@
+import unittest, mock
+from rest_framework.test import APITestCase
+from rest_framework import permissions
+
+from allauth.account.models import EmailAddress
+from django.test.client import RequestFactory
+
+from accounts.permissions import HasVerifiedEmail
+
+class BaseAPITestClass(APITestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+class HasVerifiedEmailTest(BaseAPITestClass):
+    def setUp(self):
+        super(HasVerifiedEmailTest, self).setUp()
+
+        def test_has_verified_email_when_request_user_is_anonymous(self):
+            test_request = self.factory.get('')
+            test_request.user.is_anonymous = True
+            test_view = None
+
+            self.assertTrue(HasVerifiedEmail(test_request, test_view))
+
+        @mock.patch("accounts.permissions.EmailAddress.objects")
+        def test_has_verified_email_when_verified_email_address_objects_exist(self, mock_email_objects):
+            mock_email_objects.filter.return_value = mock_email_objects
+            mock_email_objects.exists.return_value = True
+
+            test_request = self.factory.get('/about')
+            test_view = None
+            self.assertTrue(HasVerifiedEmail(test_requqest, test_view))
+
+        @mock.patch("accounts.permissions.EmailAddress.objects")
+        def test_has_verified_email_when_verified_email_address_objects_do_not_exist(self, mock_email_objects):
+            mock_email_objects.filter.return_value = mock_email_objects
+            mock_email_objects.exists.return_value = False
+
+            test_request = self.factory.get('/about')
+            test_view = None
+            self.assertFalse(HasVerifiedEmail(test_requqest, test_view))

--- a/tests/unit/accounts/test_permissions.py
+++ b/tests/unit/accounts/test_permissions.py
@@ -15,27 +15,27 @@ class HasVerifiedEmailTest(BaseAPITestClass):
     def setUp(self):
         super(HasVerifiedEmailTest, self).setUp()
 
-        def test_has_verified_email_when_request_user_is_anonymous(self):
-            test_request = self.factory.get('')
-            test_request.user.is_anonymous = True
-            test_view = None
+    def test_has_verified_email_when_request_user_is_anonymous(self):
+        test_request = self.factory.get('')
+        test_request.user.is_anonymous = True
+        test_view = None
 
-            self.assertTrue(HasVerifiedEmail(test_request, test_view))
+        self.assertTrue(HasVerifiedEmail(test_request, test_view))
 
-        @mock.patch("accounts.permissions.EmailAddress.objects")
-        def test_has_verified_email_when_verified_email_address_objects_exist(self, mock_email_objects):
-            mock_email_objects.filter.return_value = mock_email_objects
-            mock_email_objects.exists.return_value = True
+    @mock.patch("accounts.permissions.EmailAddress.objects")
+    def test_has_verified_email_when_verified_email_address_objects_exist(self, mock_email_objects):
+        mock_email_objects.filter.return_value = mock_email_objects
+        mock_email_objects.exists.return_value = True
 
-            test_request = self.factory.get('/about')
-            test_view = None
-            self.assertTrue(HasVerifiedEmail(test_requqest, test_view))
+        test_request = self.factory.get('/about')
+        test_view = None
+        self.assertTrue(HasVerifiedEmail(test_requqest, test_view))
 
-        @mock.patch("accounts.permissions.EmailAddress.objects")
-        def test_has_verified_email_when_verified_email_address_objects_do_not_exist(self, mock_email_objects):
-            mock_email_objects.filter.return_value = mock_email_objects
-            mock_email_objects.exists.return_value = False
+    @mock.patch("accounts.permissions.EmailAddress.objects")
+    def test_has_verified_email_when_verified_email_address_objects_do_not_exist(self, mock_email_objects):
+        mock_email_objects.filter.return_value = mock_email_objects
+        mock_email_objects.exists.return_value = False
 
-            test_request = self.factory.get('/about')
-            test_view = None
-            self.assertFalse(HasVerifiedEmail(test_requqest, test_view))
+        test_request = self.factory.get('/about')
+        test_view = None
+        self.assertFalse(HasVerifiedEmail(test_requqest, test_view))

--- a/tests/unit/accounts/test_permissions.py
+++ b/tests/unit/accounts/test_permissions.py
@@ -7,6 +7,7 @@ from django.test.client import RequestFactory
 
 from accounts.permissions import HasVerifiedEmail
 
+
 class BaseAPITestClass(APITestCase):
     def setUp(self):
         self.factory = RequestFactory()
@@ -15,7 +16,6 @@ class BaseAPITestClass(APITestCase):
 class HasVerifiedEmailTest(BaseAPITestClass):
     def setUp(self):
         super(HasVerifiedEmailTest, self).setUp()
-
 
     def test_has_verified_email_when_request_user_is_anonymous(self):
         test_request = self.factory.get('challenge/')

--- a/tests/unit/worker/test_submission_worker.py
+++ b/tests/unit/worker/test_submission_worker.py
@@ -199,9 +199,6 @@ class BaseAPITestClass(APITestCase):
         mock_logger.assert_called_with("Submission {} does not exist".format(non_existing_submission_pk))
         self.assertEqual(value, None)
 
-    def test_successful_run_submission(self):
-        pass
-
     @mock.patch("scripts.workers.submission_worker.load_challenge")
     def test_load_challenge_and_return_max_submissions(self, mocked_load_challenge):
         q_params = {"pk": self.challenge.pk}

--- a/tests/unit/worker/test_submission_worker.py
+++ b/tests/unit/worker/test_submission_worker.py
@@ -199,6 +199,9 @@ class BaseAPITestClass(APITestCase):
         mock_logger.assert_called_with("Submission {} does not exist".format(non_existing_submission_pk))
         self.assertEqual(value, None)
 
+    def test_successful_run_submission(self):
+        pass
+
     @mock.patch("scripts.workers.submission_worker.load_challenge")
     def test_load_challenge_and_return_max_submissions(self, mocked_load_challenge):
         q_params = {"pk": self.challenge.pk}


### PR DESCRIPTION
I used the changes from #2577 and wrote the unit tests for permissions.py, as was asked of.

Corresponding GCI task description:
"Observed Behaviour: If an unverified user tries to view a challenge page, he is not able to do so and is told to verify the email first.

Expected Behaviour: The unverified user should be allowed to view the challenge page and if he visits the Participate tab , an error stating to verify email address should be shown.

#2241"