### PR TITLE
[Travis CI] Fix travis build for case when PR is coming from forked repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ before_script:
 - wget https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.14.2.jar
 - java -jar elasticmq-server-0.14.2.jar &
 before_install:
-- openssl aes-256-cbc -K $encrypted_77d2d82026f6_key -iv $encrypted_77d2d82026f6_iv
-  -in scripts/deployment/evalai.pem.enc -out scripts/deployment/evalai.pem -d || true
 - sudo rm -f /etc/boto.cfg
 - export CHROME_BIN=chromium-browser
 - export DISPLAY=:99.0
@@ -50,6 +48,8 @@ script:
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 - coveralls --rcfile=.coveragerc
+- openssl aes-256-cbc -K $encrypted_77d2d82026f6_key -iv $encrypted_77d2d82026f6_iv
+  -in scripts/deployment/evalai.pem.enc -out scripts/deployment/evalai.pem -d || true
 - "./scripts/deployment/push.sh"
 - "./scripts/deployment/deploy.sh auto_deploy"
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
 - java -jar elasticmq-server-0.14.2.jar &
 before_install:
 - openssl aes-256-cbc -K $encrypted_77d2d82026f6_key -iv $encrypted_77d2d82026f6_iv
-  -in scripts/deployment/evalai.pem.enc -out scripts/deployment/evalai.pem -d
+  -in scripts/deployment/evalai.pem.enc -out scripts/deployment/evalai.pem -d || true
 - sudo rm -f /etc/boto.cfg
 - export CHROME_BIN=chromium-browser
 - export DISPLAY=:99.0


### PR DESCRIPTION
Builds have started to fail because the travis decript file command doesn't work when there is a PR from forked repository to the main repository. Hence, setting the exit code to 0 by default so that the build doesn't fail. 

Example build failure: https://travis-ci.org/github/Cloud-CV/EvalAI/builds/690801036