### PR TITLE
[Feature] Restrict selection of one public submission for a challenge phase

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -796,7 +796,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
             return Response(
                 response_data, status=status.HTTP_406_NOT_ACCEPTABLE
             )
-        if "is_submission_public" in data.keys() and "is_restricted_to_select_one_submission" in data.keys():
+        if data.get("is_submission_public") and data.get("is_restricted_to_select_one_submission"):
             if data["is_submission_public"] and data["is_restricted_to_select_one_submission"]:
                 message = (
                     "is_submission_public can't be 'True' for for challenge phase '{}'"
@@ -806,7 +806,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                 )
                 response_data = {"error": message}
                 return Response(
-                    response_data, status=status.HTTP_406_NOT_ACCEPTABLE
+                    response_data, status=status.HTTP_400_BAD_REQUEST
                 )
 
     # Check for challenge image in yaml file.

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -796,18 +796,18 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
             return Response(
                 response_data, status=status.HTTP_406_NOT_ACCEPTABLE
             )
-
-        if data["is_submission_public"] and data["is_restricted_to_select_one_submission"]:
-            message = (
-                "is_submission_public can't be 'True' for for challenge phase '{}'"
-                " with is_restricted_to_select_one_submission 'True'. "
-                " Please change is_submission_public to 'False'"
-                " then try again!".format(data["name"])
-            )
-            response_data = {"error": message}
-            return Response(
-                response_data, status=status.HTTP_406_NOT_ACCEPTABLE
-            )
+        if "is_submission_public" in data.keys() and "is_restricted_to_select_one_submission" in data.keys():
+            if data["is_submission_public"] and data["is_restricted_to_select_one_submission"]:
+                message = (
+                    "is_submission_public can't be 'True' for for challenge phase '{}'"
+                    " with is_restricted_to_select_one_submission 'True'. "
+                    " Please change is_submission_public to 'False'"
+                    " then try again!".format(data["name"])
+                )
+                response_data = {"error": message}
+                return Response(
+                    response_data, status=status.HTTP_406_NOT_ACCEPTABLE
+                )
 
     # Check for challenge image in yaml file.
     image = yaml_file_data.get("image")

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -797,17 +797,16 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                 response_data, status=status.HTTP_406_NOT_ACCEPTABLE
             )
         if data.get("is_submission_public") and data.get("is_restricted_to_select_one_submission"):
-            if data["is_submission_public"] and data["is_restricted_to_select_one_submission"]:
-                message = (
-                    "is_submission_public can't be 'True' for for challenge phase '{}'"
-                    " with is_restricted_to_select_one_submission 'True'. "
-                    " Please change is_submission_public to 'False'"
-                    " then try again!".format(data["name"])
-                )
-                response_data = {"error": message}
-                return Response(
-                    response_data, status=status.HTTP_400_BAD_REQUEST
-                )
+            message = (
+                "is_submission_public can't be 'True' for for challenge phase '{}'"
+                " with is_restricted_to_select_one_submission 'True'. "
+                " Please change is_submission_public to 'False'"
+                " then try again!".format(data["name"])
+            )
+            response_data = {"error": message}
+            return Response(
+                response_data, status=status.HTTP_400_BAD_REQUEST
+            )
 
     # Check for challenge image in yaml file.
     image = yaml_file_data.get("image")

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -797,6 +797,18 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                 response_data, status=status.HTTP_406_NOT_ACCEPTABLE
             )
 
+        if data["is_submission_public"] and data["is_restricted_to_select_one_submission"]:
+            message = (
+                "is_submission_public can't be 'True' for for challenge phase '{}'"
+                " with is_restricted_to_select_one_submission 'True'. "
+                " Please change is_submission_public to 'False'"
+                " then try again!".format(data["name"])
+            )
+            response_data = {"error": message}
+            return Response(
+                response_data, status=status.HTTP_406_NOT_ACCEPTABLE
+            )
+
     # Check for challenge image in yaml file.
     image = yaml_file_data.get("image")
     if image and (

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -373,18 +373,20 @@ def change_submission_data_and_visibility(
             when_made_public = datetime.datetime.now()
             request.data["when_made_public"] = when_made_public
 
-        submissions_already_public = Submission.objects.filter(
-            is_public=True,
-            participant_team=participant_team,
-            challenge_phase=challenge_phase
-        )
-
-        if (challenge_phase.is_restricted_to_select_one_submission
-                and is_public
-                and submissions_already_public.count() >= 1):
-            for submission_in_db in submissions_already_public:
-                submission_in_db.is_public = False
-                submission_in_db.save()
+        try:
+            submissions_already_public = Submission.objects.get(
+                is_public=True,
+                participant_team=participant_team,
+                challenge_phase=challenge_phase
+            )
+            # Make the existing public submission private before making the new submission public
+            if (challenge_phase.is_restricted_to_select_one_submission
+                    and is_public
+                    and submissions_already_public):
+                submissions_already_public.is_public = False
+                submissions_already_public.save()
+        except Submission.DoesNotExist:
+            pass
     except KeyError:
         pass
 

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -378,9 +378,7 @@ def change_submission_data_and_visibility(
             participant_team=participant_team,
             challenge_phase=challenge_phase
         )
-        print(submissions_already_public.count())
-        print('Is already public', is_public)
-        print(challenge_phase.is_restricted_to_select_one_submission)
+
         if (challenge_phase.is_restricted_to_select_one_submission
                 and is_public
                 and submissions_already_public.count() >= 1):

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -383,7 +383,6 @@ def change_submission_data_and_visibility(
                 and is_public
                 and submissions_already_public.count() >= 1):
             for submission_in_db in submissions_already_public:
-                print('Existing sub', submission_in_db)
                 submission_in_db.is_public = False
                 submission_in_db.save()
     except KeyError:

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -372,6 +372,22 @@ def change_submission_data_and_visibility(
         if is_public is True:
             when_made_public = datetime.datetime.now()
             request.data["when_made_public"] = when_made_public
+
+        submissions_already_public = Submission.objects.filter(
+            is_public=True,
+            participant_team=participant_team,
+            challenge_phase=challenge_phase
+        )
+        print(submissions_already_public.count())
+        print('Is already public', is_public)
+        print(challenge_phase.is_restricted_to_select_one_submission)
+        if (challenge_phase.is_restricted_to_select_one_submission
+                and is_public
+                and submissions_already_public.count() >= 1):
+            for submission_in_db in submissions_already_public:
+                print('Existing sub', submission_in_db)
+                submission_in_db.is_public = False
+                submission_in_db.save()
     except KeyError:
         pass
 

--- a/frontend/src/css/modules/submission.scss
+++ b/frontend/src/css/modules/submission.scss
@@ -59,3 +59,7 @@ code {
 .dashed-link {
 	border-bottom: 1px orange dashed;
 }
+
+.update-submission-visibility-card {
+    padding: 20px 20px 0px 20px;
+}

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -1635,13 +1635,18 @@
             vm.submissionId = submissionId;
             // Show modal only when submission is being made public
             if (submissionVisibility) {
-                $mdDialog.show({
-                    scope: $scope,
-                    preserveScope: true,
-                    templateUrl: 'dist/views/web/challenge/update-submission-visibility.html'
-                });
+                // Show pop up only when there's a submission already selected
+                if (vm.previousPublicSubmissionId) {
+                    $mdDialog.show({
+                        scope: $scope,
+                        preserveScope: true,
+                        templateUrl: 'dist/views/web/challenge/update-submission-visibility.html'
+                    });
+                } else {
+                    vm.changeSubmissionVisibility(submissionId, submissionVisibility);
+                }
             } else {
-                // case for all submission made private
+                // Case when a submission is made private
                 vm.changeSubmissionVisibility(submissionId, submissionVisibility);
             }
         };

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -1627,7 +1627,6 @@
             }
             vm.submissionVisibility[submissionId] = vm.submissionMetaData.is_public;
             vm.submissionId = submissionId;
-            console.log(vm.submissionId, vm.submissionVisibility[submissionId])
 
             $mdDialog.show({
                 scope: $scope,

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -1618,20 +1618,14 @@
             });
         };
 
-        vm.showVisibilityDialog = function(ev, submissionId) {
-            for (var i = 0; i < vm.submissionResult.count; i++) {
-                if (vm.submissionResult.results[i].id === submissionId) {
-                    vm.submissionMetaData = vm.submissionResult.results[i];
-                    break;
-                }
-            }
-            vm.submissionVisibility[submissionId] = vm.submissionMetaData.is_public;
+        vm.showVisibilityDialog = function(submissionId) {
             vm.submissionId = submissionId;
+            console.log(vm.submissionVisibility[submissionId]);
+            console.log(submissionId);
 
             $mdDialog.show({
                 scope: $scope,
                 preserveScope: true,
-                targetEvent: ev,
                 templateUrl: 'dist/views/web/challenge/update-submission-visibility.html'
             });
         };

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -1620,9 +1620,6 @@
 
         vm.showVisibilityDialog = function(submissionId) {
             vm.submissionId = submissionId;
-            console.log(vm.submissionVisibility[submissionId]);
-            console.log(submissionId);
-
             $mdDialog.show({
                 scope: $scope,
                 preserveScope: true,

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -807,6 +807,7 @@
             for (var i = 0; i < vm.phases.results.length; i++) {
                 if (all_phases[i].id == phaseId) {
                     vm.currentPhaseLeaderboardPublic = all_phases[i].leaderboard_public;
+                    vm.isCurrentPhaseRestrictedToSelectOneSubmission = all_phases[i].is_restricted_to_select_one_submission;
                     break;
                 }
             }
@@ -1400,13 +1401,19 @@
                         message = "The submission is made private.";
                       }
                       $rootScope.notify("success", message);
+                      if (vm.isCurrentPhaseRestrictedToSelectOneSubmission) {
+                        $mdDialog.hide()
+                      }
                     }
                 },
                 onError: function(response) {
                     var error = response.data;
                     var status = response.status;
-                    if(status === 400 || status === 403 ) {
+                    if(status === 400 || status === 403) {
                        $rootScope.notify("error", error.error);
+                    }
+                    if (vm.isCurrentPhaseRestrictedToSelectOneSubmission) {
+                       $mdDialog.hide()
                     }
                 }
             };
@@ -1608,6 +1615,25 @@
                 preserveScope: true,
                 targetEvent: ev,
                 templateUrl: 'dist/views/web/challenge/update-submission-metadata.html'
+            });
+        };
+
+        vm.showVisibilityDialog = function(ev, submissionId) {
+            for (var i = 0; i < vm.submissionResult.count; i++) {
+                if (vm.submissionResult.results[i].id === submissionId) {
+                    vm.submissionMetaData = vm.submissionResult.results[i];
+                    break;
+                }
+            }
+            vm.submissionVisibility[submissionId] = vm.submissionMetaData.is_public;
+            vm.submissionId = submissionId;
+            console.log(vm.submissionId, vm.submissionVisibility[submissionId])
+
+            $mdDialog.show({
+                scope: $scope,
+                preserveScope: true,
+                targetEvent: ev,
+                templateUrl: 'dist/views/web/challenge/update-submission-visibility.html'
             });
         };
 

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -1636,6 +1636,10 @@
             });
         };
 
+        vm.hideVisibilityDialog = function() {
+            $mdDialog.hide();
+        };
+
         vm.updateSubmissionMetaData = function(updateSubmissionMetaDataForm) {
             if (updateSubmissionMetaDataForm) {
                 parameters.url = "jobs/challenge/" + vm.challengeId + "/challenge_phase/" + vm.phaseId + "/submission/" + vm.submissionId;

--- a/frontend/src/views/web/challenge/my-submission.html
+++ b/frontend/src/views/web/challenge/my-submission.html
@@ -111,11 +111,20 @@
                                 <td>{{key.submitted_at | date:'medium'}}</td>
 
                                 <td ng-if="challenge.currentPhaseLeaderboardPublic" class="center">
-                                    <input ng-checked="key.is_public" ng-if="key.status == 'finished'"
+                                    <input ng-checked="key.is_public" ng-if="key.status == 'finished'
+                                     && !challenge.isCurrentPhaseRestrictedToSelectOneSubmission"
                                         ng-model="challenge.submissionVisibility[key.id]" type="checkbox"
                                         id="isPublic{{ key.id }}"
                                         ng-change="challenge.changeSubmissionVisibility(key.id)" />
-                                    <label for="isPublic{{ key.id }}"></label>
+                                    <input ng-checked="key.is_public" ng-if="key.status == 'finished'
+                                     && challenge.isCurrentPhaseRestrictedToSelectOneSubmission"
+                                        ng-model="challenge.submissionVisibility[key.id]" type="checkbox"
+                                        id="isPublicSubmission{{ key.id }}"
+                                        ng-change="challenge.showVisibilityDialog($event, key.id)" />
+                                    <label ng-if="!challenge.isCurrentPhaseRestrictedToSelectOneSubmission"
+                                           for="isPublic{{ key.id }}"></label>
+                                    <label ng-if="challenge.isCurrentPhaseRestrictedToSelectOneSubmission"
+                                           for="isPublicSubmission{{ key.id }}"></label>
                                     <span ng-if="key.status !== 'finished'" class="center"> N/A </span>
                                 </td>
                                 <td ng-if="challenge.isChallengeHost" class="center">

--- a/frontend/src/views/web/challenge/my-submission.html
+++ b/frontend/src/views/web/challenge/my-submission.html
@@ -115,12 +115,12 @@
                                      && !challenge.isCurrentPhaseRestrictedToSelectOneSubmission"
                                         ng-model="challenge.submissionVisibility[key.id]" type="checkbox"
                                         id="isPublic{{ key.id }}"
-                                        ng-change="challenge.changeSubmissionVisibility(key.id)" />
+                                        ng-change="challenge.changeSubmissionVisibility(key.id, challenge.submissionVisibility[key.id])" />
                                     <input ng-checked="key.is_public" ng-if="key.status == 'finished'
                                      && challenge.isCurrentPhaseRestrictedToSelectOneSubmission"
                                         ng-model="challenge.submissionVisibility[key.id]" type="checkbox"
                                         id="isPublicSubmission{{ key.id }}"
-                                        ng-change="challenge.showVisibilityDialog(key.id)" />
+                                        ng-change="challenge.showVisibilityDialog(key.id, challenge.submissionVisibility[key.id])" />
                                     <label ng-if="!challenge.isCurrentPhaseRestrictedToSelectOneSubmission"
                                            for="isPublic{{ key.id }}"></label>
                                     <label ng-if="challenge.isCurrentPhaseRestrictedToSelectOneSubmission"

--- a/frontend/src/views/web/challenge/my-submission.html
+++ b/frontend/src/views/web/challenge/my-submission.html
@@ -120,7 +120,7 @@
                                      && challenge.isCurrentPhaseRestrictedToSelectOneSubmission"
                                         ng-model="challenge.submissionVisibility[key.id]" type="checkbox"
                                         id="isPublicSubmission{{ key.id }}"
-                                        ng-change="challenge.showVisibilityDialog($event, key.id)" />
+                                        ng-change="challenge.showVisibilityDialog(key.id)" />
                                     <label ng-if="!challenge.isCurrentPhaseRestrictedToSelectOneSubmission"
                                            for="isPublic{{ key.id }}"></label>
                                     <label ng-if="challenge.isCurrentPhaseRestrictedToSelectOneSubmission"

--- a/frontend/src/views/web/challenge/update-submission-visibility.html
+++ b/frontend/src/views/web/challenge/update-submission-visibility.html
@@ -1,7 +1,7 @@
-<section class="ev-md-container text-center rm-overflow-y">
+<section class="text-center rm-overflow-y">
     <div class="row">
         <div class="col s12 m12">
-            <div class="ev-md-container ev-card-body update-profile-card">
+            <div class="update-submission-visibility-card">
                 <form name="updateSubmissionVisibilityForm" ng-submit="challenge.changeSubmissionVisibility(challenge.submissionId, true)">
                     <div class="pass-title">Are you sure you want to override your current public submission?</div>
 

--- a/frontend/src/views/web/challenge/update-submission-visibility.html
+++ b/frontend/src/views/web/challenge/update-submission-visibility.html
@@ -1,0 +1,16 @@
+<section class="ev-md-container text-center rm-overflow-y">
+    <div class="row">
+        <div class="col s12 m12">
+            <div class="ev-md-container ev-card-body update-profile-card">
+                <form name="updateSubmissionMetaDataForm" ng-submit="challenge.changeSubmissionVisibility(challenge.submissionId)">
+                    <div class="pass-title">Are you sure you want to override your current public submission?</div>
+
+                    <ul class="inline-list pointer">
+                        <li><a class="dark-link" type="button" ng-click="challenge.hideVisibilityDialog()"><strong>Cancel </strong></a></li>
+                        <li><button class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-14" type="submit" value="Submit">Submit </button></li>
+                    </ul>
+                </form>
+            </div>
+        </div>
+    </div>
+</section>

--- a/frontend/src/views/web/challenge/update-submission-visibility.html
+++ b/frontend/src/views/web/challenge/update-submission-visibility.html
@@ -2,7 +2,7 @@
     <div class="row">
         <div class="col s12 m12">
             <div class="ev-md-container ev-card-body update-profile-card">
-                <form name="updateSubmissionMetaDataForm" ng-submit="challenge.changeSubmissionVisibility(challenge.submissionId)">
+                <form name="updateSubmissionVisibilityForm" ng-submit="challenge.changeSubmissionVisibility(challenge.submissionId)">
                     <div class="pass-title">Are you sure you want to override your current public submission?</div>
 
                     <ul class="inline-list pointer">

--- a/frontend/src/views/web/challenge/update-submission-visibility.html
+++ b/frontend/src/views/web/challenge/update-submission-visibility.html
@@ -2,7 +2,7 @@
     <div class="row">
         <div class="col s12 m12">
             <div class="ev-md-container ev-card-body update-profile-card">
-                <form name="updateSubmissionVisibilityForm" ng-submit="challenge.changeSubmissionVisibility(challenge.submissionId)">
+                <form name="updateSubmissionVisibilityForm" ng-submit="challenge.changeSubmissionVisibility(challenge.submissionId, true)">
                     <div class="pass-title">Are you sure you want to override your current public submission?</div>
 
                     <ul class="inline-list pointer">

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -1100,6 +1100,22 @@ class GetRemainingSubmissionTest(BaseAPITestClass):
                         "remaining_submissions_this_month_count": 12,
                         "remaining_submissions_count": 99,
                     },
+                },
+                {
+                    "id": self.challenge_phase_restricted_to_one_submission.id,
+                    "name": self.challenge_phase_restricted_to_one_submission.name,
+                    "slug": self.challenge_phase_restricted_to_one_submission.slug,
+                    "start_date": "{0}{1}".format(
+                        self.challenge_phase_restricted_to_one_submission.start_date.isoformat(), "Z"
+                    ).replace("+00:00", ""),
+                    "end_date": "{0}{1}".format(
+                        self.challenge_phase_restricted_to_one_submission.end_date.isoformat(), "Z"
+                    ).replace("+00:00", ""),
+                    "limits": {
+                        "remaining_submissions_today_count": 10,
+                        "remaining_submissions_this_month_count": 20,
+                        "remaining_submissions_count": 100,
+                    },
                 }
             ],
         }
@@ -1575,12 +1591,12 @@ class ChangeSubmissionDataAndVisibilityTest(BaseAPITestClass):
     def test_get_submission_by_pk_when_submission_doesnt_exist(self):
         self.url = reverse_lazy(
             "jobs:get_submission_by_pk",
-            kwargs={"submission_id": self.submission.id + 3},
+            kwargs={"submission_id": self.submission.id + 5},
         )
 
         expected = {
             "error": "Submission {} does not exist".format(
-                self.submission.id + 3
+                self.submission.id + 5
             )
         }
 

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -159,7 +159,7 @@ class BaseAPITestClass(APITestCase):
 
             self.challenge_phase_restricted_to_one_submission = ChallengePhase.objects.create(
                 name="Restrict One Public Submission Challenge Phase",
-                description="Description for Challenge Phase",
+                description="Description for Restrict One Public Submission Challenge Phase",
                 leaderboard_public=False,
                 max_submissions_per_day=10,
                 max_submissions_per_month=20,


### PR DESCRIPTION
### Feature Description

This feature is for the challenge phases with `is_restricted_to_one_submission=True`. It allows user to choose which submission will be shown on the leaderboard. The PR handles the following cases.

1. If a submission is already selected and the participant wants to change it to some other then we will show a pop up for confirmation. 

2. While challenge creation if `is_submission_public` is `True` then `is_restricted_to_one_submission` should be `False` or vice-versa.

3. We’re not making the latest submission public from our end -- Every team has to manually choose it.