### PR TITLE
Add backend APIs for github badges feature

### DIFF
--- a/apps/jobs/urls.py
+++ b/apps/jobs/urls.py
@@ -75,4 +75,9 @@ urlpatterns = [
         views.get_bearer_token,
         name="get_bearer_token",
     ),
+    url(
+        r"^phase_split/(?P<challenge_phase_split_pk>[0-9]+)/team/(?P<participant_team_pk>[0-9]+)/github_badge/$",
+        views.get_github_badge_data,
+        name="get_github_badge_data",
+    ),
 ]

--- a/apps/jobs/urls.py
+++ b/apps/jobs/urls.py
@@ -76,8 +76,8 @@ urlpatterns = [
         name="get_bearer_token",
     ),
     url(
-        r"^phase_split/(?P<challenge_phase_split_pk>[0-9]+)/team/(?P<participant_team_pk>[0-9]+)/github_badge/$",
-        views.github_badge_data,
-        name="github_badge_data",
+        r"^phase_splits/(?P<challenge_phase_split_pk>[0-9]+)/teams/(?P<participant_team_pk>[0-9]+)/github_badge/$",
+        views.get_github_badge_data,
+        name="get_github_badge_data",
     ),
 ]

--- a/apps/jobs/urls.py
+++ b/apps/jobs/urls.py
@@ -77,7 +77,7 @@ urlpatterns = [
     ),
     url(
         r"^phase_split/(?P<challenge_phase_split_pk>[0-9]+)/team/(?P<participant_team_pk>[0-9]+)/github_badge/$",
-        views.get_github_badge_data,
-        name="get_github_badge_data",
+        views.github_badge_data,
+        name="github_badge_data",
     ),
 ]

--- a/apps/jobs/utils.py
+++ b/apps/jobs/utils.py
@@ -231,7 +231,18 @@ def handle_submission_rerun(submission, updated_status):
 def calculate_distinct_sorted_leaderboard_data(
     user, challenge_obj, challenge_phase_split, only_public_entries
 ):
+    """
+    Function to calculate and return the sorted leaderboard data
 
+    Arguments:
+        user {[Class object]} -- User model object
+        challenge_obj {[Class object]} -- Challenge model object
+        challenge_phase_split {[Class object]} -- Challenge phase split model object
+        only_public_entries {[Boolean]} -- Boolean value to determine if the user wants to include private entries or not
+
+    Returns:
+        [list] -- Ranked list of participant teams to be shown on leaderboard
+    """
     # Get the leaderboard associated with the Challenge Phase Split
     leaderboard = challenge_phase_split.leaderboard
 
@@ -240,7 +251,7 @@ def calculate_distinct_sorted_leaderboard_data(
         default_order_by = leaderboard.schema["default_order_by"]
     except KeyError:
         response_data = {
-            "error": "Sorry, Default filtering key not found in leaderboard schema!"
+            "error": "Sorry, default_order_by key is missing in leaderboard schema!"
         }
         return response_data, status.HTTP_400_BAD_REQUEST
 

--- a/apps/jobs/utils.py
+++ b/apps/jobs/utils.py
@@ -294,6 +294,7 @@ def calculate_distinct_sorted_leaderboard_data(
         "submission__participant_team__team_name",
         "submission__participant_team__team_url",
         "submission__is_baseline",
+        "submission__is_public",
         "challenge_phase_split",
         "result",
         "error",

--- a/apps/jobs/utils.py
+++ b/apps/jobs/utils.py
@@ -242,6 +242,7 @@ def calculate_distinct_sorted_leaderboard_data(
 
     Returns:
         [list] -- Ranked list of participant teams to be shown on leaderboard
+        [status] -- HTTP status code (200/400)
     """
     # Get the leaderboard associated with the Challenge Phase Split
     leaderboard = challenge_phase_split.leaderboard

--- a/apps/jobs/utils.py
+++ b/apps/jobs/utils.py
@@ -5,14 +5,18 @@ import requests
 import tempfile
 import urllib.request
 
-from base.utils import get_model_object
-from challenges.utils import get_challenge_model, get_challenge_phase_model
+from django.db.models import FloatField, Q
+from django.db.models.expressions import RawSQL
 from django.utils import timezone
-from participants.utils import get_participant_team_id_of_user_for_a_challenge
 from rest_framework import status
 
-from base.utils import suppress_autotime
-from challenges.models import ChallengePhaseSplit
+from challenges.models import ChallengePhaseSplit, LeaderboardData
+from participants.models import ParticipantTeam
+
+from base.utils import get_model_object, suppress_autotime
+from challenges.utils import get_challenge_model, get_challenge_phase_model
+from hosts.utils import is_user_a_host_of_challenge
+from participants.utils import get_participant_team_id_of_user_for_a_challenge
 
 from .constants import submission_status_to_exclude
 from .models import Submission
@@ -222,3 +226,141 @@ def handle_submission_rerun(submission, updated_status):
                 "submitted_image_uri"
             ]
     return message
+
+
+def calculate_distinct_sorted_leaderboard_data(
+    user, challenge_obj, challenge_phase_split, only_public_entries
+):
+
+    # Get the leaderboard associated with the Challenge Phase Split
+    leaderboard = challenge_phase_split.leaderboard
+
+    # Get the default order by key to rank the entries on the leaderboard
+    try:
+        default_order_by = leaderboard.schema["default_order_by"]
+    except KeyError:
+        response_data = {
+            "error": "Sorry, Default filtering key not found in leaderboard schema!"
+        }
+        return response_data, status.HTTP_400_BAD_REQUEST
+
+    # Exclude the submissions done by members of the host team
+    # while populating leaderboard
+    challenge_hosts_emails = (
+        challenge_obj.creator.get_all_challenge_host_email()
+    )
+    is_challenge_phase_public = challenge_phase_split.challenge_phase.is_public
+    # Exclude the submissions from challenge host team to be displayed on the leaderboard of public phases
+    challenge_hosts_emails = (
+        [] if not is_challenge_phase_public else challenge_hosts_emails
+    )
+
+    challenge_host_user = is_user_a_host_of_challenge(user, challenge_obj.pk)
+
+    all_banned_email_ids = challenge_obj.banned_email_ids
+
+    # Check if challenge phase leaderboard is public for participant user or not
+    if (
+        challenge_phase_split.visibility != ChallengePhaseSplit.PUBLIC
+        and not challenge_host_user
+    ):
+        response_data = {"error": "Sorry, the leaderboard is not public!"}
+        return response_data, status.HTTP_400_BAD_REQUEST
+
+    leaderboard_data = LeaderboardData.objects.exclude(
+        Q(submission__created_by__email__in=challenge_hosts_emails)
+        & Q(submission__is_baseline=False)
+    )
+
+    # Get all the successful submissions related to the challenge phase split
+    leaderboard_data = leaderboard_data.filter(
+        challenge_phase_split=challenge_phase_split,
+        submission__is_flagged=False,
+        submission__status=Submission.FINISHED,
+    ).order_by("-created_at")
+
+    leaderboard_data = leaderboard_data.annotate(
+        filtering_score=RawSQL(
+            "result->>%s", (default_order_by,), output_field=FloatField()
+        ),
+        filtering_error=RawSQL(
+            "error->>%s",
+            ("error_{0}".format(default_order_by),),
+            output_field=FloatField(),
+        ),
+    ).values(
+        "id",
+        "submission__participant_team",
+        "submission__participant_team__team_name",
+        "submission__participant_team__team_url",
+        "submission__is_baseline",
+        "challenge_phase_split",
+        "result",
+        "error",
+        "filtering_score",
+        "filtering_error",
+        "leaderboard__schema",
+        "submission__submitted_at",
+        "submission__method_name",
+    )
+    if only_public_entries:
+        if challenge_phase_split.visibility == ChallengePhaseSplit.PUBLIC:
+            leaderboard_data = leaderboard_data.filter(
+                submission__is_public=True
+            )
+
+    all_banned_participant_team = []
+    for leaderboard_item in leaderboard_data:
+        participant_team_id = leaderboard_item["submission__participant_team"]
+        participant_team = ParticipantTeam.objects.get(id=participant_team_id)
+        all_participants_email_ids = (
+            participant_team.get_all_participants_email()
+        )
+        for participant_email in all_participants_email_ids:
+            if participant_email in all_banned_email_ids:
+                all_banned_participant_team.append(participant_team_id)
+                break
+        if leaderboard_item["error"] is None:
+            leaderboard_item.update(filtering_error=0)
+
+    if challenge_phase_split.show_leaderboard_by_latest_submission:
+        sorted_leaderboard_data = leaderboard_data
+    else:
+        sorted_leaderboard_data = sorted(
+            leaderboard_data,
+            key=lambda k: (
+                float(k["filtering_score"]),
+                float(-k["filtering_error"]),
+            ),
+            reverse=True
+            if challenge_phase_split.is_leaderboard_order_descending
+            else False,
+        )
+
+    distinct_sorted_leaderboard_data = []
+    team_list = []
+    for data in sorted_leaderboard_data:
+        if (
+            data["submission__participant_team__team_name"] in team_list
+            or data["submission__participant_team"]
+            in all_banned_participant_team
+        ):
+            continue
+        elif data["submission__is_baseline"] is True:
+            distinct_sorted_leaderboard_data.append(data)
+        else:
+            distinct_sorted_leaderboard_data.append(data)
+            team_list.append(data["submission__participant_team__team_name"])
+
+    leaderboard_labels = challenge_phase_split.leaderboard.schema["labels"]
+    for item in distinct_sorted_leaderboard_data:
+        item["result"] = [
+            item["result"][index] for index in leaderboard_labels
+        ]
+        if item["error"] is not None:
+            item["error"] = [
+                item["error"]["error_{0}".format(index)]
+                for index in leaderboard_labels
+            ]
+
+    return distinct_sorted_leaderboard_data, status.HTTP_200_OK

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -1497,9 +1497,7 @@ def get_bearer_token(request, challenge_pk):
 @throttle_classes([UserRateThrottle])
 @permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))
 @authentication_classes((ExpiringTokenAuthentication,))
-def get_github_badge_data(
-    request, challenge_phase_split_pk, participant_team_pk
-):
+def github_badge_data(request, challenge_phase_split_pk, participant_team_pk):
     """
     Add API to get data for dynamically generating github badges
     Ref: https://shields.io/endpoint
@@ -1532,4 +1530,6 @@ def get_github_badge_data(
         ):
             data["message"] = f"{challenge_obj.title} Rank #{idx+1}"
             break
+        else:
+            data["message"] = f"{challenge_obj.title}"
     return Response(data, status=http_status_code)

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -496,21 +496,18 @@ def leaderboard(request, challenge_phase_split_id):
         challenge_phase_split_id
     )
     challenge_obj = challenge_phase_split.challenge_phase.challenge
-    distinct_sorted_leaderboard_data, http_status_code = calculate_distinct_sorted_leaderboard_data(
+    response_data, http_status_code = calculate_distinct_sorted_leaderboard_data(
         request.user,
         challenge_obj,
         challenge_phase_split,
         only_public_entries=True,
     )
+    # The response 400 will be returned if the leaderboard isn't public or `default_order_by` key is missing in leaderboard.
     if http_status_code == status.HTTP_400_BAD_REQUEST:
-        return Response(
-            distinct_sorted_leaderboard_data, status=http_status_code
-        )
+        return Response(response_data, status=http_status_code)
 
     paginator, result_page = paginated_queryset(
-        distinct_sorted_leaderboard_data,
-        request,
-        pagination_class=StandardResultSetPagination(),
+        response_data, request, pagination_class=StandardResultSetPagination()
     )
     response_data = result_page
     return paginator.get_paginated_response(response_data)
@@ -544,21 +541,18 @@ def get_all_entries_on_public_leaderboard(request, challenge_phase_split_pk):
         }
         return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
-    distinct_sorted_leaderboard_data, http_status_code = calculate_distinct_sorted_leaderboard_data(
+    response_data, http_status_code = calculate_distinct_sorted_leaderboard_data(
         request.user,
         challenge_obj,
         challenge_phase_split,
         only_public_entries=False,
     )
+    # The response 400 will be returned if the leaderboard isn't public or `default_order_by` key is missing in leaderboard.
     if http_status_code == status.HTTP_400_BAD_REQUEST:
-        return Response(
-            distinct_sorted_leaderboard_data, status=http_status_code
-        )
+        return Response(response_data, status=http_status_code)
 
     paginator, result_page = paginated_queryset(
-        distinct_sorted_leaderboard_data,
-        request,
-        pagination_class=StandardResultSetPagination(),
+        response_data, request, pagination_class=StandardResultSetPagination()
     )
     response_data = result_page
     return paginator.get_paginated_response(response_data)
@@ -1497,7 +1491,9 @@ def get_bearer_token(request, challenge_pk):
 @throttle_classes([UserRateThrottle])
 @permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))
 @authentication_classes((ExpiringTokenAuthentication,))
-def github_badge_data(request, challenge_phase_split_pk, participant_team_pk):
+def get_github_badge_data(
+    request, challenge_phase_split_pk, participant_team_pk
+):
     """
     Add API to get data for dynamically generating github badges
     Ref: https://shields.io/endpoint

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -13,8 +13,6 @@ from rest_framework.decorators import (
 
 from django.core.files.base import ContentFile
 from django.db import transaction, IntegrityError
-from django.db.models.expressions import RawSQL
-from django.db.models import FloatField, Q
 from django.utils import timezone
 
 from rest_framework_expiring_authtoken.authentication import (
@@ -43,7 +41,7 @@ from challenges.utils import (
     get_aws_credentials_for_challenge,
     get_challenge_model,
     get_challenge_phase_model,
-    get_challenge_phase_split_model
+    get_challenge_phase_split_model,
 )
 from hosts.models import ChallengeHost
 from hosts.utils import is_user_a_host_of_challenge
@@ -66,6 +64,7 @@ from .serializers import (
 )
 from .tasks import download_file_and_publish_submission_message
 from .utils import (
+    calculate_distinct_sorted_leaderboard_data,
     get_submission_model,
     get_remaining_submission_for_a_phase,
     handle_submission_rerun,
@@ -377,12 +376,14 @@ def change_submission_data_and_visibility(
             submissions_already_public = Submission.objects.get(
                 is_public=True,
                 participant_team=participant_team,
-                challenge_phase=challenge_phase
+                challenge_phase=challenge_phase,
             )
             # Make the existing public submission private before making the new submission public
-            if (challenge_phase.is_restricted_to_select_one_submission
-                    and is_public
-                    and submissions_already_public):
+            if (
+                challenge_phase.is_restricted_to_select_one_submission
+                and is_public
+                and submissions_already_public
+            ):
                 submissions_already_public.is_public = False
                 submissions_already_public.save()
         except Submission.DoesNotExist:
@@ -491,145 +492,20 @@ def leaderboard(request, challenge_phase_split_id):
     """
 
     # check if the challenge exists or not
-    try:
-        challenge_phase_split = ChallengePhaseSplit.objects.get(
-            pk=challenge_phase_split_id
-        )
-    except ChallengePhaseSplit.DoesNotExist:
-        response_data = {"error": "Challenge Phase Split does not exist"}
-        return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
-
-    # Get the leaderboard associated with the Challenge Phase Split
-    leaderboard = challenge_phase_split.leaderboard
-
-    # Get the default order by key to rank the entries on the leaderboard
-    try:
-        default_order_by = leaderboard.schema["default_order_by"]
-    except KeyError:
-        response_data = {
-            "error": "Sorry, Default filtering key not found in leaderboard schema!"
-        }
-        return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
-
-    # Exclude the submissions done by members of the host team
-    # while populating leaderboard
+    challenge_phase_split = get_challenge_phase_split_model(
+        challenge_phase_split_id
+    )
     challenge_obj = challenge_phase_split.challenge_phase.challenge
-    challenge_hosts_emails = (
-        challenge_obj.creator.get_all_challenge_host_email()
+    distinct_sorted_leaderboard_data, http_status_code = calculate_distinct_sorted_leaderboard_data(
+        request.user,
+        challenge_obj,
+        challenge_phase_split,
+        only_public_entries=True,
     )
-    is_challenge_phase_public = challenge_phase_split.challenge_phase.is_public
-    # Exclude the submissions from challenge host team to be displayed on the leaderboard of public phases
-    challenge_hosts_emails = (
-        [] if not is_challenge_phase_public else challenge_hosts_emails
-    )
-
-    challenge_host_user = is_user_a_host_of_challenge(
-        request.user, challenge_obj.pk
-    )
-
-    all_banned_email_ids = challenge_obj.banned_email_ids
-
-    # Check if challenge phase leaderboard is public for participant user or not
-    if (
-        challenge_phase_split.visibility != ChallengePhaseSplit.PUBLIC
-        and not challenge_host_user
-    ):
-        response_data = {"error": "Sorry, the leaderboard is not public!"}
-        return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
-
-    leaderboard_data = LeaderboardData.objects.exclude(
-        Q(submission__created_by__email__in=challenge_hosts_emails)
-        & Q(submission__is_baseline=False)
-    )
-
-    # Get all the successful submissions related to the challenge phase split
-    leaderboard_data = leaderboard_data.filter(
-        challenge_phase_split=challenge_phase_split,
-        submission__is_flagged=False,
-        submission__status=Submission.FINISHED,
-    ).order_by("-created_at")
-
-    leaderboard_data = leaderboard_data.annotate(
-        filtering_score=RawSQL(
-            "result->>%s", (default_order_by,), output_field=FloatField()
-        ),
-        filtering_error=RawSQL(
-            "error->>%s",
-            ("error_{0}".format(default_order_by),),
-            output_field=FloatField(),
-        ),
-    ).values(
-        "id",
-        "submission__participant_team",
-        "submission__participant_team__team_name",
-        "submission__participant_team__team_url",
-        "submission__is_baseline",
-        "challenge_phase_split",
-        "result",
-        "error",
-        "filtering_score",
-        "filtering_error",
-        "leaderboard__schema",
-        "submission__submitted_at",
-        "submission__method_name",
-    )
-
-    if challenge_phase_split.visibility == ChallengePhaseSplit.PUBLIC:
-        leaderboard_data = leaderboard_data.filter(submission__is_public=True)
-
-    all_banned_participant_team = []
-    for leaderboard_item in leaderboard_data:
-        participant_team_id = leaderboard_item["submission__participant_team"]
-        participant_team = ParticipantTeam.objects.get(id=participant_team_id)
-        all_participants_email_ids = (
-            participant_team.get_all_participants_email()
+    if http_status_code == status.HTTP_400_BAD_REQUEST:
+        return Response(
+            distinct_sorted_leaderboard_data, status=http_status_code
         )
-        for participant_email in all_participants_email_ids:
-            if participant_email in all_banned_email_ids:
-                all_banned_participant_team.append(participant_team_id)
-                break
-        if leaderboard_item["error"] is None:
-            leaderboard_item.update(filtering_error=0)
-
-    if challenge_phase_split.show_leaderboard_by_latest_submission:
-        sorted_leaderboard_data = leaderboard_data
-    else:
-        sorted_leaderboard_data = sorted(
-            leaderboard_data,
-            key=lambda k: (
-                float(k["filtering_score"]),
-                float(-k["filtering_error"]),
-            ),
-            reverse=True
-            if challenge_phase_split.is_leaderboard_order_descending
-            else False,
-        )
-
-    distinct_sorted_leaderboard_data = []
-    team_list = []
-    for data in sorted_leaderboard_data:
-        if (
-            data["submission__participant_team__team_name"] in team_list
-            or data["submission__participant_team"]
-            in all_banned_participant_team
-        ):
-            continue
-        elif data["submission__is_baseline"] is True:
-            distinct_sorted_leaderboard_data.append(data)
-        else:
-            distinct_sorted_leaderboard_data.append(data)
-            team_list.append(data["submission__participant_team__team_name"])
-
-    leaderboard_labels = challenge_phase_split.leaderboard.schema["labels"]
-    for item in distinct_sorted_leaderboard_data:
-        item["result"] = [
-            item["result"][index] for index in leaderboard_labels
-        ]
-        if item["error"] is not None:
-            item["error"] = [
-                item["error"]["error_{0}".format(index)]
-                for index in leaderboard_labels
-            ]
 
     paginator, result_page = paginated_queryset(
         distinct_sorted_leaderboard_data,
@@ -655,128 +531,29 @@ def get_all_entries_on_public_leaderboard(request, challenge_phase_split_pk):
         All Leaderboard entry objects in a list
     """
     # check if the challenge exists or not
-    challenge_phase_split = get_challenge_phase_split_model(challenge_phase_split_pk)
+    challenge_phase_split = get_challenge_phase_split_model(
+        challenge_phase_split_pk
+    )
 
     challenge_obj = challenge_phase_split.challenge_phase.challenge
 
     # Allow access only to challenge host
     if not is_user_a_host_of_challenge(request.user, challenge_obj.pk):
-        response_data = {"error": "Sorry, you are not authorized to make this request!"}
-        return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
-
-    # Get the leaderboard associated with the Challenge Phase Split
-    leaderboard = challenge_phase_split.leaderboard
-
-    # Get the default order by key to rank the entries on the leaderboard
-    try:
-        default_order_by = leaderboard.schema["default_order_by"]
-    except KeyError:
         response_data = {
-            "error": "Sorry, Default filtering key not found in leaderboard schema!"
+            "error": "Sorry, you are not authorized to make this request!"
         }
         return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
-    # Exclude the submissions done by members of the host team
-    # while populating leaderboard
-    challenge_hosts_emails = (
-        challenge_obj.creator.get_all_challenge_host_email()
+    distinct_sorted_leaderboard_data, http_status_code = calculate_distinct_sorted_leaderboard_data(
+        request.user,
+        challenge_obj,
+        challenge_phase_split,
+        only_public_entries=False,
     )
-    is_challenge_phase_public = challenge_phase_split.challenge_phase.is_public
-    # Exclude the submissions from challenge host team to be displayed on the leaderboard of public phases
-    challenge_hosts_emails = (
-        [] if not is_challenge_phase_public else challenge_hosts_emails
-    )
-
-    all_banned_email_ids = challenge_obj.banned_email_ids
-
-    leaderboard_data = LeaderboardData.objects.exclude(
-        Q(submission__created_by__email__in=challenge_hosts_emails)
-        & Q(submission__is_baseline=False)
-    )
-    # Get all the successful submissions related to the challenge phase split
-    leaderboard_data = leaderboard_data.filter(
-        challenge_phase_split=challenge_phase_split,
-        submission__status=Submission.FINISHED,
-    ).order_by("-created_at")
-
-    leaderboard_data = leaderboard_data.annotate(
-        filtering_score=RawSQL(
-            "result->>%s", (default_order_by,), output_field=FloatField()
-        ),
-        filtering_error=RawSQL(
-            "error->>%s",
-            ("error_{0}".format(default_order_by),),
-            output_field=FloatField(),
-        ),
-    ).values(
-        "id",
-        "submission__participant_team",
-        "submission__participant_team__team_name",
-        "submission__participant_team__team_url",
-        "submission__is_baseline",
-        "challenge_phase_split",
-        "result",
-        "error",
-        "filtering_score",
-        "filtering_error",
-        "leaderboard__schema",
-        "submission__submitted_at",
-        "submission__method_name",
-        "submission__is_public"
-    )
-    all_banned_participant_team = []
-    for leaderboard_item in leaderboard_data:
-        participant_team_id = leaderboard_item["submission__participant_team"]
-        participant_team = ParticipantTeam.objects.get(id=participant_team_id)
-        all_participants_email_ids = (
-            participant_team.get_all_participants_email()
+    if http_status_code == status.HTTP_400_BAD_REQUEST:
+        return Response(
+            distinct_sorted_leaderboard_data, status=http_status_code
         )
-        for participant_email in all_participants_email_ids:
-            if participant_email in all_banned_email_ids:
-                all_banned_participant_team.append(participant_team_id)
-                break
-        if leaderboard_item["error"] is None:
-            leaderboard_item.update(filtering_error=0)
-
-    if challenge_phase_split.show_leaderboard_by_latest_submission:
-        sorted_leaderboard_data = leaderboard_data
-    else:
-        sorted_leaderboard_data = sorted(
-            leaderboard_data,
-            key=lambda k: (
-                float(k["filtering_score"]),
-                float(-k["filtering_error"]),
-            ),
-            reverse=True
-            if challenge_phase_split.is_leaderboard_order_descending
-            else False,
-        )
-
-    distinct_sorted_leaderboard_data = []
-    team_list = []
-    for data in sorted_leaderboard_data:
-        if (
-            data["submission__participant_team__team_name"] in team_list
-            or data["submission__participant_team"]
-            in all_banned_participant_team
-        ):
-            continue
-        elif data["submission__is_baseline"] is True:
-            distinct_sorted_leaderboard_data.append(data)
-        else:
-            distinct_sorted_leaderboard_data.append(data)
-            team_list.append(data["submission__participant_team__team_name"])
-
-    leaderboard_labels = challenge_phase_split.leaderboard.schema["labels"]
-    for item in distinct_sorted_leaderboard_data:
-        item["result"] = [
-            item["result"][index] for index in leaderboard_labels
-        ]
-        if item["error"] is not None:
-            item["error"] = [
-                item["error"]["error_{0}".format(index)]
-                for index in leaderboard_labels
-            ]
 
     paginator, result_page = paginated_queryset(
         distinct_sorted_leaderboard_data,
@@ -1714,3 +1491,45 @@ def get_bearer_token(request, challenge_pk):
     }
 
     return Response(response_data, status=status.HTTP_200_OK)
+
+
+@api_view(["GET"])
+@throttle_classes([UserRateThrottle])
+@permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))
+@authentication_classes((ExpiringTokenAuthentication,))
+def get_github_badge_data(
+    request, challenge_phase_split_pk, participant_team_pk
+):
+    """
+    Add API to get data for dynamically generating github badges
+    Ref: https://shields.io/endpoint
+    Arguments:
+        request {HttpRequest} -- The request object
+        phase_pk {[int]} -- Challenge phase primary key
+        participant_team_pk {[int]} -- Participant team primary key
+
+    Returns:
+        {dict} -- A dict which contains keys schemaVersion, label, message and color of badge
+    """
+    challenge_phase_split = get_challenge_phase_split_model(
+        challenge_phase_split_pk
+    )
+    challenge_obj = challenge_phase_split.challenge_phase.challenge
+    data = {"schemaVersion": 1, "label": "EvalAI", "color": "blue"}
+
+    response_data, http_status_code = calculate_distinct_sorted_leaderboard_data(
+        request.user,
+        challenge_obj,
+        challenge_phase_split,
+        only_public_entries=True,
+    )
+    if http_status_code == status.HTTP_400_BAD_REQUEST:
+        return Response(response_data, status=http_status_code)
+
+    for idx, team_data in enumerate(response_data):
+        if team_data["submission__participant_team"] == int(
+            participant_team_pk
+        ):
+            data["message"] = f"{challenge_obj.title} Rank #{idx+1}"
+            break
+    return Response(data, status=http_status_code)

--- a/apps/participants/urls.py
+++ b/apps/participants/urls.py
@@ -38,4 +38,9 @@ urlpatterns = [
         views.participant_team_detail,
         name="get_participant_team_details",
     ),
+    url(
+        r"^challenge/(?P<challenge_pk>[0-9]+)/team_detail/$",
+        views.participant_team_detail_in_challenge,
+        name="participant_team_detail_in_challenge",
+    ),
 ]

--- a/apps/participants/urls.py
+++ b/apps/participants/urls.py
@@ -39,8 +39,8 @@ urlpatterns = [
         name="get_participant_team_details",
     ),
     url(
-        r"^challenge/(?P<challenge_pk>[0-9]+)/team_detail/$",
-        views.participant_team_detail_in_challenge,
-        name="participant_team_detail_in_challenge",
+        r"^challenges/(?P<challenge_pk>[0-9]+)/team_details/$",
+        views.get_participant_team_details_for_challenge,
+        name="get_participant_team_details_for_challenge",
     ),
 ]

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -20,7 +20,7 @@ from challenges.serializers import ChallengeSerializer
 from challenges.utils import (
     get_challenge_model,
     is_user_in_allowed_email_domains,
-    is_user_in_blocked_email_domains
+    is_user_in_blocked_email_domains,
 )
 from hosts.utils import is_user_a_host_of_challenge
 
@@ -36,6 +36,8 @@ from .serializers import (
 from .utils import (
     get_list_of_challenges_for_participant_team,
     get_list_of_challenges_participated_by_a_user,
+    get_participant_team_of_user_for_a_challenge,
+    has_user_participated_in_challenge,
     is_user_part_of_participant_team,
 )
 
@@ -53,7 +55,9 @@ def participant_team_list(request):
         participant_teams = ParticipantTeam.objects.filter(
             id__in=participant_teams_id
         ).order_by("-id")
-        paginator, result_page = team_paginated_queryset(participant_teams, request)
+        paginator, result_page = team_paginated_queryset(
+            participant_teams, request
+        )
         serializer = ParticipantTeamDetailSerializer(result_page, many=True)
         response_data = serializer.data
         return paginator.get_paginated_response(response_data)
@@ -208,13 +212,18 @@ def invite_participant_to_team(request, pk):
 
             if len(challenge.banned_email_ids) > 0:
                 # Check if team participants emails are banned
-                for participant_email in participant_team.get_all_participants_email():
+                for (
+                    participant_email
+                ) in participant_team.get_all_participants_email():
                     if participant_email in challenge.banned_email_ids:
                         message = "You cannot invite as you're a part of {} team and it has been banned "
                         "from this challenge. Please contact the challenge host."
-                        response_data = {"error": message.format(participant_team.team_name)}
+                        response_data = {
+                            "error": message.format(participant_team.team_name)
+                        }
                         return Response(
-                            response_data, status=status.HTTP_406_NOT_ACCEPTABLE
+                            response_data,
+                            status=status.HTTP_406_NOT_ACCEPTABLE,
                         )
 
                 # Check if invited user is banned
@@ -386,3 +395,23 @@ def remove_self_from_participant_team(request, participant_team_pk):
         if participants.count() == 0:
             participant_team.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+@api_view(["GET"])
+@throttle_classes([UserRateThrottle])
+@permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))
+@authentication_classes((ExpiringTokenAuthentication,))
+def participant_team_detail_in_challenge(request, challenge_pk):
+
+    challenge = get_challenge_model(challenge_pk)
+    if has_user_participated_in_challenge(request.user, challenge_pk):
+        participant_team = get_participant_team_of_user_for_a_challenge(
+            request.user, challenge_pk
+        )
+        serializer = ParticipantTeamSerializer(participant_team)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+    else:
+        response_data = {
+            "error": f"The user {request.user.username} has not participanted in {challenge.title}"
+        }
+        return Response(response_data, status=status.HTTP_404_NOT_FOUND)

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -410,7 +410,7 @@ def participant_team_detail_in_challenge(request, challenge_pk):
         challenge_pk {[int]} -- Challenge primary key
 
     Returns:
-        Participant team detail that has participated in the challenge
+        {dict} -- Participant team detail that has participated in the challenge
     """
 
     challenge = get_challenge_model(challenge_pk)

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -401,7 +401,7 @@ def remove_self_from_participant_team(request, participant_team_pk):
 @throttle_classes([UserRateThrottle])
 @permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))
 @authentication_classes((ExpiringTokenAuthentication,))
-def participant_team_detail_in_challenge(request, challenge_pk):
+def get_participant_team_details_for_challenge(request, challenge_pk):
     """
     API to get the participant team detail
 

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -402,6 +402,16 @@ def remove_self_from_participant_team(request, participant_team_pk):
 @permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))
 @authentication_classes((ExpiringTokenAuthentication,))
 def participant_team_detail_in_challenge(request, challenge_pk):
+    """
+    API to get the participant team detail
+
+    Arguments:
+        request {HttpRequest} -- The request object
+        challenge_pk {[int]} -- Challenge primary key
+
+    Returns:
+        Participant team detail that has participated in the challenge
+    """
 
     challenge = get_challenge_model(challenge_pk)
     if has_user_participated_in_challenge(request.user, challenge_pk):

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -2118,7 +2118,7 @@ class ChallengeLeaderboardTest(BaseAPITestClass):
         )
 
         expected = {
-            "error": "Sorry, Default filtering key not found in leaderboard schema!"
+            "error": "Sorry, default_order_by key is missing in leaderboard schema!"
         }
 
         leaderboard_schema = {"labels": ["score", "test-score"]}

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -1106,17 +1106,19 @@ class GetRemainingSubmissionTest(BaseAPITestClass):
                     "name": self.challenge_phase_restricted_to_one_submission.name,
                     "slug": self.challenge_phase_restricted_to_one_submission.slug,
                     "start_date": "{0}{1}".format(
-                        self.challenge_phase_restricted_to_one_submission.start_date.isoformat(), "Z"
+                        self.challenge_phase_restricted_to_one_submission.start_date.isoformat(),
+                        "Z",
                     ).replace("+00:00", ""),
                     "end_date": "{0}{1}".format(
-                        self.challenge_phase_restricted_to_one_submission.end_date.isoformat(), "Z"
+                        self.challenge_phase_restricted_to_one_submission.end_date.isoformat(),
+                        "Z",
                     ).replace("+00:00", ""),
                     "limits": {
                         "remaining_submissions_today_count": 10,
                         "remaining_submissions_this_month_count": 20,
                         "remaining_submissions_count": 100,
                     },
-                }
+                },
             ],
         }
         self.challenge.participant_teams.add(self.participant_team)
@@ -1487,7 +1489,9 @@ class ChangeSubmissionDataAndVisibilityTest(BaseAPITestClass):
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_change_submission_data_and_visibility_when_is_restricted_to_select_one_submission_true(self):
+    def test_change_submission_data_and_visibility_when_is_restricted_to_select_one_submission_true(
+        self
+    ):
         self.url = reverse_lazy(
             "jobs:change_submission_data_and_visibility",
             kwargs={
@@ -2093,11 +2097,13 @@ class ChallengeLeaderboardTest(BaseAPITestClass):
             },
         )
 
-        expected = {"error": "Challenge Phase Split does not exist"}
+        expected = {
+            "detail": f"ChallengePhaseSplit {self.challenge_phase_split.id + 2} does not exist"
+        }
 
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_leaderboard_with_default_order_by_key_missing(self):
         self.url = reverse_lazy(

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -1925,6 +1925,7 @@ class ChallengeLeaderboardTest(BaseAPITestClass):
                     "submission__submitted_at": self.submission.submitted_at,
                     "submission__is_baseline": False,
                     "submission__method_name": self.submission.method_name,
+                    "submission__is_public": self.submission.is_public,
                 }
             ],
         }
@@ -1968,6 +1969,7 @@ class ChallengeLeaderboardTest(BaseAPITestClass):
                     "submission__submitted_at": self.host_participant_team_submission.submitted_at,
                     "submission__is_baseline": True,
                     "submission__method_name": self.host_participant_team_submission.method_name,
+                    "submission__is_public": self.submission.is_public,
                 },
                 {
                     "id": self.leaderboard_data.id,
@@ -1986,6 +1988,7 @@ class ChallengeLeaderboardTest(BaseAPITestClass):
                     "submission__submitted_at": self.submission.submitted_at,
                     "submission__is_baseline": False,
                     "submission__method_name": self.submission.method_name,
+                    "submission__is_public": self.submission.is_public,
                 },
             ],
         }
@@ -2036,6 +2039,7 @@ class ChallengeLeaderboardTest(BaseAPITestClass):
                     "submission__submitted_at": self.host_participant_team_submission.submitted_at,
                     "submission__is_baseline": True,
                     "submission__method_name": self.host_participant_team_submission.method_name,
+                    "submission__is_public": self.submission.is_public,
                 },
                 {
                     "id": self.leaderboard_data.id,
@@ -2054,6 +2058,7 @@ class ChallengeLeaderboardTest(BaseAPITestClass):
                     "submission__submitted_at": self.submission.submitted_at,
                     "submission__is_baseline": False,
                     "submission__method_name": self.submission.method_name,
+                    "submission__is_public": self.submission.is_public,
                 },
                 {
                     "id": self.host_participant_leaderboard_data_2.id,
@@ -2072,6 +2077,7 @@ class ChallengeLeaderboardTest(BaseAPITestClass):
                     "submission__submitted_at": self.host_participant_team_submission_2.submitted_at,
                     "submission__is_baseline": True,
                     "submission__method_name": self.host_participant_team_submission_2.method_name,
+                    "submission__is_public": self.submission.is_public,
                 },
             ],
         }
@@ -2154,7 +2160,8 @@ class ChallengeLeaderboardTest(BaseAPITestClass):
                     },
                     "submission__submitted_at": self.private_submission.submitted_at,
                     "submission__is_baseline": False,
-                    "submission__method_name": self.submission.method_name,
+                    "submission__method_name": self.private_submission.method_name,
+                    "submission__is_public": self.private_submission.is_public,
                 }
             ],
         }


### PR DESCRIPTION
**Description:**
This feature will enable participants to add badges to their Github code repositories for the entry on the EvalAI leaderboard and the rank on the badge will be dynamic.
Sample badge image -
![Screenshot 2020-05-25 at 3 21 01 AM](https://user-images.githubusercontent.com/12206047/82790377-f5a86600-9e39-11ea-89aa-062c04d3b7e5.png)

This PR contains -
- [x] Backend API for fetching data for GitHub Badges.
- [x] Refactor leaderboard API code.
- [x] Add API for fetching details of the participant team in a challenge from user auth token and challenge_pk.
