### PR TITLE
Add API documentation for AWS SQS endpoints

### DIFF
--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -402,7 +402,7 @@ def change_submission_data_and_visibility(
             required=True,
         )
     ],
-    operation_id="Get_Leaderboard_Data",
+    operation_id="leaderboard",
     responses={
         status.HTTP_200_OK: openapi.Response(
             description="",
@@ -464,6 +464,12 @@ def change_submission_data_and_visibility(
 def leaderboard(request, challenge_phase_split_id):
     """
     Returns leaderboard for a corresponding Challenge Phase Split
+
+    - Arguments:
+        ``challenge_phase_split_id``: Primary key for the challenge phase split for which leaderboard is to be fetched
+
+    - Returns:
+        Leaderboard entry objects in a list
     """
 
     # check if the challenge exists or not
@@ -1190,12 +1196,12 @@ def get_submission_message_from_queue(request, queue_name):
     """
     API to fetch submission message from AWS SQS queue.
 
-    Path Parameters:
-     - ``queue_name``: AWS SQS queue name
+    - Arguments:
+        ``queue_name``: AWS SQS queue name
 
-    Response Schema:
-     - ``body``: The message body content
-     - ``receipt_handle``: The message receipt handle
+    - Returns:
+        ``body``: The message body content as a key-value pair
+        ``receipt_handle``: The message receipt handle
     """
     try:
         challenge = Challenge.objects.get(queue=queue_name)  # noqa

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -816,6 +816,41 @@ def get_submission_by_pk(request, submission_id):
         ),
     },
 )
+@swagger_auto_schema(
+    methods=["patch"],
+    manual_parameters=[
+        openapi.Parameter(
+            name="challenge_pk",
+            in_=openapi.IN_PATH,
+            type=openapi.TYPE_STRING,
+            description="Challenge ID",
+            required=True,
+        )
+    ],
+    operation_id="update_submission",
+    request_body=openapi.Schema(
+        type=openapi.TYPE_OBJECT,
+        properties={
+            "submission": openapi.Schema(
+                type=openapi.TYPE_STRING, description="Submission ID"
+            ),
+            "job_name": openapi.Schema(
+                type=openapi.TYPE_STRING,
+                description="Job name for the running submission",
+            ),
+            "submission_status": openapi.Schema(
+                type=openapi.TYPE_STRING,
+                description="Updated status of submission from submitted i.e. RUNNING",
+            ),
+        },
+    ),
+    responses={
+        status.HTTP_200_OK: openapi.Response("{<updated submission-data>}"),
+        status.HTTP_400_BAD_REQUEST: openapi.Response(
+            "{'error': 'Error message goes here'}"
+        ),
+    },
+)
 @api_view(["PUT", "PATCH"])
 @throttle_classes([UserRateThrottle])
 @permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))


### PR DESCRIPTION
This PR includes -
- [ ] API documentation for the `get_message_from_sqs_queue` API
- [ ] API documentation for the `delete_message_from_sqs_queue` API
- [ ] Error response format for the `get_message_from_sqs_queue` and `delete_message_from_sqs_queue` is changed.
- [ ] Fix documentation for `leaderboard` API
- [ ] Add documentation for the `update_submission` PATCH API