### PR TITLE
[Frontend_v2] Bugfix for same leaderboard rank and text align justify

### DIFF
--- a/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.html
+++ b/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.html
@@ -164,7 +164,7 @@
               </thead>
               <tbody>
                 <tr *ngFor="let key of leaderboard" class="content">
-                  <td>{{ initial_ranking[key.submission__participant_team__team_name] }}</td>
+                  <td>{{ initial_ranking[key.id] }}</td>
                   <td class="fw-regular">
                     {{ key.submission__participant_team__team_name }}
                     <b><span *ngIf="key.submission__is_public === false" class="orange-text">*</span></b>

--- a/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.ts
+++ b/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.ts
@@ -334,7 +334,7 @@ export class ChallengeleaderboardComponent implements OnInit, AfterViewInit {
   updateLeaderboardResults(leaderboardApi, self) {
     const leaderboard = leaderboardApi.slice();
     for (let i = 0; i < leaderboard.length; i++) {
-      self.initial_ranking[leaderboard[i].submission__participant_team__team_name] = i + 1;
+      self.initial_ranking[leaderboard[i].id] = i + 1;
       const DATE_NOW = new Date();
       const SUBMISSION_TIME = new Date(Date.parse(leaderboard[i].submission__submitted_at));
       const DURATION = self.globalService.getDateDifferenceString(DATE_NOW, SUBMISSION_TIME);
@@ -384,7 +384,7 @@ export class ChallengeleaderboardComponent implements OnInit, AfterViewInit {
     if (this.sortColumn === 'date') {
       return Date.parse(key.submission__submitted_at);
     } else if (this.sortColumn === 'rank') {
-      return this.initial_ranking[key.submission__participant_team__team_name];
+      return this.initial_ranking[key.id];
     } else if (this.sortColumn === 'number') {
       return parseFloat(key.result[this.columnIndexSort]);
     } else if (this.sortColumn === 'string') {

--- a/frontend_v2/src/styles/base.scss
+++ b/frontend_v2/src/styles/base.scss
@@ -424,6 +424,7 @@ mat-chip {
   border-radius: 4px;
   overflow: hidden;
   box-shadow: 0px 0px 12px $shadow-black;
+  text-align: justify;
 }
 
 .ev-md-container {


### PR DESCRIPTION
### Description

This PR fixes:

1. Multiple submissions with the same rank when made public by same team
2. The text should be justified - For cards in Challenge page ex: Evaluation, Terms and Conditions.

Leaderboard before:
<img width="1472" alt="Screen_Shot_2020-08-09_at_1 09 29_PM" src="https://user-images.githubusercontent.com/16323427/90227602-7ae85900-de32-11ea-9e17-e2d8cf133b2a.png">

Leaderboard after:
<img width="1440" alt="Screen Shot 2020-08-14 at 1 26 58 PM" src="https://user-images.githubusercontent.com/16323427/90227650-8b003880-de32-11ea-84d0-2bc875bed762.png">


Card text before:
<img width="1440" alt="Screen Shot 2020-08-14 at 1 35 44 PM" src="https://user-images.githubusercontent.com/16323427/90228040-2f827a80-de33-11ea-8d29-55dfdaa4110e.png">

Card text after:
<img width="1440" alt="Screen Shot 2020-08-14 at 1 35 54 PM" src="https://user-images.githubusercontent.com/16323427/90228055-34dfc500-de33-11ea-8cce-fac13539cea1.png">



