### PR TITLE
Fix #2766: Update contribution.rst to use black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: https://github.com/ambv/black
+-   repo: https://github.com/psf/black
     rev: stable
     hooks:
     - id: black

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -37,16 +37,19 @@ branches based off of development and merged into it once stable and
 reviewed. To submit code, follow these steps:
 
 1. Create a new branch off of development. Select a descriptive branch
-   name. We highly encourage you to use `autopep8` to follow the PEP8 styling. Run the following command before creating the pull request:
-
+   name. 
    ::
-
-       autopep8 --in-place --exclude venv,docs --recursive .
-
        git fetch upstream
        git checkout master
        git merge upstream/master
        git checkout -b your-branch-name
+
+   We highly encourage using `black <http://www.github.com/psf/black>`_
+   to format your code. It sticks to PEP8 and is in line with the rest
+   of the repo. To use black, install it via `pip` and run the following
+   command:
+   ::
+      black --exclude venv,docs ./
 
 2. Commit and push code to your branch:
 

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -45,11 +45,13 @@ reviewed. To submit code, follow these steps:
        git checkout -b your-branch-name
 
    We highly encourage using `black <http://www.github.com/psf/black>`_
-   to format your code. It sticks to PEP8 and is in line with the rest
-   of the repo. To use black, install it via `pip` and run the following
-   command:
+   to format your code. It sticks to PEP8 for the most part and is in 
+   line with the rest of the repo. We have already set up `pre-commit 
+   hooks <https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks>`_
+   to run black and flake8. To activate the hooks, you just need to run
+   the following comamnd once:
    ::
-      black --exclude venv,docs ./
+      pre-commit install
 
 2. Commit and push code to your branch:
 


### PR DESCRIPTION
Changes:
* Replace `autopep8` instructions with `black` instructions
* Separate the `git` code block and `black` code block to avoid confusion
* Add instructions for using pre-commit hook.
