### PR TITLE
Fix travis build package incompatibility issue

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,6 +1,7 @@
 asgi-redis==1.4.3
 boto3==1.13.16
 botocore==1.16.16
+vine=1.1.3
 celery[sqs]==4.3.0
 commonmark==0.5.4
 django==1.11.23

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,7 +1,7 @@
 asgi-redis==1.4.3
 boto3==1.13.16
 botocore==1.16.16
-vine==1.1.3
+vine==1.3.0
 celery[sqs]==4.3.0
 commonmark==0.5.4
 django==1.11.23

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,7 +1,7 @@
 asgi-redis==1.4.3
 boto3==1.13.16
 botocore==1.16.16
-vine=1.1.3
+vine==1.1.3
 celery[sqs]==4.3.0
 commonmark==0.5.4
 django==1.11.23


### PR DESCRIPTION
### Description

This PR adds `vine==1.3.0` package to resolve package conflict issue in travis build. Please refer to a successful [travis build](https://travis-ci.org/github/Cloud-CV/EvalAI/builds/724544915) and [failed build](https://travis-ci.org/github/Cloud-CV/EvalAI/builds/725025476) for reference. We have to specify `vine` explicitly because there is a conflict of package version between `celery` and `amqp`. Celery needs `vine<5.0.0` to work and `amqp==2.6.1` (which is a dependency in `asgi-redis` was installing `vine==5.0.0` which breaking celery. Issue seems to be introduced because of recent release in `amqp` package