### PR TITLE
[Minor] Challenge page tabs size and weight made same as EvalAI

### DIFF
--- a/frontend_v2/src/app/components/publiclists/challengelist/challengelist.component.scss
+++ b/frontend_v2/src/app/components/publiclists/challengelist/challengelist.component.scss
@@ -10,3 +10,9 @@ a.btn-card-detail:focus {
 .none {
   margin: 1%;
 }
+
+::ng-deep .mat-tab-label .mat-tab-label-content {
+  color: #4d4d4d;;
+  font-weight: 500;
+  font-size: 18px;
+}

--- a/frontend_v2/src/app/components/publiclists/challengelist/challengelist.component.scss
+++ b/frontend_v2/src/app/components/publiclists/challengelist/challengelist.component.scss
@@ -12,7 +12,7 @@ a.btn-card-detail:focus {
 }
 
 ::ng-deep .mat-tab-label .mat-tab-label-content {
-  color: #4d4d4d;;
+  color: #4d4d4d;
   font-weight: 500;
   font-size: 18px;
 }


### PR DESCRIPTION
**Fix**
Challenge page tabs now have the same size and font-weight as that of EvalAI.

Screenshot:
![Screenshot from 2020-06-13 12-08-50](https://user-images.githubusercontent.com/44888949/84562066-13992480-ad6f-11ea-90b0-8950fed95b05.png)
