### PR TITLE
[Docker] Improve docker build setup

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -1,6 +1,5 @@
 version: "3"
 services:
-
   django:
     image: ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/evalai-production-backend:${COMMIT_ID}
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 version: "3"
 services:
-
   db:
     image: postgres:10.4
     ports:

--- a/docker/dev/celery/Dockerfile
+++ b/docker/dev/celery/Dockerfile
@@ -1,12 +1,3 @@
-FROM python:3.7.5
-
-ENV PYTHONUNBUFFERED 1
-
-RUN mkdir /code
-WORKDIR /code
-
-ADD requirements/* /code/
-
-RUN pip install -r dev.txt
+FROM evalai_django
 
 CMD ["./docker/wait-for-it.sh", "django:8000", "--", "sh", "/code/docker/dev/celery/container-start.sh"]

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.5
+FROM python:3.6.5
 
 ENV PYTHONUNBUFFERED 1
 
@@ -10,5 +10,3 @@ ADD requirements/* /code/
 RUN pip install -r dev.txt
 
 CMD ["./docker/wait-for-it.sh", "db:5432", "--", "sh", "/code/docker/dev/django/container-start.sh"]
-
-EXPOSE 8000

--- a/docker/dev/worker/Dockerfile
+++ b/docker/dev/worker/Dockerfile
@@ -1,18 +1,10 @@
-FROM python:3.7.5
-
-ENV PYTHONUNBUFFERED 1
+FROM evalai_django
 
 RUN apt-get update && \
   apt-get upgrade -y && \
   apt-get install -q -y default-jdk
 
-RUN mkdir /code
-WORKDIR /code
-
-ADD requirements/* /code/
-
 RUN pip install -U cffi service_identity cython==0.29 numpy==1.14.5
-RUN pip install -r dev.txt
 RUN pip install -r worker.txt
 
 ADD . /code

--- a/docker/prod/celery/Dockerfile
+++ b/docker/prod/celery/Dockerfile
@@ -1,12 +1,3 @@
-FROM python:3.6.5
-
-ENV PYTHONUNBUFFERED 1
-
-RUN mkdir /code
-WORKDIR /code
-ADD requirements/* /code/
-RUN pip install -r prod.txt
-
-ADD . /code
+FROM evalai_django
 
 CMD ["sh", "/code/docker/prod/celery/container-start.sh"]

--- a/docker/prod/django/Dockerfile
+++ b/docker/prod/django/Dockerfile
@@ -9,6 +9,4 @@ RUN pip install -r prod.txt
 
 ADD . /code
 
-EXPOSE 8000
-
 CMD ["sh", "/code/docker/prod/django/container-start.sh"]

--- a/docker/prod/worker/Dockerfile
+++ b/docker/prod/worker/Dockerfile
@@ -1,24 +1,14 @@
-FROM python:3.7.5
-
-ENV PYTHONUNBUFFERED 1
+FROM evalai_django
 
 RUN apt-get update && \
   apt-get upgrade -y && \
   apt-get install -q -y default-jre default-jdk
 
-RUN yes Y | apt-get install git cmake python3-dev python3.7-venv \
+RUN yes Y | apt-get install git cmake \
   libeigen3-dev libboost-python-dev libopencv-dev python-opencv \
   libgmp-dev libcgal-qt5-dev swig
 
-RUN mkdir /code
-WORKDIR /code
-
-ADD requirements/* /code/
-
 RUN pip install -U cffi service_identity cython==0.29 numpy==1.18.1
-RUN pip install -r prod.txt
 RUN pip install -r worker.txt
-
-ADD . /code
 
 CMD ["python", "-m", "scripts.workers.submission_worker"]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,4 +21,3 @@ sphinx-markdown-tables==0.0.9
 sphinx-rtd-theme==0.3.0
 pytest-django==3.1.2
 Faker==0.7.7
-


### PR DESCRIPTION
Right now, we have duplicate steps in the celery and worker image that we already cover in the django. So, adding a new multistage build for celery and worker image which imports from the built django image rather than using `python:3.6.5`