### PR TITLE
Fix #2702: Fix travis build of permission ctrl test

### DIFF
--- a/frontend/tests/controllers-test/permissionCtrl.test.js
+++ b/frontend/tests/controllers-test/permissionCtrl.test.js
@@ -14,6 +14,7 @@ describe('Unit tests for permission controller', function () {
         createController = function () {
             return $controller('PermCtrl', {$scope: $scope});
         };
+        utilities.storeData('emailError', 'Email is not verified');
         vm = $controller('PermCtrl', { $scope: $scope });
     }));
 


### PR DESCRIPTION
Fixes #2702 

- Stored default message for the `emailError` local storage so that it gets the message when it call `utilities.getData`.

