### PR TITLE
Fix:#2783 Bullet list in Trix editor

### DIFF
--- a/frontend/src/css/modules/base.scss
+++ b/frontend/src/css/modules/base.scss
@@ -126,6 +126,22 @@ ul.inline-list {
     }
 }
 
+.trix-container ul:not(.browser-default) li {
+	list-style-type: disc;
+}
+
+.editor ul:not(.browser-default) li {
+	list-style-type: disc;
+}
+
+trix-editor ul li {
+    margin-left: 6%;
+}
+
+.trix-container ul li {
+	margin-left: 4%;
+}
+
 span.inline {
     p {
         display: inline;

--- a/frontend/src/css/modules/submission.scss
+++ b/frontend/src/css/modules/submission.scss
@@ -30,6 +30,10 @@
 	line-height: 36px;
 }
 
+.phase-container ul:not(.browser-default) li {
+	list-style-type: none;
+}
+
 li {
 	margin-bottom: 1.5%;
   }

--- a/frontend/src/views/web/challenge/evaluation.html
+++ b/frontend/src/views/web/challenge/evaluation.html
@@ -17,7 +17,7 @@
         </div>
         <div class="row">
             <div class="col s12">
-                <div ng-bind-html="challenge.page.evaluation_details" class="fs-16 w-300 evaluation-details"></div>
+                <div ng-bind-html="challenge.page.evaluation_details" class="fs-16 w-300 evaluation-details trix-container"></div>
             </div>
         </div>
     </div>
@@ -34,7 +34,7 @@
         </div>
         <div class="row">
             <div class="col s12 m11 l11">
-                <div ng-bind-html="challenge.page.terms_and_conditions" class="fs-16 w-300 terms-and-conditions"></div>
+                <div ng-bind-html="challenge.page.terms_and_conditions" class="fs-16 w-300 terms-and-conditions trix-container"></div>
             </div>
         </div>
     </div>

--- a/frontend/src/views/web/challenge/overview.html
+++ b/frontend/src/views/web/challenge/overview.html
@@ -15,7 +15,7 @@
         </div>
         <div class="row">
             <div class="col s12">
-                <div ng-bind-html="challenge.page.description" class="fs-16 w-300 challenge-description"></div>
+                <div ng-bind-html="challenge.page.description" class="fs-16 w-300 challenge-description trix-container"></div>
             </div>
         </div>
     </div>

--- a/frontend/src/views/web/challenge/phases.html
+++ b/frontend/src/views/web/challenge/phases.html
@@ -23,7 +23,7 @@
                 </p>
             </div>
             <div class="col s12 m12 l12">
-                <div ng-bind-html="item.description" class="fs-16 w-300 phase-description"></div>
+                <div ng-bind-html="item.description" class="fs-16 w-300 phase-description trix-container"></div>
             </div>
             <div class="col s12 m12 l3">
                 <p class="fs-16">Max submissions/day: <span class="w-300">{{item.max_submissions_per_day}}</span></p>

--- a/frontend/src/views/web/challenge/submission.html
+++ b/frontend/src/views/web/challenge/submission.html
@@ -22,14 +22,14 @@
                 </strong>
             </div>
             <div class="col s12">
-                <div ng-bind-html="challenge.page.submission_guidelines" class="fs-16 w-300 submission-guidelines"></div>
+                <div ng-bind-html="challenge.page.submission_guidelines" class="fs-16 w-300 submission-guidelines trix-container"></div>
             </div>
         </div>
     </div>
 </section>
 
 <!-- If challenge is docker based -->
-<section class="ev-sm-container ev-view challenge-container" ng-if="challenge.page.is_docker_based">
+<section class="ev-sm-container ev-view challenge-container phase-container" ng-if="challenge.page.is_docker_based">
     <div class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view margin-btm-0">
         <div class="row margin-bottom-cancel">
             <div class="col s12">
@@ -71,7 +71,7 @@
 </section>
 
 <!-- If challenge is docker based -->
-<section class="ev-sm-container ev-view challenge-container" ng-if="challenge.page.is_docker_based">
+<section class="ev-sm-container ev-view challenge-container phase-container" ng-if="challenge.page.is_docker_based">
     <div class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view">
         <div class="row margin-bottom-cancel">
             <div class="col s12">
@@ -157,7 +157,7 @@
 </section>
 
 <!-- If challenge is not docker based -->
-<section class="ev-sm-container ev-view challenge-container" ng-if="!challenge.page.is_docker_based">
+<section class="ev-sm-container ev-view challenge-container phase-container" ng-if="!challenge.page.is_docker_based">
     <div class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view">
         <div class="row margin-bottom-cancel">
             <div class="col s12">


### PR DESCRIPTION
Fix: #2783 

**Cause of Bug:**

CSS override in particular here `ul:not(.browser-default)` was being set with `list-style-type: none;` and it was overriding the bullet-list

**GIF of Fix:**
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/44888949/81324677-f0ff5600-90b4-11ea-92b2-18587f33a72c.gif)
