### PR TITLE
Edit teams will have pre-populated data

### DIFF
--- a/frontend_v2/src/app/components/publiclists/teamlist/teamcard/teamcard.component.ts
+++ b/frontend_v2/src/app/components/publiclists/teamlist/teamcard/teamcard.component.ts
@@ -154,7 +154,7 @@ export class TeamcardComponent implements OnInit, OnChanges {
    */
   editTeam(e) {
     e.stopPropagation();
-    this.editTeamCard.emit(this.team['id']);
+    this.editTeamCard.emit(this.team);
   }
 
   /**

--- a/frontend_v2/src/app/components/publiclists/teamlist/teamlist.component.ts
+++ b/frontend_v2/src/app/components/publiclists/teamlist/teamlist.component.ts
@@ -417,7 +417,10 @@ export class TeamlistComponent implements OnInit, OnDestroy {
     const SELF = this;
     let TeamUrl;
     const editTeam = (team) => {
-    TeamUrl = (this.isHost) ? SELF.endpointsService.hostTeamURL(team) : SELF.endpointsService.participantTeamURL(team);
+    const teamId = team['id'];
+    const teamName = team['team_name'];
+    const teamUrl = team['team_url'];
+    TeamUrl = (this.isHost) ? SELF.endpointsService.hostTeamURL(teamId) : SELF.endpointsService.participantTeamURL(teamId);
       SELF.apiCall = (params) => {
         const BODY = JSON.stringify(params);
         SELF.apiService.patchUrl(TeamUrl, BODY).subscribe(
@@ -440,15 +443,17 @@ export class TeamlistComponent implements OnInit, OnDestroy {
         deny: 'Cancel',
         form: [
           {
-            isRequired: true,
+            isRequired: false,
             label: 'team_name',
             placeholder: 'Team Name',
+            value: teamName,
             type: 'text'
           },
           {
             isRequired: false,
             label: 'team_url',
             placeholder: 'Team URL',
+            value: teamUrl,
             type: 'text'
           }
         ],


### PR DESCRIPTION
**Fixes The Bug**
The edit team option in `ngx`  used to give the empty field which used to make user write the details from scratch.

**Fix**
Now the edit team dialogue box contains pre-populated data.

GIF of Fix:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/44888949/84262724-bc5f3e00-ab3b-11ea-8272-4107bc56ed73.gif)
