### PR TITLE
Set all stdout, stderr, result and metadata files to none while re-running submissions

### DIFF
--- a/apps/jobs/utils.py
+++ b/apps/jobs/utils.py
@@ -191,6 +191,10 @@ def handle_submission_rerun(submission, updated_status):
         serializer.save()
 
     submission.pk = None
+    submission.stdout_file = None
+    submission.stderr_file = None
+    submission.submission_result_file = None
+    submission.submission_metadata_file = None
     submission.save()
     message = {
         "challenge_pk": submission.challenge_phase.challenge.pk,


### PR DESCRIPTION
Minor Fixes to #2749 
