### PR TITLE
[Frontend_v2] Evaluation Tab UI made same as EvalAI

### DIFF
--- a/frontend_v2/src/app/components/challenge/challengeevaluation/challengeevaluation.component.html
+++ b/frontend_v2/src/app/components/challenge/challengeevaluation/challengeevaluation.component.html
@@ -1,6 +1,6 @@
 <div class="challenge-card">
 	<div class="row">
-		<div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 ev-pad">
+		<div class="ev-pad">
 			<div class="ev-md-container ev-card-panel">
 				<div class="col-lg-10 col-md-10 col-sm-10 col-xs-10 content">
 					<span class="fw-semibold fs-18">
@@ -22,7 +22,9 @@
 				</div>
 			</div>
 		</div>
-		<div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 tnc-pad">
+  </div>
+  <div class="row">
+    <div class="tnc-pad">
 			<div class="ev-md-container ev-card-panel">
 				<div class="col-lg-10 col-md-10 col-sm-10 col-xs-10 content">
 					<span class="fw-semibold fs-18">
@@ -38,5 +40,5 @@
 				</div>
 			</div>
 		</div>
-	</div>
+  </div>
 </div>

--- a/frontend_v2/src/app/components/challenge/challengeevaluation/challengeevaluation.component.scss
+++ b/frontend_v2/src/app/components/challenge/challengeevaluation/challengeevaluation.component.scss
@@ -4,13 +4,16 @@
 .ev-pad {
 	padding-left: 15px;
 	padding-right: 10px;
-	margin-bottom: 20px;
 }
 
 .tnc-pad {
 	padding-left: 10px;
 	padding-right: 15px;
-	margin-bottom: 20px;
+}
+
+.challenge-card {
+  padding-bottom: 0px;
+  margin-bottom: -40px;
 }
 
 @include screen-small {


### PR DESCRIPTION
**Changes introduced through this PR**
The `Terms and Condition Tab` and `Evaluation Criteria` sections will now be aligned one after another i.e same as in EvalAI rather than side by side.

Screenshot:
![Screenshot from 2020-06-14 14-51-39](https://user-images.githubusercontent.com/44888949/84634345-4aa63c00-af0f-11ea-9770-2f91655bbcea.png)
