### PR TITLE
Fix #2699: Adds API to filter and get challenges by title

### DIFF
--- a/apps/challenges/urls.py
+++ b/apps/challenges/urls.py
@@ -50,7 +50,7 @@ urlpatterns = [
         name="get_challenge_by_pk",
     ),
     url(
-        r"^challenge/(?P<title>[A-Za-z\w\s]+)/$",
+        r"^challenge/(?P<title>[\w\s]+)/$",
         views.get_challenge_by_title,
         name="get_challenge_by_title",
     ),

--- a/apps/challenges/urls.py
+++ b/apps/challenges/urls.py
@@ -50,6 +50,11 @@ urlpatterns = [
         name="get_challenge_by_pk",
     ),
     url(
+        r"^challenge/(?P<title>[A-Za-z\w\s]+)/$",
+        views.get_challenge_by_title,
+        name="get_challenge_by_title",
+    ),
+    url(
         r"^challenge$",
         views.get_challenges_based_on_teams,
         name="get_challenges_based_on_teams",

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -426,6 +426,7 @@ def get_challenge_by_pk(request, pk):
         response_data = {"error": "Challenge does not exist!"}
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
+
 @api_view(["GET"])
 @throttle_classes([AnonRateThrottle])
 def get_challenge_by_title(request, title):
@@ -441,10 +442,10 @@ def get_challenge_by_title(request, title):
             challenge, context={"request": request}
         )
         response_data.append(serializer.data)
-    if len(response_data)==0:
+    if len(response_data) == 0:
         exception_data = {"error": "Challenge does not exist!"}
         return Response(exception_data, status=status.HTTP_406_NOT_ACCEPTABLE)
-    return Response(response_data, status=status.HTTP_200_OK)        
+    return Response(response_data, status=status.HTTP_200_OK)
 
 
 @api_view(["GET"])

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -426,6 +426,26 @@ def get_challenge_by_pk(request, pk):
         response_data = {"error": "Challenge does not exist!"}
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
+@api_view(["GET"])
+@throttle_classes([AnonRateThrottle])
+def get_challenge_by_title(request, title):
+    """
+    Returns a particular challenge by title. The string in request should exactly match the title of challenge.
+    """
+    challenges = Challenge.objects.filter(
+        title__icontains=title, approved_by_admin=True, published=True
+    )
+    response_data = []
+    for challenge in challenges:
+        serializer = ChallengeSerializer(
+            challenge, context={"request": request}
+        )
+        response_data.append(serializer.data)
+    if len(response_data)==0:
+        exception_data = {"error": "Challenge does not exist!"}
+        return Response(exception_data, status=status.HTTP_406_NOT_ACCEPTABLE)
+    return Response(response_data, status=status.HTTP_200_OK)        
+
 
 @api_view(["GET"])
 @throttle_classes([UserRateThrottle])

--- a/docker/dev/django/container-start.sh
+++ b/docker/dev/django/container-start.sh
@@ -2,4 +2,4 @@
 cd /code && \
 python manage.py migrate --noinput && \
 python manage.py seed && \
-python manage.py runserver 0.0.0.0:8000 --settings=settings.dev
+python manage.py runserver 0.0.0.0:8000

--- a/docker/dev/django/container-start.sh
+++ b/docker/dev/django/container-start.sh
@@ -2,4 +2,4 @@
 cd /code && \
 python manage.py migrate --noinput && \
 python manage.py seed && \
-python manage.py runserver 0.0.0.0:8000
+python manage.py runserver 0.0.0.0:8000 --settings=settings.dev

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -1313,6 +1313,7 @@ class GetFeaturedChallengesTest(BaseAPITestClass):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["results"], expected)
 
+
 class GetChallengeByTitle(BaseAPITestClass):
     def setUp(self):
         super(GetChallengeByTitle, self).setUp()

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -1317,41 +1317,12 @@ class GetChallengeByTitle(BaseAPITestClass):
     def setUp(self):
         super(GetChallengeByTitle, self).setUp()
 
-        self.user1 = User.objects.create(
-            username="user1",
-            email="user1@test.com",
-            password="secret_password",
-        )
-
-        EmailAddress.objects.create(
-            user=self.user1,
-            email="user1@test.com",
-            primary=True,
-            verified=True,
-        )
-
         self.challenge3 = Challenge.objects.create(
             title="Test Challenge 3",
             short_description="Short description for test challenge 3",
             description="Description for test challenge 3",
             terms_and_conditions="Terms and conditions for test challenge 3",
             submission_guidelines="Submission guidelines for test challenge 3",
-            creator=self.challenge_host_team,
-            published=False,
-            is_registration_open=True,
-            enable_forum=True,
-            anonymous_leaderboard=False,
-            start_date=timezone.now() - timedelta(days=2),
-            end_date=timezone.now() + timedelta(days=1),
-            approved_by_admin=False,
-        )
-
-        self.challenge4 = Challenge.objects.create(
-            title="Test Challenge 4",
-            short_description="Short description for test challenge 4",
-            description="Description for test challenge 4",
-            terms_and_conditions="Terms and conditions for test challenge 4",
-            submission_guidelines="Submission guidelines for test challenge 4",
             creator=self.challenge_host_team,
             published=True,
             is_registration_open=True,
@@ -1364,29 +1335,12 @@ class GetChallengeByTitle(BaseAPITestClass):
             approved_by_admin=True,
         )
 
-        self.challenge5 = Challenge.objects.create(
-            title="Test Challenge 5",
-            short_description="Short description for test challenge 5",
-            description="Description for test challenge 5",
-            terms_and_conditions="Terms and conditions for test challenge 5",
-            submission_guidelines="Submission guidelines for test challenge 5",
-            creator=self.challenge_host_team,
-            published=False,
-            is_registration_open=True,
-            enable_forum=True,
-            leaderboard_description=None,
-            anonymous_leaderboard=False,
-            start_date=timezone.now() - timedelta(days=2),
-            end_date=timezone.now() + timedelta(days=1),
-            is_disabled=True,
-        )
-
-        self.challenge6 = Challenge.objects.create(
-            title="Test Challenge 6",
-            short_description="Short description for test challenge 6",
-            description="Description for test challenge 6",
-            terms_and_conditions="Terms and conditions for test challenge 6",
-            submission_guidelines="Submission guidelines for test challenge 6",
+        self.challenge4 = Challenge.objects.create(
+            title="Test Challenge 4",
+            short_description="Short description for test challenge 4",
+            description="Description for test challenge 4",
+            terms_and_conditions="Terms and conditions for test challenge 4",
+            submission_guidelines="Submission guidelines for test challenge 4",
             creator=self.challenge_host_team,
             published=True,
             is_registration_open=True,
@@ -1411,45 +1365,45 @@ class GetChallengeByTitle(BaseAPITestClass):
 
     def test_get_challenge_by_title_when_single_challenge_matches_query(self):
         self.url = reverse_lazy(
-            "challenges:get_challenge_by_title", kwargs={"title": self.challenge4.title}
+            "challenges:get_challenge_by_title", kwargs={"title": self.challenge3.title}
         )
         self.client.force_authenticate(user=self.user)
         expected = {
-            "id": self.challenge4.pk,
-            "title": self.challenge4.title,
-            "short_description": self.challenge4.short_description,
-            "description": self.challenge4.description,
-            "terms_and_conditions": self.challenge4.terms_and_conditions,
-            "submission_guidelines": self.challenge4.submission_guidelines,
-            "evaluation_details": self.challenge4.evaluation_details,
+            "id": self.challenge3.pk,
+            "title": self.challenge3.title,
+            "short_description": self.challenge3.short_description,
+            "description": self.challenge3.description,
+            "terms_and_conditions": self.challenge3.terms_and_conditions,
+            "submission_guidelines": self.challenge3.submission_guidelines,
+            "evaluation_details": self.challenge3.evaluation_details,
             "image": None,
             "start_date": "{0}{1}".format(
-                self.challenge4.start_date.isoformat(), "Z"
+                self.challenge3.start_date.isoformat(), "Z"
             ).replace("+00:00", ""),
             "end_date": "{0}{1}".format(
-                self.challenge4.end_date.isoformat(), "Z"
+                self.challenge3.end_date.isoformat(), "Z"
             ).replace("+00:00", ""),
             "creator": {
-                "id": self.challenge4.creator.pk,
-                "team_name": self.challenge4.creator.team_name,
-                "created_by": self.challenge4.creator.created_by.username,
-                "team_url": self.challenge4.creator.team_url,
+                "id": self.challenge3.creator.pk,
+                "team_name": self.challenge3.creator.team_name,
+                "created_by": self.challenge3.creator.created_by.username,
+                "team_url": self.challenge3.creator.team_url,
             },
-            "published": self.challenge4.published,
-            "is_registration_open": self.challenge4.is_registration_open,
-            "enable_forum": self.challenge4.enable_forum,
-            "leaderboard_description": self.challenge4.leaderboard_description,
-            "anonymous_leaderboard": self.challenge4.anonymous_leaderboard,
+            "published": self.challenge3.published,
+            "is_registration_open": self.challenge3.is_registration_open,
+            "enable_forum": self.challenge3.enable_forum,
+            "leaderboard_description": self.challenge3.leaderboard_description,
+            "anonymous_leaderboard": self.challenge3.anonymous_leaderboard,
             "is_active": True,
             "allowed_email_domains": [],
             "blocked_email_domains": [],
             "banned_email_ids": [],
-            "approved_by_admin": self.challenge4.approved_by_admin,
-            "forum_url": self.challenge4.forum_url,
-            "is_docker_based": self.challenge4.is_docker_based,
-            "slug": self.challenge4.slug,
-            "max_docker_image_size": self.challenge4.max_docker_image_size,
-            "cli_version": self.challenge4.cli_version,
+            "approved_by_admin": self.challenge3.approved_by_admin,
+            "forum_url": self.challenge3.forum_url,
+            "is_docker_based": self.challenge3.is_docker_based,
+            "slug": self.challenge3.slug,
+            "max_docker_image_size": self.challenge3.max_docker_image_size,
+            "cli_version": self.challenge3.cli_version,
         }
         response = self.client.get(self.url, {})
         self.assertEqual(response.data[0], expected)
@@ -1459,8 +1413,43 @@ class GetChallengeByTitle(BaseAPITestClass):
         self.url = reverse_lazy(
             "challenges:get_challenge_by_title", kwargs={"title": 'test challenge'}
         )
-        self.client.force_authenticate(user=self.user)
         expected = [{
+            "id": self.challenge3.pk,
+            "title": self.challenge3.title,
+            "short_description": self.challenge3.short_description,
+            "description": self.challenge3.description,
+            "terms_and_conditions": self.challenge3.terms_and_conditions,
+            "submission_guidelines": self.challenge3.submission_guidelines,
+            "evaluation_details": self.challenge3.evaluation_details,
+            "image": None,
+            "start_date": "{0}{1}".format(
+                self.challenge3.start_date.isoformat(), "Z"
+            ).replace("+00:00", ""),
+            "end_date": "{0}{1}".format(
+                self.challenge3.end_date.isoformat(), "Z"
+            ).replace("+00:00", ""),
+            "creator": {
+                "id": self.challenge3.creator.pk,
+                "team_name": self.challenge3.creator.team_name,
+                "created_by": self.challenge3.creator.created_by.username,
+                "team_url": self.challenge3.creator.team_url,
+            },
+            "published": self.challenge3.published,
+            "is_registration_open": self.challenge3.is_registration_open,
+            "enable_forum": self.challenge3.enable_forum,
+            "leaderboard_description": self.challenge3.leaderboard_description,
+            "anonymous_leaderboard": self.challenge3.anonymous_leaderboard,
+            "is_active": True,
+            "allowed_email_domains": [],
+            "blocked_email_domains": [],
+            "banned_email_ids": [],
+            "approved_by_admin": self.challenge3.approved_by_admin,
+            "forum_url": self.challenge3.forum_url,
+            "is_docker_based": self.challenge3.is_docker_based,
+            "slug": self.challenge3.slug,
+            "max_docker_image_size": self.challenge3.max_docker_image_size,
+            "cli_version": self.challenge3.cli_version,
+        }, {
             "id": self.challenge4.pk,
             "title": self.challenge4.title,
             "short_description": self.challenge4.short_description,
@@ -1496,42 +1485,6 @@ class GetChallengeByTitle(BaseAPITestClass):
             "slug": self.challenge4.slug,
             "max_docker_image_size": self.challenge4.max_docker_image_size,
             "cli_version": self.challenge4.cli_version,
-        }, {
-            "id": self.challenge6.pk,
-            "title": self.challenge6.title,
-            "short_description": self.challenge6.short_description,
-            "description": self.challenge6.description,
-            "terms_and_conditions": self.challenge6.terms_and_conditions,
-            "submission_guidelines": self.challenge6.submission_guidelines,
-            "evaluation_details": self.challenge6.evaluation_details,
-            "image": None,
-            "start_date": "{0}{1}".format(
-                self.challenge6.start_date.isoformat(), "Z"
-            ).replace("+00:00", ""),
-            "end_date": "{0}{1}".format(
-                self.challenge6.end_date.isoformat(), "Z"
-            ).replace("+00:00", ""),
-            "creator": {
-                "id": self.challenge6.creator.pk,
-                "team_name": self.challenge6.creator.team_name,
-                "created_by": self.challenge6.creator.created_by.username,
-                "team_url": self.challenge6.creator.team_url,
-            },
-            "published": self.challenge6.published,
-            "is_registration_open": self.challenge6.is_registration_open,
-            "enable_forum": self.challenge6.enable_forum,
-            "leaderboard_description": self.challenge6.leaderboard_description,
-            "anonymous_leaderboard": self.challenge6.anonymous_leaderboard,
-            "is_active": True,
-            "allowed_email_domains": [],
-            "blocked_email_domains": [],
-            "banned_email_ids": [],
-            "approved_by_admin": self.challenge6.approved_by_admin,
-            "forum_url": self.challenge6.forum_url,
-            "is_docker_based": self.challenge6.is_docker_based,
-            "slug": self.challenge6.slug,
-            "max_docker_image_size": self.challenge6.max_docker_image_size,
-            "cli_version": self.challenge6.cli_version,
         }]
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)


### PR DESCRIPTION
Fix for #2699 

Description:
Since we've more than 50 AI challenges on EvalAI, it would be good to add filtering based upon the challenge name.

Deliverables:

- [x] Add an API to filter challenges based upon the challenge name in the challenges app.

- [x] Add unit tests for the API
