### PR TITLE
[WIP][Travis CI] Change CI build steps and run tests in docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
 script:
 - flake8 ./
 - docker-compose build
+- docker-compose run nodejs karma start --single-run
 - docker-compose run -e DJANGO_SETTINGS_MODULE=settings.test django pytest --cov . --cov-config .coveragerc
 before_cache:
 - rm -f $HOME/.cache/pip/log/debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,51 +2,24 @@ language: python
 sudo: false
 services:
 - docker
+- xvfb
 python:
 - '3.6'
-addons:
-  postgresql: '10'
-  apt:
-    update: true
-    packages:
-    - postgresql-10
-    - postgresql-client-10
-    - default-jre # Java11 is used for elasticmq
-    - libgnutls28-dev
-env:
-  global:
-  - PGPORT=5432
 cache:
   directories:
   - "$HOME/.cache/pip"
-before_cache:
-- rm -f $HOME/.cache/pip/log/debug.log
-before_script:
-- npm install
-- npm install -g bower
-- npm install -g gulp
-- npm install -g karma-cli
-- bower install
-- gulp dev
-- sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/10/main/postgresql.conf
-- sudo cp /etc/postgresql/{9.4,10}/main/pg_hba.conf
-- sudo service postgresql restart
-- psql -c "CREATE DATABASE evalai" -U postgres
-- wget https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.14.2.jar
-- java -jar elasticmq-server-0.14.2.jar &
 before_install:
 - sudo rm -f /etc/boto.cfg
 - export CHROME_BIN=chromium-browser
 - export DISPLAY=:99.0
-services:
-- xvfb
 install:
-- pip install -r requirements/dev.txt
-- pip install awscli==1.16.57 coveralls
+- pip install awscli==1.18.66 flake8==3.8.2
 script:
 - flake8 ./
-- karma start --single-run
-- py.test --cov . --cov-config .coveragerc
+- docker-compose build
+- docker-compose run -e DJANGO_SETTINGS_MODULE=settings.test django pytest --cov . --cov-config .coveragerc
+before_cache:
+- rm -f $HOME/.cache/pip/log/debug.log
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 - coveralls --rcfile=.coveragerc

--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -1,6 +1,14 @@
 FROM node:8.11.2
 
+# install chrome for protractor tests
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+RUN apt-get update && apt-get install -yq google-chrome-stable
+
 WORKDIR /code
+
+# add `/app/node_modules/.bin` to $PATH
+ENV PATH /code/node_modules/.bin:$PATH
 
 # Add dependencies
 ADD ./package.json /code
@@ -11,22 +19,6 @@ ADD ./karma.conf.js /code
 
 # Install Prerequisites
 RUN npm install -g bower gulp
-
-# This enables `apt` to run from the new sources
-RUN printf "deb http://archive.debian.org/debian/ \
-jessie main\ndeb-src http://archive.debian.org/debian/ \
-jessie main\ndeb http://security.debian.org jessie/updates \
-main\ndeb-src http://security.debian.org \
-jessie/updates main" > /etc/apt/sources.list
-
-# Install the latest chrome dev package
-RUN apt-get update && \
-	apt-get -y --force-yes install gconf-service libasound2 libatk1.0-0 libc6 libcairo2 \
-		libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 \
-		libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 \
-		libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 \
-		libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 \
-		libnss3 lsb-release xdg-utils wget
 
 RUN npm link gulp
 

--- a/docker/dev/worker/Dockerfile
+++ b/docker/dev/worker/Dockerfile
@@ -1,7 +1,6 @@
 FROM evalai_django
 
 RUN apt-get update && \
-  apt-get upgrade -y && \
   apt-get install -q -y default-jdk
 
 RUN pip install -U cffi service_identity cython==0.29 numpy==1.14.5

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -27,7 +27,7 @@ module.exports = function(config) {
     files: [
         'frontend/dist/vendors/*.js',
         'frontend/dist/js/config.js',
-        'bower_components/angular/angular.js',
+        'bower_components/**/*.js',
         'node_modules/angular-mocks/angular-mocks.js',
         'frontend/src/js/app.js',
         'frontend/src/**/*.js',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -27,6 +27,7 @@ module.exports = function(config) {
     files: [
         'frontend/dist/vendors/*.js',
         'frontend/dist/js/config.js',
+        'bower_components/angular/angular.js',
         'node_modules/angular-mocks/angular-mocks.js',
         'frontend/src/js/app.js',
         'frontend/src/**/*.js',

--- a/middleware/metrics/metrics_middleware.py
+++ b/middleware/metrics/metrics_middleware.py
@@ -61,4 +61,4 @@ class DatadogMiddleware(MiddlewareMixin):
         api.Event.create(title=title, text=text, tags=event_tags)
 
     def _get_metric_tags(self, request):
-            return ['path:{0}'.format(request.path)]
+        return ['path:{0}'.format(request.path)]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 python_files=test*.py
 DJANGO_SETTINGS_MODULE=settings.test
-DJANGO_SERVER=testserver
+DJANGO_SERVER=django
 norecursedirs=env venv node_modules bower_components

--- a/scripts/workers/remote_submission_worker.py
+++ b/scripts/workers/remote_submission_worker.py
@@ -354,10 +354,7 @@ def make_request(url, method, data=None):
             )
             raise
         except requests.exceptions.HTTPError:
-            logger.exception(
-                "The request to URL {} is failed due to {}"
-                % (url, response.json())
-            )
+            logger.exception(f"The request to URL {url} is failed due to {response.json()}")
             raise
         return response.json()
 
@@ -371,10 +368,7 @@ def make_request(url, method, data=None):
             )
             raise
         except requests.exceptions.HTTPError:
-            logger.info(
-                "The request to URL {} is failed due to {}"
-                % (url, response.json())
-            )
+            logger.info(f"The request to URL {url} is failed due to {response.json()}")
             raise
         return response.json()
 
@@ -388,10 +382,7 @@ def make_request(url, method, data=None):
             )
             raise
         except requests.exceptions.HTTPError:
-            logger.info(
-                "The request to URL {} is failed due to {}"
-                % (url, response.json())
-            )
+            logger.info(f"The request to URL {url} is failed due to {response.json()}")
             raise
         return response.json()
 

--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -25,7 +25,6 @@ from os.path import join
 
 from django.core.files.base import ContentFile
 from django.utils import timezone
-from django.conf import settings
 
 # all challenge and submission will be stored in temp directory
 BASE_TEMP_DIR = tempfile.mkdtemp()
@@ -34,24 +33,21 @@ COMPUTE_DIRECTORY_PATH = join(BASE_TEMP_DIR, "compute")
 logger = logging.getLogger(__name__)
 django.setup()
 
-DJANGO_SETTINGS_MODULE = os.environ.get(
-    "DJANGO_SETTINGS_MODULE", "settings.dev"
-)
-DJANGO_SERVER = os.environ.get("DJANGO_SERVER", "localhost")
-LIMIT_CONCURRENT_SUBMISSION_PROCESSING = os.environ.get(
-    "LIMIT_CONCURRENT_SUBMISSION_PROCESSING"
-)
-
-from challenges.models import (
+# Load django app settings
+from django.conf import settings  # noqa
+from challenges.models import (  # noqa:E402
     Challenge,
     ChallengePhase,
     ChallengePhaseSplit,
     LeaderboardData,
-)  # noqa
+)
 
-from jobs.models import Submission  # noqa
-from jobs.serializers import SubmissionSerializer  # noqa
+from jobs.models import Submission  # noqa:E402
+from jobs.serializers import SubmissionSerializer  # noqa:E402
 
+LIMIT_CONCURRENT_SUBMISSION_PROCESSING = os.environ.get(
+    "LIMIT_CONCURRENT_SUBMISSION_PROCESSING"
+)
 
 CHALLENGE_DATA_BASE_DIR = join(COMPUTE_DIRECTORY_PATH, "challenge_data")
 SUBMISSION_DATA_BASE_DIR = join(COMPUTE_DIRECTORY_PATH, "submission_files")
@@ -202,14 +198,8 @@ def create_dir_as_python_package(directory):
 
 
 def return_file_url_per_environment(url):
-
-    if DJANGO_SETTINGS_MODULE == "settings.dev":
-        base_url = "http://{0}:8000".format(DJANGO_SERVER)
-        url = "{0}{1}".format(base_url, url)
-
-    elif DJANGO_SETTINGS_MODULE == "settings.test":
-        url = "{0}{1}".format("http://testserver", url)
-
+    base_url = f"http://{settings.DJANGO_SERVER}:{settings.DJANGO_SERVER_PORT}"
+    url = "{0}{1}".format(base_url, url)
     return url
 
 

--- a/settings/common.py
+++ b/settings/common.py
@@ -299,6 +299,9 @@ SWAGGER_SETTINGS = {
 
 REDOC_SETTINGS = {"SPEC_URL": ("docs.yaml", {"format": ".yaml"})}
 
+DJANGO_SERVER = os.environ.get("DJANGO_SERVER")
+DJANGO_SERVER_PORT = os.environ.get("DJANGO_SERVER_PORT")
+
 HOSTNAME = os.environ.get("HOSTNAME")
 
 SENDGRID_SETTINGS = {

--- a/tests/integration/worker/test_submission_worker.py
+++ b/tests/integration/worker/test_submission_worker.py
@@ -8,6 +8,7 @@ from allauth.account.models import EmailAddress
 
 from datetime import timedelta
 
+from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.urlresolvers import reverse_lazy
@@ -228,7 +229,7 @@ class ExtractSubmissionDataTestClass(BaseTestClass):
         submission_worker.extract_submission_data(self.submission.pk)
 
         name = os.path.basename(self.submission.input_file.name)
-        submission_input_file_url = "http://testserver{}".format(self.submission.input_file.url)
+        submission_input_file_url = f"http://{settings.DJANGO_SERVER}:{settings.DJANGO_SERVER_PORT}{self.submission.input_file.url}"
         submission_input_file_path = "mocked/dir/submission_{}/{}".format(self.submission.pk, name)
         mock_down_ext.assert_called_with(submission_input_file_url, submission_input_file_path)
 

--- a/tests/unit/worker/test_submission_worker.py
+++ b/tests/unit/worker/test_submission_worker.py
@@ -11,6 +11,7 @@ from moto import mock_sqs
 from io import BytesIO
 from os.path import join
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils import timezone
@@ -49,7 +50,7 @@ class BaseAPITestClass(APITestCase):
 
         self.temp_directory = join(self.BASE_TEMP_DIR, "temp_dir")
 
-        self.testserver = "http://testserver"
+        self.testserver = f"http://{settings.DJANGO_SERVER}:{settings.DJANGO_SERVER_PORT}"
         self.url = "/test/url"
 
         self.input_file = open(join(self.BASE_TEMP_DIR, 'dummy_input.txt'), "w+")


### PR DESCRIPTION
Currently, we run the tests in the Travis CI virtualenv which doesn't represent the environment where EvalAI code actually runs. Hence, moving the tests to run inside the docker container.

Changes introduced:
- Running frontend and backend tests inside docker container
- Get rid of standalone dependencies like elasticmq etc and just use docker as a service
- Fix PEP8 issues

One of the disadvantage is that Travis CI cannot cache the docker layers by default so we will have to add caching manually. I had tried adding caching the docker layers in  tarball and do the extraction before we run the docker build but it seems to take a lot more time to zip and unzip the tarball. So, not following the caching path.