### PR TITLE
Fix[#2478] password strength visibility

### DIFF
--- a/frontend/src/js/controllers/authCtrl.js
+++ b/frontend/src/js/controllers/authCtrl.js
@@ -11,7 +11,8 @@
 
     function AuthCtrl(utilities, $state, $rootScope) {
         var vm = this;
-
+        // condition for showing password strength
+        vm.showPasswordStrength = false;
         vm.isRem = false;
         vm.isAuth = false;
         vm.isMail = true;
@@ -197,6 +198,12 @@
 
         // function to check password strength
         vm.checkStrength = function(password) {
+            if(password) {
+                vm.showPasswordStrength = true;
+            }
+            else {
+                vm.showPasswordStrength = false;
+            }
             var passwordStrength = utilities.passwordStrength(password);
             vm.message = passwordStrength[0];
             vm.color = passwordStrength[1];

--- a/frontend/src/views/web/auth/signup.html
+++ b/frontend/src/views/web/auth/signup.html
@@ -37,7 +37,7 @@
             </span>
             <label for="password">
                 <strong>Password-minlength:8 required</strong>
-                <span ng-style="{color: auth.color}">{{auth.message}}</span>
+                <span ng-style="{color: auth.color}" ng-if="auth.showPasswordStrength">{{auth.message}}</span>
             </label>
             <div class="wrn-msg text-highlight" ng-messages="signupForm.password.$error" ng-if="signupForm.password.$touched || signupForm.$submitted">
                 <p ng-message="minlength">Password is less than 8 characters.</p>


### PR DESCRIPTION
Fix: #2478 [ UI Design : Signup page displays your password is weak even though password field is empty ]

**After Fix:**
Password strength will only be shown if the length of the password is greater than the minimum length specified.

**GIF of fix:**
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/44888949/84116081-c8200700-aa4c-11ea-9d0d-0c26acb919b3.gif)
