### PR TITLE
Add feature to update job name in submission

### DIFF
--- a/apps/jobs/admin.py
+++ b/apps/jobs/admin.py
@@ -34,6 +34,7 @@ class SubmissionAdmin(ImportExportTimeStampedAdmin):
         "stderr_file",
         "submission_result_file",
         "submission_metadata_file",
+        "job_name",
     )
     list_filter = (
         "challenge_phase__challenge",

--- a/apps/jobs/serializers.py
+++ b/apps/jobs/serializers.py
@@ -50,6 +50,7 @@ class SubmissionSerializer(serializers.ModelSerializer):
             "submission_result_file",
             "when_made_public",
             "is_baseline",
+            "job_name",
         )
 
     def get_participant_team_name(self, obj):

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -999,11 +999,20 @@ def update_submission(request, challenge_pk):
     if request.method == "PATCH":
         submission_pk = request.data.get("submission")
         submission_status = request.data.get("submission_status", "").lower()
+        job_name = request.data.get("job_name", "").lower()
         submission = get_submission_model(submission_pk)
+        jobs = submission.job_name
+        if job_name:
+            jobs.append(job_name)
         if submission_status not in [Submission.RUNNING]:
             response_data = {"error": "Sorry, submission status is invalid"}
             return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
-        data = {"status": submission_status, "started_at": timezone.now()}
+
+        data = {
+            "status": submission_status,
+            "started_at": timezone.now(),
+            "job_name": jobs,
+        }
         serializer = SubmissionSerializer(
             submission, data=data, partial=True, context={"request": request}
         )

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -2543,7 +2543,7 @@ class BaseChallengePhaseSplitClass(BaseAPITestClass):
             visibility=ChallengePhaseSplit.PUBLIC,
             leaderboard_decimal_precision=2,
             is_leaderboard_order_descending=True,
-            show_leaderboard_by_latest_submission=False
+            show_leaderboard_by_latest_submission=False,
         )
 
         self.challenge_phase_split_host = ChallengePhaseSplit.objects.create(
@@ -2551,7 +2551,7 @@ class BaseChallengePhaseSplitClass(BaseAPITestClass):
             challenge_phase=self.challenge_phase,
             leaderboard=self.leaderboard,
             visibility=ChallengePhaseSplit.HOST,
-            show_leaderboard_by_latest_submission=False
+            show_leaderboard_by_latest_submission=False,
         )
 
     def tearDown(self):
@@ -2575,8 +2575,7 @@ class GetChallengePhaseSplitTest(BaseChallengePhaseSplitClass):
                 "dataset_split": self.dataset_split.id,
                 "dataset_split_name": self.dataset_split.name,
                 "visibility": self.challenge_phase_split.visibility,
-                "show_leaderboard_by_latest_submission":
-                    self.challenge_phase_split.show_leaderboard_by_latest_submission
+                "show_leaderboard_by_latest_submission": self.challenge_phase_split.show_leaderboard_by_latest_submission,
             }
         ]
         self.client.force_authenticate(user=self.participant_user)
@@ -2612,8 +2611,7 @@ class GetChallengePhaseSplitTest(BaseChallengePhaseSplitClass):
                 "dataset_split": self.dataset_split.id,
                 "dataset_split_name": self.dataset_split.name,
                 "visibility": self.challenge_phase_split.visibility,
-                "show_leaderboard_by_latest_submission":
-                    self.challenge_phase_split.show_leaderboard_by_latest_submission
+                "show_leaderboard_by_latest_submission": self.challenge_phase_split.show_leaderboard_by_latest_submission,
             },
             {
                 "id": self.challenge_phase_split_host.id,
@@ -2622,8 +2620,7 @@ class GetChallengePhaseSplitTest(BaseChallengePhaseSplitClass):
                 "dataset_split": self.dataset_split_host.id,
                 "dataset_split_name": self.dataset_split_host.name,
                 "visibility": self.challenge_phase_split_host.visibility,
-                "show_leaderboard_by_latest_submission":
-                    self.challenge_phase_split_host.show_leaderboard_by_latest_submission
+                "show_leaderboard_by_latest_submission": self.challenge_phase_split_host.show_leaderboard_by_latest_submission,
             },
         ]
         self.client.force_authenticate(user=self.user)
@@ -3206,6 +3203,7 @@ class GetAllSubmissionsTest(BaseAPITestClass):
                 "is_flagged": self.submission1.is_flagged,
                 "when_made_public": self.submission1.when_made_public,
                 "is_baseline": self.submission1.is_baseline,
+                "job_name": self.submission1.job_name,
             }
         ]
         self.challenge5.participant_teams.add(self.participant_team6)
@@ -3720,7 +3718,7 @@ class GetOrUpdateChallengePhaseSplitTest(BaseChallengePhaseSplitClass):
             "visibility": self.challenge_phase_split.visibility,
             "leaderboard_decimal_precision": self.challenge_phase_split.leaderboard_decimal_precision,
             "is_leaderboard_order_descending": self.challenge_phase_split.is_leaderboard_order_descending,
-            "show_leaderboard_by_latest_submission": self.challenge_phase_split.show_leaderboard_by_latest_submission
+            "show_leaderboard_by_latest_submission": self.challenge_phase_split.show_leaderboard_by_latest_submission,
         }
         response = self.client.get(self.url)
         self.assertEqual(response.data, expected)
@@ -4078,9 +4076,7 @@ class GetAWSCredentialsForParticipantTeamTest(BaseChallengePhaseClass):
             "challenges:get_aws_credentials_for_participant_team",
             kwargs={"phase_pk": self.challenge_phase.pk},
         )
-        expected = {
-            "error": "Sorry, this is not a docker based challenge."
-        }
+        expected = {"error": "Sorry, this is not a docker based challenge."}
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -4090,9 +4086,7 @@ class GetAWSCredentialsForParticipantTeamTest(BaseChallengePhaseClass):
             "challenges:get_aws_credentials_for_participant_team",
             kwargs={"phase_pk": self.challenge_phase.pk},
         )
-        expected = {
-            "error": "You have not participated in this challenge."
-        }
+        expected = {"error": "You have not participated in this challenge."}
         self.client.force_authenticate(user=self.user2)
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -172,7 +172,7 @@ class BaseAPITestClass(APITestCase):
         )
 
         self.rl_submission_file = SimpleUploadedFile(
-            "submission.json", b'{"submitted_image_uri": "evalai-repo.com"}',
+            "submission.json", b'{"submitted_image_uri": "evalai-repo.com"}'
         )
 
     def tearDown(self):
@@ -638,6 +638,7 @@ class GetChallengeSubmissionTest(BaseAPITestClass):
                 "is_flagged": self.submission.is_flagged,
                 "when_made_public": self.submission.when_made_public,
                 "is_baseline": self.submission.is_baseline,
+                "job_name": self.submission.job_name,
             }
         ]
         self.challenge.participant_teams.add(self.participant_team)
@@ -1309,6 +1310,7 @@ class ChangeSubmissionDataAndVisibilityTest(BaseAPITestClass):
                 self.submission.when_made_public.isoformat(), "Z"
             ).replace("+00:00", ""),
             "is_baseline": self.submission.is_baseline,
+            "job_name": self.submission.job_name,
         }
         self.challenge.participant_teams.add(self.participant_team)
         response = self.client.patch(self.url, self.data)
@@ -1354,6 +1356,7 @@ class ChangeSubmissionDataAndVisibilityTest(BaseAPITestClass):
                 self.private_submission.when_made_public.isoformat(), "Z"
             ).replace("+00:00", ""),
             "is_baseline": self.submission.is_baseline,
+            "job_name": self.submission.job_name,
         }
 
         self.client.force_authenticate(user=self.user)
@@ -1417,15 +1420,14 @@ class ChangeSubmissionDataAndVisibilityTest(BaseAPITestClass):
                 self.submission.when_made_public.isoformat(), "Z"
             ).replace("+00:00", ""),
             "is_baseline": self.submission.is_baseline,
+            "job_name": self.submission.job_name,
         }
         self.challenge.participant_teams.add(self.participant_team)
         response = self.client.patch(self.url, self.data)
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_toggle_baseline_when_user_is_not_a_host(
-        self
-    ):
+    def test_toggle_baseline_when_user_is_not_a_host(self):
         self.url = reverse_lazy(
             "jobs:change_submission_data_and_visibility",
             kwargs={
@@ -1437,14 +1439,14 @@ class ChangeSubmissionDataAndVisibilityTest(BaseAPITestClass):
         self.data = {"is_baseline": True}
         self.challenge.save()
         self.client.force_authenticate(user=self.user1)
-        expected = {"error": "Sorry, you are not authorized to make this request"}
+        expected = {
+            "error": "Sorry, you are not authorized to make this request"
+        }
         response = self.client.patch(self.url, self.data)
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_toggle_baseline_when_user_is_host(
-        self
-    ):
+    def test_toggle_baseline_when_user_is_host(self):
         self.url = reverse_lazy(
             "jobs:change_submission_data_and_visibility",
             kwargs={
@@ -1474,14 +1476,17 @@ class ChangeSubmissionDataAndVisibilityTest(BaseAPITestClass):
             "stderr_file": None,
             "submission_result_file": None,
             "submitted_at": "{0}{1}".format(
-                self.host_participant_team_submission.submitted_at.isoformat(), "Z"
+                self.host_participant_team_submission.submitted_at.isoformat(),
+                "Z",
             ).replace("+00:00", ""),
             "is_public": self.host_participant_team_submission.is_public,
             "is_flagged": self.host_participant_team_submission.is_flagged,
             "when_made_public": "{0}{1}".format(
-                self.host_participant_team_submission.when_made_public.isoformat(), "Z"
+                self.host_participant_team_submission.when_made_public.isoformat(),
+                "Z",
             ).replace("+00:00", ""),
             "is_baseline": True,
+            "job_name": self.host_participant_team_submission.job_name,
         }
         response = self.client.patch(self.url, self.data)
         self.assertEqual(response.data, expected)
@@ -1555,6 +1560,7 @@ class ChangeSubmissionDataAndVisibilityTest(BaseAPITestClass):
                 self.submission.when_made_public.isoformat(), "Z"
             ).replace("+00:00", ""),
             "is_baseline": self.submission.is_baseline,
+            "job_name": self.submission.job_name,
         }
 
         self.client.force_authenticate(user=self.submission.created_by)
@@ -1595,6 +1601,7 @@ class ChangeSubmissionDataAndVisibilityTest(BaseAPITestClass):
                 self.submission.when_made_public.isoformat(), "Z"
             ).replace("+00:00", ""),
             "is_baseline": self.submission.is_baseline,
+            "job_name": self.submission.job_name,
         }
 
         self.client.force_authenticate(user=self.user)
@@ -1734,9 +1741,15 @@ class ChallengeLeaderboardTest(BaseAPITestClass):
 
         self.result_json_2 = {"score": 10.0, "test-score": 20.0}
 
-        self.result_json_host_participant_team = {"score": 52.0, "test-score": 80.0}
+        self.result_json_host_participant_team = {
+            "score": 52.0,
+            "test-score": 80.0,
+        }
 
-        self.result_json_host_participant_team_2 = {"score": 20.0, "test-score": 60.0}
+        self.result_json_host_participant_team_2 = {
+            "score": 20.0,
+            "test-score": 60.0,
+        }
 
         self.expected_results = [
             self.result_json["score"],
@@ -1889,7 +1902,7 @@ class ChallengeLeaderboardTest(BaseAPITestClass):
                     "submission__submitted_at": self.submission.submitted_at,
                     "submission__is_baseline": False,
                     "submission__method_name": self.submission.method_name,
-                }
+                },
             ],
         }
         expected = collections.OrderedDict(expected)
@@ -1975,7 +1988,7 @@ class ChallengeLeaderboardTest(BaseAPITestClass):
                     "submission__submitted_at": self.host_participant_team_submission_2.submitted_at,
                     "submission__is_baseline": True,
                     "submission__method_name": self.host_participant_team_submission_2.method_name,
-                }
+                },
             ],
         }
         expected = collections.OrderedDict(expected)


### PR DESCRIPTION
Changes in this PR -
1. Add `job_name` in submission admin
2. Update `job_name` in the database using the update_submission API

cc: @vkartik97 