### PR TITLE
Add missing file url check in submission API

### DIFF
--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -271,6 +271,11 @@ def challenge_submission(request, challenge_id, challenge_phase_id):
             )
 
         if not request.FILES:
+            if request.data.get("file_url") is None:
+                response_data = {"error": "The file URL is missing!"}
+                return Response(
+                    response_data, status=status.HTTP_400_BAD_REQUEST
+                )
             if not is_url_valid(request.data["file_url"]):
                 response_data = {"error": "The file URL does not exists!"}
                 return Response(

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -531,6 +531,28 @@ class BaseAPITestClass(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    def test_challenge_submission_when_file_url_is_none(self):
+        self.url = reverse_lazy(
+            "jobs:challenge_submission",
+            kwargs={
+                "challenge_id": self.challenge.pk,
+                "challenge_phase_id": self.challenge_phase.pk,
+            },
+        )
+
+        self.challenge.participant_teams.add(self.participant_team)
+        self.challenge.save()
+
+        expected = {"error": "The file URL is missing!"}
+
+        response = self.client.post(
+            self.url,
+            {"status": "submitting"},
+            format="multipart",
+        )
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
 
 class GetChallengeSubmissionTest(BaseAPITestClass):
     def setUp(self):


### PR DESCRIPTION
### Description

This PR adds the missing `file_url` check in submission api. Currently, we are not handling this case because of which the submission API throws an exception. Refer [this](https://sentry.io/organizations/cloudcv/issues/1929968923/?project=152529&referrer=slack).