### PR TITLE
Fix #2691: Updated Python Version to 3.7.5 in .travis/yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 services:
 - docker
 python:
-- '3.6'
+- '3.7.5'
 addons:
   postgresql: '10'
   apt:


### PR DESCRIPTION
Modified the Python version at line number 6 from '3.6' to '3.7.5' as per issue #2691 [Update Python version in .travis.yml #2691](https://github.com/Cloud-CV/EvalAI/edit/master/.travis.yml).
