### PR TITLE
Fix #2685 Updated Python to 3.7.5

### DIFF
--- a/docker/dev/celery/Dockerfile
+++ b/docker/dev/celery/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.7.5
 
 ENV PYTHONUNBUFFERED 1
 

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.7.5
 
 ENV PYTHONUNBUFFERED 1
 

--- a/docker/dev/worker/Dockerfile
+++ b/docker/dev/worker/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.6.5
+FROM python:3.7.5
 
 ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update && \
   apt-get upgrade -y && \
-  apt-get install -q -y openjdk-8-jdk
+  apt-get install -q -y default-jdk
 
 RUN mkdir /code
 WORKDIR /code


### PR DESCRIPTION
- [x] Updated Django docker container dev Dockerfile with python3.7.5 as the base image.

- [x] Updated worker docker container dev Dockerfile with python3.7.5 as the base image.

- [x] Updated celery container dev Dockerfile with python3.7.5 as the base image
(closes #2685 )