### PR TITLE
[Frontend] Fix frontend development setup issue

### DIFF
--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -21,7 +21,7 @@ jessie/updates main" > /etc/apt/sources.list
 
 # Install the latest chrome dev package
 RUN apt-get update && \
-	apt-get -y install gconf-service libasound2 libatk1.0-0 libc6 libcairo2 \
+	apt-get -y --force-yes install gconf-service libasound2 libatk1.0-0 libc6 libcairo2 \
 		libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 \
 		libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 \
 		libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 \


### PR DESCRIPTION
Trying to setup EvalAI locally on Ubuntu 20.04 LTS and it is failing with the following error:

```bash
E: There are problems and -y was used without --force-yes
ERROR: Service 'nodejs' failed to build: The command '/bin/sh -c apt-get update && 	apt-get -y install gconf-service libasound2 libatk1.0-0 libc6 libcairo2 		libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 		libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 		libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 		libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 		libnss3 lsb-release xdg-utils wget' returned a non-zero code: 100
```

Adding a fix for the same. 