### PR TITLE
Fix staging backend environment URL in new UI

### DIFF
--- a/frontend_v2/src/environments/environment.staging.ts
+++ b/frontend_v2/src/environments/environment.staging.ts
@@ -8,5 +8,5 @@
  */
 export const environment = {
   production: true,
-  api_endpoint: 'http://staging-evalai.cloudcv.org/api/',
+  api_endpoint: 'http://evalai-staging.cloudcv.org/api/',
 };


### PR DESCRIPTION
This PR --
- [x] Change staging backend URL from `https://staging-evalai.cloudcv.org` to `https://evalai-staging.cloudcv.org`
