### PR TITLE
[Frontend_v2] Fix loader being triggered twice

### DIFF
--- a/frontend_v2/src/app/components/publiclists/challengelist/challengelist.component.ts
+++ b/frontend_v2/src/app/components/publiclists/challengelist/challengelist.component.ts
@@ -271,7 +271,7 @@ export class ChallengelistComponent implements OnInit {
   fetchTeams(path) {
     const SELF = this;
     SELF.filteredChallenges = [];
-    this.apiService.getUrl(path).subscribe(
+    this.apiService.getUrl(path, true, false).subscribe(
       data => {
         if (data['results']) {
           const TEAMS = data['results'].map((item) => item['id']);
@@ -313,7 +313,7 @@ export class ChallengelistComponent implements OnInit {
    */
   fetchChallengesFromApi(path, callback = null) {
     const SELF = this;
-    SELF.apiService.getUrl(path).subscribe(
+    SELF.apiService.getUrl(path, true, false).subscribe(
       data => {
         if (path.endsWith('future')) {
           SELF.upcomingChallenges = data['results'];


### PR DESCRIPTION
**Before Fix**
Loader was being triggered twice for both `All Challenges` and `Hosted challenges` functionalities.

**After Fix**
Only once the loader will be triggered for navigating between the functionlities.

GIF of fix:
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/44888949/84492137-543b6400-acc3-11ea-814f-faf4fcc1b0d3.gif)
