### PR TITLE
Add API to generate and get bearer token EKS requests

### DIFF
--- a/apps/challenges/utils.py
+++ b/apps/challenges/utils.py
@@ -6,11 +6,7 @@ import uuid
 from botocore.exceptions import ClientError
 from moto import mock_ecr, mock_sts
 
-from base.utils import (
-    get_model_object,
-    get_boto3_client,
-    mock_if_non_prod_aws,
-)
+from base.utils import get_model_object, get_boto3_client, mock_if_non_prod_aws
 
 from .models import (
     Challenge,
@@ -86,9 +82,15 @@ def get_aws_credentials_for_challenge(challenge_pk):
         }
     else:
         aws_keys = {
-            "AWS_ACCOUNT_ID": os.environ.get("AWS_ACCOUNT_ID", "aws_account_id"),
-            "AWS_ACCESS_KEY_ID": os.environ.get("AWS_ACCESS_KEY_ID", "aws_access_key_id"),
-            "AWS_SECRET_ACCESS_KEY": os.environ.get("AWS_SECRET_ACCESS_KEY", "aws_secret_access_key"),
+            "AWS_ACCOUNT_ID": os.environ.get(
+                "AWS_ACCOUNT_ID", "aws_account_id"
+            ),
+            "AWS_ACCESS_KEY_ID": os.environ.get(
+                "AWS_ACCESS_KEY_ID", "aws_access_key_id"
+            ),
+            "AWS_SECRET_ACCESS_KEY": os.environ.get(
+                "AWS_SECRET_ACCESS_KEY", "aws_secret_access_key"
+            ),
             "AWS_REGION": os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
         }
     return aws_keys
@@ -124,8 +126,10 @@ def get_or_create_ecr_repository(name, aws_keys):
         )
         repository = response["repositories"][0]
     except ClientError as e:
-        if e.response["Error"]["Code"] == "RepositoryNotFoundException" or\
-           e.response["Error"]["Code"] == "400":
+        if (
+            e.response["Error"]["Code"] == "RepositoryNotFoundException"
+            or e.response["Error"]["Code"] == "400"
+        ):
             response = client.create_repository(repositoryName=name)
             repository = response["repository"]
             created = True

--- a/apps/jobs/aws_utils.py
+++ b/apps/jobs/aws_utils.py
@@ -7,6 +7,15 @@ from challenges.utils import get_aws_credentials_for_challenge
 
 
 def generate_aws_eks_bearer_token(cluster_name, challenge):
+    """Function to generate the AWS EKS bearer Token
+
+    Arguments:
+        cluster_name {string} -- Cluster name for which the object is generated
+        challenge {Object} -- Challenge Object
+
+    Returns:
+        {string} -- Generated bearer token
+    """
     challenge_pk = challenge.id
     aws_keys = get_aws_credentials_for_challenge(challenge_pk)
     session = boto3.Session(

--- a/apps/jobs/aws_utils.py
+++ b/apps/jobs/aws_utils.py
@@ -1,0 +1,44 @@
+import base64
+import boto3
+import re
+from botocore.signers import RequestSigner
+
+from challenges.utils import get_aws_credentials_for_challenge
+
+
+def generate_aws_eks_bearer_token(cluster_name, challenge):
+    challenge_pk = challenge.id
+    aws_keys = get_aws_credentials_for_challenge(challenge_pk)
+    session = boto3.Session(
+        aws_access_key_id=aws_keys["AWS_ACCESS_KEY_ID"],
+        aws_secret_access_key=aws_keys["AWS_SECRET_ACCESS_KEY"],
+    )
+    region = aws_keys["AWS_REGION"]
+    client = session.client("sts", region_name=region)
+    service_id = client.meta.service_model.service_id
+    signer = RequestSigner(
+        service_id,
+        region,
+        "sts",
+        "v4",
+        session.get_credentials(),
+        session.events,
+    )
+    params = {
+        "method": "GET",
+        "url": "https://sts.{}.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15".format(
+            region
+        ),
+        "body": {},
+        "headers": {"x-k8s-aws-id": cluster_name},
+        "context": {},
+    }
+    signed_url = signer.generate_presigned_url(
+        params, region_name=region, expires_in=60, operation_name=""
+    )
+    base64_url = base64.urlsafe_b64encode(signed_url.encode("utf-8")).decode(
+        "utf-8"
+    )
+    # remove any base64 encoding padding
+    bearer_token = "k8s-aws-v1." + re.sub(r"=*", "", base64_url)
+    return bearer_token

--- a/apps/jobs/serializers.py
+++ b/apps/jobs/serializers.py
@@ -2,11 +2,7 @@ from django.contrib.auth.models import User
 
 from rest_framework import serializers
 
-from challenges.models import (
-    ChallengeEvaluationCluster,
-    ChallengePhase,
-    LeaderboardData,
-)
+from challenges.models import ChallengePhase, LeaderboardData
 from participants.models import Participant, ParticipantTeam
 
 from .models import Submission
@@ -239,9 +235,3 @@ class RemainingSubmissionDataSerializer(serializers.ModelSerializer):
 
     def get_limits(self, obj):
         return self.context.get("limits")
-
-
-class ChallengeEvaluationClusterSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = ChallengeEvaluationCluster
-        fields = ("id", "challenge", "name", "cluster_yaml", "kube_config")

--- a/apps/jobs/serializers.py
+++ b/apps/jobs/serializers.py
@@ -2,7 +2,11 @@ from django.contrib.auth.models import User
 
 from rest_framework import serializers
 
-from challenges.models import ChallengePhase, LeaderboardData
+from challenges.models import (
+    ChallengeEvaluationCluster,
+    ChallengePhase,
+    LeaderboardData,
+)
 from participants.models import Participant, ParticipantTeam
 
 from .models import Submission
@@ -235,3 +239,9 @@ class RemainingSubmissionDataSerializer(serializers.ModelSerializer):
 
     def get_limits(self, obj):
         return self.context.get("limits")
+
+
+class ChallengeEvaluationClusterSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ChallengeEvaluationCluster
+        fields = ("id", "challenge", "name", "cluster_yaml", "kube_config")

--- a/apps/jobs/urls.py
+++ b/apps/jobs/urls.py
@@ -65,4 +65,9 @@ urlpatterns = [
         views.update_leaderboard_data,
         name="update_leaderboard_data",
     ),
+    url(
+        r"^challenge/(?P<challenge_pk>[0-9]+)/eks_bearer_token/$",
+        views.get_bearer_token,
+        name="get_bearer_token",
+    ),
 ]

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -36,6 +36,7 @@ from base.utils import (
 from challenges.models import (
     ChallengePhase,
     Challenge,
+    ChallengeEvaluationCluster,
     ChallengePhaseSplit,
     LeaderboardData,
 )
@@ -53,6 +54,7 @@ from participants.utils import (
     get_participant_team_of_user_for_a_challenge,
     is_user_part_of_participant_team,
 )
+from .aws_utils import generate_aws_eks_bearer_token
 from .filters import SubmissionFilter
 from .models import Submission
 from .sender import publish_submission_message
@@ -1516,3 +1518,38 @@ def update_leaderboard_data(request, leaderboard_data_pk):
         serializer.save()
         return Response(serializer.data, status=status.HTTP_200_OK)
     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(["GET"])
+@throttle_classes([UserRateThrottle])
+@permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))
+@authentication_classes((ExpiringTokenAuthentication,))
+def get_bearer_token(request, challenge_pk):
+
+    challenge = get_challenge_model(challenge_pk)
+
+    if not is_user_a_host_of_challenge(request.user, challenge.id):
+        response_data = {
+            "error": "Sorry, you are not authorized to make this request!"
+        }
+        return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
+
+    try:
+        challenge_evaluation_cluster = ChallengeEvaluationCluster.objects.get(
+            challenge=challenge
+        )
+    except ChallengeEvaluationCluster.DoesNotExist:
+        response_data = {
+            "error": "Challenge evaluation cluster for the challenge with pk {} does not exist".format(
+                challenge.pk
+            )
+        }
+        return Response(response_data, status=status.HTTP_404_NOT_FOUND)
+
+    cluster_name = challenge_evaluation_cluster.name
+    bearer_token = generate_aws_eks_bearer_token(cluster_name, challenge)
+    response_data = {
+        "aws_eks_bearer_token": bearer_token,
+        "cluster_name": cluster_name,
+    }
+    return Response(response_data, status=status.HTTP_200_OK)

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -1525,7 +1525,15 @@ def update_leaderboard_data(request, leaderboard_data_pk):
 @permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))
 @authentication_classes((ExpiringTokenAuthentication,))
 def get_bearer_token(request, challenge_pk):
+    """API to generate and return bearer token AWS EKS requests
 
+    Arguments:
+        request {HttpRequest} -- The request object
+        challenge_pk {int} -- The challenge pk for which bearer token is to be generated
+
+    Returns:
+        Response object -- Response object with appropriate response code (200/400/404)
+    """
     challenge = get_challenge_model(challenge_pk)
 
     if not is_user_a_host_of_challenge(request.user, challenge.id):

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -1542,6 +1542,12 @@ def get_bearer_token(request, challenge_pk):
         }
         return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
+    if not challenge.is_docker_based:
+        response_data = {
+            "error": "The challenge doesn't require uploading Docker images, hence there isn't a need for bearer token."
+        }
+        return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
+
     try:
         challenge_evaluation_cluster = ChallengeEvaluationCluster.objects.get(
             challenge=challenge


### PR DESCRIPTION
This PR adds -
- [x] Utils function to generate the bearer token
- [x]  API to be accessed by challenge host for generating the bearer token
- [x] Black Formatting changes for `challenges/utils.py`