### PR TITLE
[Backend] Allow making submissions private before finished

### DIFF
--- a/apps/jobs/models.py
+++ b/apps/jobs/models.py
@@ -247,11 +247,6 @@ class Submission(TimeStampedModel):
                         "error": "The maximum number of submission for today has been reached"
                     }
                 )
-
-            self.is_public = (
-                True if self.challenge_phase.is_submission_public else False
-            )
-
             self.status = Submission.SUBMITTED
 
         submission_instance = super(Submission, self).save(*args, **kwargs)

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -295,6 +295,11 @@ def challenge_submission(request, challenge_id, challenge_phase_id):
                 "submission_meta_attributes"
             ] = submission_meta_attributes
 
+        if request.data.get("is_public") is None:
+            request.data["is_public"] = (
+                True if challenge_phase.is_submission_public else False
+            )
+
         serializer = SubmissionSerializer(
             data=request.data,
             context={

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -531,8 +531,6 @@
                     formData.append("project_url", vm.projectUrl);
                     formData.append("publication_url", vm.publicationUrl);
                     formData.append("submission_metadata", JSON.stringify(vm.metaAttributesforCurrentSubmission));
-                    console.log("is public : " + vm.isPublicSubmission);
-                    console.log("is public =null : " + vm.isPublicSubmission === null)
                     if (vm.isPublicSubmission !== null) {
                         formData.append("is_public", vm.isPublicSubmission);
                     }

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -23,6 +23,7 @@
         vm.methodDesc = "";
         vm.projectUrl = "";
         vm.publicationUrl = "";
+        vm.isPublicSubmission = null;
         vm.wrnMsg = {};
         vm.page = {};
         vm.isParticipated = false;
@@ -530,6 +531,11 @@
                     formData.append("project_url", vm.projectUrl);
                     formData.append("publication_url", vm.publicationUrl);
                     formData.append("submission_metadata", JSON.stringify(vm.metaAttributesforCurrentSubmission));
+                    console.log("is public : " + vm.isPublicSubmission);
+                    console.log("is public =null : " + vm.isPublicSubmission === null)
+                    if (vm.isPublicSubmission !== null) {
+                        formData.append("is_public", vm.isPublicSubmission);
+                    }
 
                     parameters.data = formData;
 
@@ -555,6 +561,7 @@
                             vm.methodDesc = "";
                             vm.projectUrl = "";
                             vm.publicationUrl = "";
+                            vm.isPublicSubmission = null;
                             $rootScope.notify("success", "Your submission has been recorded succesfully!");
                             vm.disableSubmit = true;
                             vm.showSubmissionNumbers = false;
@@ -571,6 +578,7 @@
                             vm.methodDesc = null;
                             vm.projectUrl = null;
                             vm.publicationUrl = null;
+                            vm.isPublicSubmission = null;
                             if (status == 404) {
                                 vm.subErrors.msg = "Please select phase!";
                             } else {

--- a/frontend/src/views/web/challenge/my-submission.html
+++ b/frontend/src/views/web/challenge/my-submission.html
@@ -110,13 +110,11 @@
                                 <td>{{key.submitted_at | date:'medium'}}</td>
 
                                 <td ng-if="challenge.currentPhaseLeaderboardPublic" class="center">
-                                    <input ng-checked="key.is_public" ng-if="key.status == 'finished'
-                                     && !challenge.isCurrentPhaseRestrictedToSelectOneSubmission"
+                                    <input ng-checked="key.is_public" ng-if="!challenge.isCurrentPhaseRestrictedToSelectOneSubmission"
                                         ng-model="challenge.submissionVisibility[key.id]" type="checkbox"
                                         id="isPublic{{ key.id }}"
                                         ng-change="challenge.changeSubmissionVisibility(key.id, challenge.submissionVisibility[key.id])" />
-                                    <input ng-checked="key.is_public" ng-if="key.status == 'finished'
-                                     && challenge.isCurrentPhaseRestrictedToSelectOneSubmission"
+                                    <input ng-checked="key.is_public" ng-if="challenge.isCurrentPhaseRestrictedToSelectOneSubmission"
                                         ng-model="challenge.submissionVisibility[key.id]" type="checkbox"
                                         id="isPublicSubmission{{ key.id }}"
                                         ng-change="challenge.showVisibilityDialog(key.id, challenge.submissionVisibility[key.id])" />
@@ -124,7 +122,6 @@
                                            for="isPublic{{ key.id }}"></label>
                                     <label ng-if="challenge.isCurrentPhaseRestrictedToSelectOneSubmission"
                                            for="isPublicSubmission{{ key.id }}"></label>
-                                    <span ng-if="key.status !== 'finished'" class="center"> N/A </span>
                                 </td>
                                 <td ng-if="challenge.isChallengeHost" class="center">
                                     <input ng-checked="key.is_baseline" ng-if="key.status == 'finished' || key.status == 'partially_evaluated'"

--- a/frontend/src/views/web/challenge/submission.html
+++ b/frontend/src/views/web/challenge/submission.html
@@ -243,6 +243,28 @@
                             </div>
                             <span
                                 ng-show="challenge.isSubmissionUsingUrl == true || challenge.isSubmissionUsingUrl == false">
+
+                                <p class="fs-14 w-400">Select submission visibility:</p>
+                                <li>
+                                    <input type="radio" name="submissionVisibility" class="with-gap selectPhase" id="isPublicubmission"
+                                        value="isPublicubmission" ng-click="challenge.isPublicSubmission = true">
+                                    <label for="isPublicubmission"></label>
+                                    <div class="show-member-title pointer">
+                                        <strong class="fs-16 w-300">Public
+                                        </strong>
+                                    </div>
+                                    <div class="clearfix"></div>
+
+                                    <input type="radio" name="submissionVisibility" class="with-gap selectPhase"
+                                        id="isPrivateSubmission" value="isPrivateSubmission"
+                                        ng-click="challenge.isPublicSubmission = false">
+                                    <label for="isPrivateSubmission"></label>
+                                    <div class="show-member-title pointer">
+                                        <strong class="fs-16 w-300">Private </strong>
+                                    </div>
+                                    <div class="clearfix"></div>
+                                </li>
+
                                 <div class="row">
                                     <div class="input-field align-left col s10">
                                         <input type="text" id="methodName" name="methodName"
@@ -269,13 +291,12 @@
                                 </div>
                                 <div class="row">
                                     <div class="input-field align-left col s10">
-                                        <input type="text" id="publicationUrl" name="publicationUrl"
-                                            ng-model="challenge.publicationUrl">
+                                        <input type="text" id="methodName" name="methodName"
+                                            ng-model="challenge.methodName">
                                         <span class="form-icon"><i class="fa fa-text"></i></span>
-                                        <label for="publicationUrl">Publication URL (Optional)</label>
+                                        <label for="methodName">Method name (Optional)</label>
                                     </div>
                                 </div>
-
                                 <div class="dynamicform">
                                     <div ng-if="challenge.metaAttributesforCurrentSubmission != null" ng-repeat="attribute in challenge.metaAttributesforCurrentSubmission">
                                        <div class="row">

--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -445,6 +445,7 @@ def create_submission(
         submission_result_file=ContentFile(submission_result),
         submission_metadata_file=None,
         is_baseline=True,
+        is_public=challenge_phase.is_submission_public,
     )
     submission.status = status
     submission.save()

--- a/tests/unit/jobs/test_admin.py
+++ b/tests/unit/jobs/test_admin.py
@@ -141,6 +141,7 @@ class SubmissionAdminTest(BaseAPITestClass):
 
     def test_make_submission_public(self):
 
+        # make all submissions private before test
         Submission.objects.filter(is_public=self.submission.is_public).update(
             is_public=False
         )
@@ -150,6 +151,15 @@ class SubmissionAdminTest(BaseAPITestClass):
 
     def test_make_submission_private(self):
 
+        # make all submissions public before test
+        Submission.objects.filter(is_public=False).update(
+            is_public=True
+        )
+        f = open('test.txt', 'w')
+        f.write(str(Submission.objects.filter(is_public=False).count()) + "\n")
+        f.write(str(Submission.objects.filter(is_public=True).count()) + "\n")
         queryset = Submission.objects.filter(is_public=True)
-        self.app_admin.make_submission_public(request, queryset)
+        f.write(str(queryset.count()) + "\n")
+        f.write(str(Submission.objects.filter(is_public=False)))
+        self.app_admin.make_submission_private(request, queryset)
         self.assertEqual(Submission.objects.filter(is_public=False).count(), 1)

--- a/tests/unit/jobs/test_admin.py
+++ b/tests/unit/jobs/test_admin.py
@@ -155,11 +155,6 @@ class SubmissionAdminTest(BaseAPITestClass):
         Submission.objects.filter(is_public=False).update(
             is_public=True
         )
-        f = open('test.txt', 'w')
-        f.write(str(Submission.objects.filter(is_public=False).count()) + "\n")
-        f.write(str(Submission.objects.filter(is_public=True).count()) + "\n")
         queryset = Submission.objects.filter(is_public=True)
-        f.write(str(queryset.count()) + "\n")
-        f.write(str(Submission.objects.filter(is_public=False)))
         self.app_admin.make_submission_private(request, queryset)
         self.assertEqual(Submission.objects.filter(is_public=False).count(), 1)

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -1482,7 +1482,7 @@ class ChangeSubmissionDataAndVisibilityTest(BaseAPITestClass):
             "submitted_at": "{0}{1}".format(
                 self.submission.submitted_at.isoformat(), "Z"
             ).replace("+00:00", ""),
-            "is_public": self.submission.is_public,
+            "is_public": self.data["is_public"],
             "is_flagged": self.submission.is_flagged,
             "ignore_submission": False,
             "when_made_public": "{0}{1}".format(


### PR DESCRIPTION
### Description

This PR adds changes to allow making submissions private before it is in `FINISHED` state. Earlier we only allowed modifying submission visibilty when submission was evaluated successfully