### PR TITLE
Add remote evaluation check before spawning worker or eks cluster

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -974,7 +974,10 @@ def challenge_workers_start_notifier(sender, instance, field_name, **kwargs):
     if (
         curr and not prev
     ):  # Checking if the challenge has been approved by admin since last time.
-        if not challenge.is_docker_based:
+        if (
+            not challenge.is_docker_based
+            and challenge.remote_evaluation is False
+        ):
             response = start_workers([challenge])
             count, failures = response["count"], response["failures"]
             if count != 1:

--- a/apps/challenges/models.py
+++ b/apps/challenges/models.py
@@ -193,6 +193,7 @@ def create_eks_cluster_for_challenge(sender, instance, created, **kwargs):
         if (
             instance.approved_by_admin is True
             and instance.is_docker_based is True
+            and instance.remote_evaluation is False
         ):
             serialized_obj = serializers.serialize("json", [instance])
             create_eks_cluster.delay(serialized_obj)


### PR DESCRIPTION
This PR -
- [x] The EKS cluster or the Fargate should only spawn when the challenge is not remotely evaluated by the host by setting up their own infrastructure.