### PR TITLE
[Frontend] Change css class name for EvalAI sponsors

### DIFF
--- a/frontend/src/css/modules/landing.scss
+++ b/frontend/src/css/modules/landing.scss
@@ -559,7 +559,7 @@ a.view-more {
     height: 45%;
 }
 
-.sponsor-logo {
+.evalai-sponsor-logo {
     max-width: 100%;
     height: 120px;
     text-align: center;

--- a/frontend/src/views/web/landing.html
+++ b/frontend/src/views/web/landing.html
@@ -366,12 +366,12 @@
                 </div>
                 <div class="row">
                     <div class="col s12 m3 l3 offset-l3">
-                        <div class="sponsor-logo">
+                        <div class="evalai-sponsor-logo">
                             <img src="dist/images/sponsors/aws.png" id="aws">
                         </div>
                     </div>
                     <div class="col s3 m3 l3">
-                        <div class="sponsor-logo">
+                        <div class="evalai-sponsor-logo">
                             <img src="dist/images/sponsors/gsoc.png" id="gsoc">
                         </div>
                     </div>


### PR DESCRIPTION
@RishabhJain2018 @Ayukha @yashdusing seems like the issue was related to our css class name. It was getting overridden by some other css package class name that was setting it to `display: none !important;` and hence it wasn't showing up on some of the browsers. 