### PR TITLE
Remove celery from dev setup and increase wait time of worker for docker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,18 +26,6 @@ services:
     volumes:
       - .:/code
 
-  celery:
-    hostname: celery
-    env_file:
-      - docker/dev/docker.env
-    build:
-      context: ./
-      dockerfile: docker/dev/celery/Dockerfile
-    depends_on:
-      - django
-    volumes:
-      - .:/code
-
   worker:
     env_file:
       - docker/dev/docker.env
@@ -63,3 +51,16 @@ services:
       - .:/code
       - /code/node_modules
       - /code/bower_components
+
+  # TODO: Add alternative for AWS SQS Celery (https://docs.celeryproject.org/en/stable/getting-started/brokers/sqs.html) in dev setup.
+  # celery:
+  #   hostname: celery
+  #   env_file:
+  #     - docker/dev/docker.env
+  #   build:
+  #     context: ./
+  #     dockerfile: docker/dev/celery/Dockerfile
+  #   depends_on:
+  #     - django
+  #   volumes:
+  #     - .:/code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,3 +64,4 @@ services:
   #     - django
   #   volumes:
   #     - .:/code
+  

--- a/docker/wait-for-it.sh
+++ b/docker/wait-for-it.sh
@@ -131,7 +131,7 @@ if [[ "$HOST" == "" || "$PORT" == "" ]]; then
     usage
 fi
 
-TIMEOUT=${TIMEOUT:-15}
+TIMEOUT=${TIMEOUT:-45}
 STRICT=${STRICT:-0}
 CHILD=${CHILD:-0}
 QUIET=${QUIET:-0}


### PR DESCRIPTION
This PR -- Fixes dev setup.
- [x] Removes the breaking dependency of celery from dev setup.
- [x] Increases the wait time of worker container for docker container to 45 seconds. 