### PR TITLE
Bolden ordering field in leaderboard

### DIFF
--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -2082,6 +2082,10 @@
             }
         };
 
+        vm.boldenLeaderboardFieldColumn = function(fieldName) {
+            return {'font-weight' : (vm.sortColumn==fieldName)?'bold':'300'};
+        };
+
         $scope.$on('$destroy', function() {
             vm.stopFetchingSubmissions();
             vm.stopLeaderboard();

--- a/frontend/src/views/web/challenge/leaderboard.html
+++ b/frontend/src/views/web/challenge/leaderboard.html
@@ -119,8 +119,8 @@
                             ng-click="challenge.scrollToSpecificEntryLeaderboard('leaderboardrank-' + challenge.initial_ranking[key.id])"
                             ng-repeat="key in challenge.leaderboard|orderBy:challenge.sortFunction:challenge.reverseSort"
                             class="fs-16" id="leaderboardrank-{{challenge.initial_ranking[key.id]}}">
-                            <td>{{challenge.initial_ranking[key.id]}}</td>
-                            <td><a ng-if="key.submission__participant_team__team_url" class="orange-text"
+                            <td ng-style="{'font-weight': (challenge.sortColumn=='rank')?'bold':'normal'}">{{challenge.initial_ranking[key.id]}}</td>
+                            <td ng-style="{'font-weight': (challenge.sortColumn=='string')?'bold':'normal'}"><a ng-if="key.submission__participant_team__team_url" class="orange-text"
                                     target="_blank"
                                     href="{{key.submission__participant_team__team_url}}">{{key.submission__participant_team__team_name}}</a><span
                                     ng-if="!key.submission__participant_team__team_url">{{key.submission__participant_team__team_name}}</span>
@@ -129,12 +129,12 @@
                                     id="baseline-badge" class="new badge orange-background" data-badge-caption="B"
                                     ng-if="key.submission__is_baseline"></span>
                             </td>
-                            <td ng-repeat="(i, score) in key.result track by $index">
+                            <td ng-style="{'font-weight': (challenge.sortColumn=='number')?'bold':'normal'}" ng-repeat="(i, score) in key.result track by $index"> <!--this is the correct spot for bold letters-->
                                 {{score | number : challenge.selectedPhaseSplit.leaderboard_decimal_precision}}
                                 <span ng-if="key.error != nil"> ±
                                     {{key.error[i] | number : challenge.selectedPhaseSplit.leaderboard_decimal_precision}}</span>
                             </td>
-                            <td>{{ key.submission__submitted_at | number: 0}}&nbsp;{{key.timeSpan}} ago
+                            <td ng-style="{'font-weight': (challenge.sortColumn=='date')?'bold':'normal'}">{{ key.submission__submitted_at | number: 0}}&nbsp;{{key.timeSpan}} ago
                             </td>
                         </tr>
                     </tbody>

--- a/frontend/src/views/web/challenge/leaderboard.html
+++ b/frontend/src/views/web/challenge/leaderboard.html
@@ -119,8 +119,8 @@
                             ng-click="challenge.scrollToSpecificEntryLeaderboard('leaderboardrank-' + challenge.initial_ranking[key.id])"
                             ng-repeat="key in challenge.leaderboard|orderBy:challenge.sortFunction:challenge.reverseSort"
                             class="fs-16" id="leaderboardrank-{{challenge.initial_ranking[key.id]}}">
-                            <td ng-style="{'font-weight': (challenge.sortColumn=='rank')?'bold':'300'}">{{challenge.initial_ranking[key.id]}}</td>
-                            <td ng-style="{'font-weight': (challenge.sortColumn=='string')?'bold':'300'}"><a ng-if="key.submission__participant_team__team_url" class="orange-text"
+                            <td ng-style="challenge.boldenLeaderboardFieldColumn('rank')">{{challenge.initial_ranking[key.id]}}</td>
+                            <td ng-style="challenge.boldenLeaderboardFieldColumn('string')"><a ng-if="key.submission__participant_team__team_url" class="orange-text"
                                     target="_blank"
                                     href="{{key.submission__participant_team__team_url}}">{{key.submission__participant_team__team_name}}</a><span
                                     ng-if="!key.submission__participant_team__team_url">{{key.submission__participant_team__team_name}}</span>
@@ -129,12 +129,12 @@
                                     id="baseline-badge" class="new badge orange-background" data-badge-caption="B"
                                     ng-if="key.submission__is_baseline"></span>
                             </td>
-                            <td ng-style="{'font-weight': (challenge.sortColumn=='number')?'bold':'300'}" ng-repeat="(i, score) in key.result track by $index"> <!--this is the correct spot for bold letters-->
+                            <td ng-style="challenge.boldenLeaderboardFieldColumn('number')" ng-repeat="(i, score) in key.result track by $index"> <!--this is the correct spot for bold letters-->
                                 {{score | number : challenge.selectedPhaseSplit.leaderboard_decimal_precision}}
                                 <span ng-if="key.error != nil"> ±
                                     {{key.error[i] | number : challenge.selectedPhaseSplit.leaderboard_decimal_precision}}</span>
                             </td>
-                            <td ng-style="{'font-weight': (challenge.sortColumn=='date')?'bold':'300'}">{{ key.submission__submitted_at | number: 0}}&nbsp;{{key.timeSpan}} ago
+                            <td ng-style="challenge.boldenLeaderboardFieldColumn('date')">{{ key.submission__submitted_at | number: 0}}&nbsp;{{key.timeSpan}} ago
                             </td>
                         </tr>
                     </tbody>

--- a/frontend/src/views/web/challenge/leaderboard.html
+++ b/frontend/src/views/web/challenge/leaderboard.html
@@ -119,8 +119,8 @@
                             ng-click="challenge.scrollToSpecificEntryLeaderboard('leaderboardrank-' + challenge.initial_ranking[key.id])"
                             ng-repeat="key in challenge.leaderboard|orderBy:challenge.sortFunction:challenge.reverseSort"
                             class="fs-16" id="leaderboardrank-{{challenge.initial_ranking[key.id]}}">
-                            <td ng-style="{'font-weight': (challenge.sortColumn=='rank')?'bold':'normal'}">{{challenge.initial_ranking[key.id]}}</td>
-                            <td ng-style="{'font-weight': (challenge.sortColumn=='string')?'bold':'normal'}"><a ng-if="key.submission__participant_team__team_url" class="orange-text"
+                            <td ng-style="{'font-weight': (challenge.sortColumn=='rank')?'bold':'300'}">{{challenge.initial_ranking[key.id]}}</td>
+                            <td ng-style="{'font-weight': (challenge.sortColumn=='string')?'bold':'300'}"><a ng-if="key.submission__participant_team__team_url" class="orange-text"
                                     target="_blank"
                                     href="{{key.submission__participant_team__team_url}}">{{key.submission__participant_team__team_name}}</a><span
                                     ng-if="!key.submission__participant_team__team_url">{{key.submission__participant_team__team_name}}</span>
@@ -129,12 +129,12 @@
                                     id="baseline-badge" class="new badge orange-background" data-badge-caption="B"
                                     ng-if="key.submission__is_baseline"></span>
                             </td>
-                            <td ng-style="{'font-weight': (challenge.sortColumn=='number')?'bold':'normal'}" ng-repeat="(i, score) in key.result track by $index"> <!--this is the correct spot for bold letters-->
+                            <td ng-style="{'font-weight': (challenge.sortColumn=='number')?'bold':'300'}" ng-repeat="(i, score) in key.result track by $index"> <!--this is the correct spot for bold letters-->
                                 {{score | number : challenge.selectedPhaseSplit.leaderboard_decimal_precision}}
                                 <span ng-if="key.error != nil"> ±
                                     {{key.error[i] | number : challenge.selectedPhaseSplit.leaderboard_decimal_precision}}</span>
                             </td>
-                            <td ng-style="{'font-weight': (challenge.sortColumn=='date')?'bold':'normal'}">{{ key.submission__submitted_at | number: 0}}&nbsp;{{key.timeSpan}} ago
+                            <td ng-style="{'font-weight': (challenge.sortColumn=='date')?'bold':'300'}">{{ key.submission__submitted_at | number: 0}}&nbsp;{{key.timeSpan}} ago
                             </td>
                         </tr>
                     </tbody>


### PR DESCRIPTION
Make the field with which the leaderboard is sorted is now bold
Before: 
![leaderboard_before](https://user-images.githubusercontent.com/28953079/81874534-0ad4e900-954c-11ea-8316-d4525cba9723.png)
After: 
![leaderboardorder_after](https://user-images.githubusercontent.com/28953079/81874538-0f010680-954c-11ea-88b9-cba51536c7d3.png)
