### PR TITLE
Fix #2691: Update python version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 services:
 - docker
 python:
-- '3.6'
+- '3.7.5'
 addons:
   postgresql: '10'
   apt:


### PR DESCRIPTION
Updates python version to 3.7.5 (closes #2691 )