### PR TITLE
Change info and error icons in the toast UI

### DIFF
--- a/frontend_v2/src/app/components/utility/toast/toast.component.html
+++ b/frontend_v2/src/app/components/utility/toast/toast.component.html
@@ -4,8 +4,8 @@
     [ngClass]="{ 'toast-success': type == 'success', 'toast-error': type == 'error', 'toast-info': type == 'info' }"
   >
     <span *ngIf="type == 'success'"><i class="fa fa-check" aria-hidden="true"></i></span>
-    <span *ngIf="type == 'error'"><i class="fa fa-warning" aria-hidden="true"></i></span>
-    <span *ngIf="type == 'info'"><i class="fa fa-info-circle" aria-hidden="true"></i></span>
+    <span *ngIf="type == 'error'"><i class="fa fa-times" aria-hidden="true"></i></span>
+    <span *ngIf="type == 'info'"><i class="fa fa-info" aria-hidden="true"></i></span>
     <span class="toast-message" id="toastmessage">{{ message }}</span>
   </div>
 </div>

--- a/frontend_v2/src/app/components/utility/toast/toast.component.scss
+++ b/frontend_v2/src/app/components/utility/toast/toast.component.scss
@@ -20,11 +20,9 @@
       margin-left: 8px;
     }
     .fa-info,
-    .fa-times{
-      font-size: 14px;
-    }
+    .fa-times,
     .fa-check {
-      font-size: 16px;
+      font-size: 15px;
     }
   }
   &.show {

--- a/frontend_v2/src/app/components/utility/toast/toast.component.scss
+++ b/frontend_v2/src/app/components/utility/toast/toast.component.scss
@@ -12,17 +12,19 @@
   top: 64px;
   box-shadow: none;
   .toast-desc {
-    padding: 15px 40px;
+    padding: 15px 20px;
     @include box-shadow(0px, 0px, 10px, 5px, $overlay-light);
     .toast-message {
       font-size: $fs-14;
-      font-weight: $fw-bolder;
+      font-weight: $fw-light;
       margin-left: 8px;
     }
-    .fa-info-circle,
-    .fa-warning,
+    .fa-info,
+    .fa-times{
+      font-size: 14px;
+    }
     .fa-check {
-      font-size: 28px;
+      font-size: 16px;
     }
   }
   &.show {
@@ -58,9 +60,9 @@
   }
 
   &.toast-info {
-    background-color: $blue;
+    background-color: $info-blue;
     &:hover {
-      background-color: $blue;
+      background-color: $info-blue;
     }
   }
 }

--- a/frontend_v2/src/styles/variables.scss
+++ b/frontend_v2/src/styles/variables.scss
@@ -15,6 +15,7 @@ $wild-blue: #adb4d0;
 $dust-gray: #1a1b1f;
 $blue: #3b9eb9;
 $wait-blue: #5843a3;
+$info-blue: #31708f;
 
 $teal: #008081;
 


### PR DESCRIPTION
This PR --
- [x] Changes the info and error icons for the toast UI.
- [x] Fixes the CSS and font-weight for the toast.

New Toast --
<img width="365" alt="Screenshot 2020-10-14 at 2 27 52 AM" src="https://user-images.githubusercontent.com/12206047/95951814-0f385300-0dc5-11eb-8481-1cd59f0aea49.png">
<img width="375" alt="Screenshot 2020-10-14 at 2 27 46 AM" src="https://user-images.githubusercontent.com/12206047/95951815-0f385300-0dc5-11eb-833f-dadb9547913e.png">
<img width="384" alt="Screenshot 2020-10-14 at 2 27 27 AM" src="https://user-images.githubusercontent.com/12206047/95951817-0fd0e980-0dc5-11eb-947f-eeb3c778d86a.png">
