### PR TITLE
[Frontend] Clear error message when selecting phase

### DIFF
--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -1615,6 +1615,10 @@
             utilities.sendRequest(parameters);
         };
 
+        vm.clearSubmissionErrorMessage = function() {
+            vm.subErrors.msg = "";
+        };
+
         vm.showRemainingSubmissions = function(phaseID) {
             vm.remainingSubmissions = {};
             vm.remainingTime = {};

--- a/frontend/src/views/web/challenge/submission.html
+++ b/frontend/src/views/web/challenge/submission.html
@@ -174,7 +174,7 @@
                                     ng-disabled="challenge.currentDate < item.start_date || challenge.currentDate >= item.end_date"
                                     type="radio" name="selectPhase" class="with-gap selectPhase" id="{{item.id}}"
                                     value="{{item.id}}" ng-model="challenge.phaseId"
-                                    ng-click="challenge.showRemainingSubmissions(item.id); challenge.loadPhaseAttributes(item.id); challenge.clearMetaAttributeValues();">
+                                    ng-click="challenge.showRemainingSubmissions(item.id); challenge.loadPhaseAttributes(item.id); challenge.clearMetaAttributeValues(); challenge.clearSubmissionErrorMessage();">
                                 <label for="{{item.id}}"></label>
                                 <div class="show-member-title pointer" ng-if="!item.showPrivate"><strong
                                         class="text-med-black">Phase: </strong>{{item.name}}

--- a/requirements/worker.txt
+++ b/requirements/worker.txt
@@ -2,6 +2,6 @@ matplotlib==2.2.3
 networkx==2.1
 pandas==0.25.3
 pycocotools==2.0.0
-scipy==1.2.1
+scipy==1.1.0
 sklearn==0.0
 tqdm==4.25.0

--- a/requirements/worker.txt
+++ b/requirements/worker.txt
@@ -2,6 +2,6 @@ matplotlib==2.2.3
 networkx==2.1
 pandas==0.25.3
 pycocotools==2.0.0
-scipy==1.1.0
+scipy==1.2.1
 sklearn==0.0
 tqdm==4.25.0


### PR DESCRIPTION
### Description

This PR adds a method to clear the error message when we select a phase. Earlier, once we show an error message for a invalid submission in a phase the error message wasn't cleared until we refresh the page.