### PR TITLE
Add frontend for badges feature and minor API changes

### DIFF
--- a/apps/jobs/urls.py
+++ b/apps/jobs/urls.py
@@ -76,7 +76,7 @@ urlpatterns = [
         name="get_bearer_token",
     ),
     url(
-        r"^phase_splits/(?P<challenge_phase_split_pk>[0-9]+)/teams/(?P<participant_team_pk>[0-9]+)/github_badge/$",
+        r"^phase_splits/(?P<challenge_phase_split_pk>[0-9]+)/teams/(?P<participant_team_name>[\w|\W]+)/github_badge/$",
         views.get_github_badge_data,
         name="get_github_badge_data",
     ),

--- a/frontend/src/css/modules/challenge.scss
+++ b/frontend/src/css/modules/challenge.scss
@@ -267,3 +267,7 @@ md-select .md-select-value span:first-child:after {
     display: inline-block;
     padding-left: 10px;
 }
+
+.github-badge-card {
+    padding: 10px 10px 0px 5px;
+}

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -73,6 +73,7 @@
 
         vm.isChallengeLeaderboardPrivate = false;
         vm.previousPublicSubmissionId = null;
+        vm.participantTeamDetail = "";
 
         utilities.showLoader();
 
@@ -539,6 +540,24 @@
                 var error = response.data;
                 utilities.storeData('emailError', error.detail);
                 $state.go('web.permission-denied');
+                utilities.hideLoader();
+            }
+        };
+
+        utilities.sendRequest(parameters);
+
+        // get details of the participant team in the challenge
+        parameters.url = 'participants/challenges/' + vm.challengeId + '/team_details/';
+        parameters.method = 'GET';
+        parameters.data = {};
+        parameters.callback = {
+            onSuccess: function (response) {
+                var details = response.data;
+                vm.participantTeamDetail = details;
+            },
+            onError: function (response) {
+                var error = response.data;
+                $rootScope.notify("error", error);
                 utilities.hideLoader();
             }
         };
@@ -2296,7 +2315,37 @@
             }
         };
 
-
+        vm.showGithubBadgePreview = function (ev, phaseSplit, participantTeamId, participantTeamName) {
+            vm.githubBadgeURL = utilities.baseAPIURL + 'jobs/phase_splits/' + phaseSplit.id + '/teams/' + participantTeamName + '/github_badge/';
+            vm.leaderboardEntryURL = utilities.baseAPIURL + "web/challenges/challenge-page/" + vm.challengeId.toString() + "/leaderboard/" + phaseSplit.id.toString() + "#leaderboardrank-" + participantTeamId;
+            // get svg data for github badge
+            parameters.url = 'jobs/phase_splits/' + phaseSplit.id + '/teams/' + participantTeamName + '/github_badge/';
+            parameters.method = 'GET';
+            parameters.data = {};
+            parameters.callback = {
+                onSuccess: function (response) {
+                    vm.githubData = response.data;
+                    utilities.hideLoader();
+                },
+                onError: function (response) {
+                    var error = response.data;
+                    $rootScope.notify("error", error);
+                    utilities.hideLoader();
+                }
+            };
+            utilities.sendRequest(parameters);
+            $mdDialog.show({
+                scope: $scope,
+                preserveScope: true,
+                targetEvent: ev,
+                templateUrl: 'dist/views/web/challenge/github-badge.html',
+                escapeToClose: false
+            });
+        };
+        
+        vm.hideDialog = function () {
+            $mdDialog.hide();
+        };
     }
 
 })();

--- a/frontend/src/js/services/services.js
+++ b/frontend/src/js/services/services.js
@@ -14,7 +14,8 @@
     function utilities($http, EnvironmentConfig) {
 
         // factory for API calls
-        this.sendRequest = function(parameters, header, type) {
+        this.baseAPIURL = EnvironmentConfig.API;
+        this.sendRequest = function (parameters, header, type) {
             var url = EnvironmentConfig.API + parameters.url;
             var data = parameters.data;
             var token = parameters.token;

--- a/frontend/src/views/web/challenge/github-badge.html
+++ b/frontend/src/views/web/challenge/github-badge.html
@@ -1,0 +1,71 @@
+<section class="ev-md-container text-center rm-overflow-y github-badge-card">
+    <div class="row">
+        <div class="col s12 m12">
+            <div class="ev-card-body pd-20 font-size-14">
+            <div class="row">
+                <div class="col s12 m12 l12">
+                    <div class="col s12 m2 l2">
+                        <div class="badge-label">
+                            Badge Preview
+                        </div>
+                    </div>
+                    <div class="col s12 m10 l10">
+                        <div class="badge-preview">
+                            <!-- svg for github badge -->
+                            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="210" height="20">
+                            <link xmlns="" type="text/css" id="dark-mode" rel="stylesheet" href=""/><style xmlns="" type="text/css" id="dark-mode-custom-style"/>
+                            <linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>
+                            <clipPath id="r"><rect width="210" height="20" rx="3" fill="#fff"/></clipPath>
+                            <g clip-path="url(#r)"><rect width="45" height="20" fill="#555"/><rect x="45" width="165" height="20" fill="#007ec6"/>
+                            <rect width="210" height="20" fill="url(#s)"/></g>
+                            <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+                            <text x="235" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="350">EvalAI</text>
+                            <text x="235" y="140" transform="scale(.1)" textLength="350">EvalAI</text>
+                            <text x="1265" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="1550">{{challenge.githubData.message}}</text>
+                            <text x="1265" y="140" transform="scale(.1)" textLength="1550">{{challenge.githubData.message}}</text></g></svg> 
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col s12 m12 l12">
+                    <div class="col s12 m2 l2">
+                        <div class="markdown-label">
+                            Markdown
+                        </div>
+                    </div>
+                    <div class="col s12 m10 l10">
+                        <div class="markdown-url">
+                            [![EvalAI](https://img.shields.io/endpoint?url={{challenge.githubBadgeURL}})]({{challenge.leaderboardEntryURL}})
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col s12 m12 l12">
+                    <div class="col s12 m2 l2">
+                        <div class="url-label">
+                            URL
+                        </div>
+                    </div>
+                    <div class="col s12 m10 l10">
+                        <div class="url">
+                            <a class="blue-text" target="_blank" href="https://img.shields.io/endpoint?url={{challenge.githubBadgeURL}}">
+                                https://img.shields.io/endpoint?url={{challenge.githubBadgeURL}}
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="align-right text-med-black w-400">
+                <ul class="inline-list pointer">
+                    <li>
+                        <button class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-16"
+                            ng-click="challenge.hideDialog()">Close
+                        </button>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</section>

--- a/frontend/src/views/web/challenge/leaderboard.html
+++ b/frontend/src/views/web/challenge/leaderboard.html
@@ -113,7 +113,7 @@
                             </td>
                             <td data-field="submission_time">
                                 <a href="#" ng-click="challenge.sortLeaderboard(challenge, 'date');">
-                                    <span class="fs-20 w-300">Last submission at</span>
+                                    <span class="fs-20 w-300">Submitted at</span>
                                     <span class="fa-stack fa-1x">
                                         <i class="fa fa-sort-asc fa-stack-1x"
                                             ng-class="challenge.reverseSort && challenge.sortColumn == 'date'? 'text-dark-black' : 'text-light-black w-300'"></i>
@@ -124,6 +124,7 @@
                             </td>
                         </tr>
                     </thead>
+                    {{challenge.phaseRemainingSubmissions.participant_team}}
                     <tbody class="fs-16 w-300">
                         <tr ng-class="{highlightLeaderboard:isHighlight == challenge.initial_ranking[key.id]}"
                             ng-click="challenge.scrollToSpecificEntryLeaderboard('leaderboardrank-' + challenge.initial_ranking[key.id])"
@@ -135,10 +136,11 @@
                                     href="{{key.submission__participant_team__team_url}}">{{key.submission__participant_team__team_name}}</a><span
                                     ng-if="!key.submission__participant_team__team_url">{{key.submission__participant_team__team_name}}</span>
                                     <b><span ng-if="key.submission__is_public === false" class="orange-text">*</span></b>
-                                <span
-                                    ng-if="key.submission__method_name">({{key.submission__method_name | limitTo:30}})</span><span
-                                    id="baseline-badge" class="new badge orange-background baseline-tag" data-badge-caption="B"
+                                <span ng-if="key.submission__method_name">({{key.submission__method_name | limitTo:30}})</span>
+                                <span id="baseline-badge" class="new badge orange-background baseline-tag" data-badge-caption="B"
                                     ng-if="key.submission__is_baseline"></span>
+                                <span id="github-badge" class="blue-text pointer" ng-if="key.submission__is_public && key.submission__participant_team == challenge.participantTeamDetail.id"
+                                ng-click="challenge.showGithubBadgePreview($event, challenge.selectedPhaseSplit, challenge.initial_ranking[key.id], key.submission__participant_team__team_name); $event.stopPropagation();"><i class="fa fa-github"></i></span>
                             </td>
                             <td ng-repeat="(i, score) in key.result track by $index">
                                 {{score | number : challenge.selectedPhaseSplit.leaderboard_decimal_precision}}


### PR DESCRIPTION
Extension to #2819 
This PR contains -
- [x] Frontend for displaying badges for leaderboard entry.
- [x] API changes to remove authentication and add a check if the participant team exists or not.
Sample UI of the frontend -
<img width="1157" alt="Screenshot 2020-05-27 at 11 58 54 AM" src="https://user-images.githubusercontent.com/12206047/83043948-84bba680-a011-11ea-8824-7a7e44ed6b03.png">
<img width="1166" alt="Screenshot 2020-05-27 at 11 58 45 AM" src="https://user-images.githubusercontent.com/12206047/83043951-85ecd380-a011-11ea-9008-c526110fbe11.png">
