### PR TITLE
Fix file URLs in submission worker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,5 @@
 python_files=test*.py
 DJANGO_SETTINGS_MODULE=settings.test
 DJANGO_SERVER=django
+DJANGO_SERVER_PORT=8000
 norecursedirs=env venv node_modules bower_components

--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -48,6 +48,9 @@ from jobs.serializers import SubmissionSerializer  # noqa:E402
 LIMIT_CONCURRENT_SUBMISSION_PROCESSING = os.environ.get(
     "LIMIT_CONCURRENT_SUBMISSION_PROCESSING"
 )
+DJANGO_SETTINGS_MODULE = os.environ.get(
+    "DJANGO_SETTINGS_MODULE", "settings.dev"
+)
 
 CHALLENGE_DATA_BASE_DIR = join(COMPUTE_DIRECTORY_PATH, "challenge_data")
 SUBMISSION_DATA_BASE_DIR = join(COMPUTE_DIRECTORY_PATH, "submission_files")
@@ -198,8 +201,14 @@ def create_dir_as_python_package(directory):
 
 
 def return_file_url_per_environment(url):
-    base_url = f"http://{settings.DJANGO_SERVER}:{settings.DJANGO_SERVER_PORT}"
-    url = "{0}{1}".format(base_url, url)
+    if (
+        DJANGO_SETTINGS_MODULE == "settings.dev"
+        or DJANGO_SETTINGS_MODULE == "settings.test"
+    ):
+        base_url = (
+            f"http://{settings.DJANGO_SERVER}:{settings.DJANGO_SERVER_PORT}"
+        )
+        url = "{0}{1}".format(base_url, url)
     return url
 
 


### PR DESCRIPTION
Fixes to #2818 
This PR -
- [x] Add missing variable `DJANGO_SERVER_PORT` in `pytest.ini` file for tests.
- [x] Add `DJANGO_SETTINGS_MODULE` as an environment variable in `submission_worker.py`
- [x] Modify `return_file_url_per_environment` in `submission_worker.py` to return HTTP URL in dev or test settings and HTTPS URL in production setting. 