### PR TITLE
Fix timeframe for getting logs

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -2684,7 +2684,7 @@ def get_worker_logs(request, challenge_pk):
     # This is to specify the time window for fetching logs: 15 minutes before from current time.
     timeframe = 15
     current_time = int(round(time.time() * 1000))
-    start_time = current_time - timeframe * 900000
+    start_time = current_time - (timeframe * 60000)
     end_time = current_time
 
     logs = get_logs_from_cloudwatch(


### PR DESCRIPTION
Fixes the conversion of the time from minutes to milliseconds when specifying a time window to fetch logs from cloudwatch.
@RishabhJain2018 @Ram81 