### PR TITLE
Add stdout log handler in submission worker

### DIFF
--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -30,7 +30,13 @@ from django.utils import timezone
 BASE_TEMP_DIR = tempfile.mkdtemp()
 COMPUTE_DIRECTORY_PATH = join(BASE_TEMP_DIR, "compute")
 
+formatter = logging.Formatter("[%(asctime)s] %(levelname)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(formatter)
+
 logger = logging.getLogger(__name__)
+logger.addHandler(handler)
 django.setup()
 
 # Load django app settings


### PR DESCRIPTION
### Description

Logs from submission worker script are not being sent to cloudwatch because the default logger didn't have any handlers to send logs to stdout. This PR adds a handler to write logs to stdout.