### PR TITLE
Disable manage tab for remote evaluation challenge

### DIFF
--- a/apps/challenges/serializers.py
+++ b/apps/challenges/serializers.py
@@ -59,6 +59,7 @@ class ChallengeSerializer(serializers.ModelSerializer):
             "slug",
             "max_docker_image_size",
             "cli_version",
+            "remote_evaluation"
         )
 
 

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -1390,7 +1390,7 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
                 send_slack_notification(message=message)
 
             template_data = get_challenge_template_data(zip_config.challenge)
-            if not challenge.is_docker_based and challenge.inform_hosts:
+            if not challenge.is_docker_based and challenge.inform_hosts and not challenge.remote_evaluation:
                 try:
                     response = start_workers([zip_config.challenge])
                     count, failures = response["count"], response["failures"]

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -62,6 +62,7 @@
         vm.termsAndConditions = false;
         vm.team = {};
         vm.isSubmissionUsingUrl = null;
+        vm.isRemoteChallenge = false;
 
         vm.filter_all_submission_by_team_name = '';
         vm.filter_my_submission_by_team_name = '';
@@ -257,6 +258,7 @@
                 vm.cliVersion = details.cli_version;
                 vm.isRegistrationOpen = details.is_registration_open;
                 vm.approved_by_admin = details.approved_by_admin;
+                vm.isRemoteChallenge = details.remote_evaluation
                 vm.getTeamName(vm.challengeId);
 
                 if (vm.page.image === null) {

--- a/frontend/src/views/web/challenge/challenge-page.html
+++ b/frontend/src/views/web/challenge/challenge-page.html
@@ -120,7 +120,7 @@
                             All Submissions</a></li>
                     <li class="margin-btm-0"><a ui-sref=".leaderboard" ui-sref-active="active-challenge"
                             class="text-light-black w-300"><i class="fa fa-line-chart"></i> Leaderboard</a></li>
-                    <li class="margin-btm-0" ng-if="challenge.isChallengeHost"><a ui-sref=".manage" ui-sref-active="active-challenge"
+                    <li class="margin-btm-0" ng-if="challenge.isChallengeHost && !challenge.isRemoteChallenge"><a ui-sref=".manage" ui-sref-active="active-challenge"
                             class="text-light-black w-300"><i class="fa fa-cogs"></i> Manage</a></li>
                     <li class="margin-btm-0" ng-if="challenge.isForumEnabled && challenge.forumURL"><a
                             href="{{challenge.forumURL}}" target="_blank" class="text-light-black w-300"><i

--- a/frontend_v2/src/app/components/challenge/challengesettings/challengesettings.component.html
+++ b/frontend_v2/src/app/components/challenge/challengesettings/challengesettings.component.html
@@ -99,7 +99,7 @@
         </div>
       </div>
     </div>
-    <div class="row settings-section">
+    <div class="row settings-section" *ngIf="!challenge['remote_evaluation']">
       <div class="row margin-bottom-cancel">
         <div class="col s12">
           <h5 class="w-300">Submission worker actions</h5>

--- a/frontend_v2/src/app/components/challenge/challengesettings/challengesettings.component.ts
+++ b/frontend_v2/src/app/components/challenge/challengesettings/challengesettings.component.ts
@@ -94,8 +94,10 @@ export class ChallengesettingsComponent implements OnInit, OnDestroy {
     this.challengeService.isChallengeHost.subscribe((status) => {
       this.isChallengeHost = status;
     });
-    this.fetchWorkerLogs();
-    this.startLoadingLogs();
+    if (!this.challenge["remote_evaluation"]) {
+      this.fetchWorkerLogs();
+      this.startLoadingLogs();
+    }
   }
 
   updateView() {

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -167,6 +167,7 @@ class GetChallengeTest(BaseAPITestClass):
                 "slug": self.challenge.slug,
                 "max_docker_image_size": self.challenge.max_docker_image_size,
                 "cli_version": self.challenge.cli_version,
+                "remote_evaluation": self.challenge.remote_evaluation,
             }
         ]
 
@@ -307,6 +308,7 @@ class GetParticularChallenge(BaseAPITestClass):
             "slug": self.challenge.slug,
             "max_docker_image_size": self.challenge.max_docker_image_size,
             "cli_version": self.challenge.cli_version,
+            "remote_evaluation": self.challenge.remote_evaluation,
         }
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
@@ -379,6 +381,7 @@ class GetParticularChallenge(BaseAPITestClass):
             )[:199],
             "max_docker_image_size": self.challenge.max_docker_image_size,
             "cli_version": self.challenge.cli_version,
+            "remote_evaluation": self.challenge.remote_evaluation,
         }
         response = self.client.put(
             self.url, {"title": new_title, "description": new_description}
@@ -477,6 +480,7 @@ class UpdateParticularChallenge(BaseAPITestClass):
             )[:199],
             "max_docker_image_size": self.challenge.max_docker_image_size,
             "cli_version": self.challenge.cli_version,
+            "remote_evaluation": self.challenge.remote_evaluation,
         }
         response = self.client.patch(self.url, self.partial_update_data)
         self.assertEqual(response.data, expected)
@@ -524,6 +528,7 @@ class UpdateParticularChallenge(BaseAPITestClass):
             )[:199],
             "max_docker_image_size": self.challenge.max_docker_image_size,
             "cli_version": self.challenge.cli_version,
+            "remote_evaluation": self.challenge.remote_evaluation,
         }
         response = self.client.put(self.url, self.data)
         self.assertEqual(response.data, expected)
@@ -1020,6 +1025,7 @@ class GetAllChallengesTest(BaseAPITestClass):
                 "slug": self.challenge3.slug,
                 "max_docker_image_size": self.challenge3.max_docker_image_size,
                 "cli_version": self.challenge3.cli_version,
+                "remote_evaluation": self.challenge3.remote_evaluation,
             }
         ]
         response = self.client.get(self.url, {}, format="json")
@@ -1069,6 +1075,7 @@ class GetAllChallengesTest(BaseAPITestClass):
                 "slug": self.challenge2.slug,
                 "max_docker_image_size": self.challenge2.max_docker_image_size,
                 "cli_version": self.challenge2.cli_version,
+                "remote_evaluation": self.challenge2.remote_evaluation,
             }
         ]
         response = self.client.get(self.url, {}, format="json")
@@ -1118,6 +1125,7 @@ class GetAllChallengesTest(BaseAPITestClass):
                 "slug": self.challenge4.slug,
                 "max_docker_image_size": self.challenge4.max_docker_image_size,
                 "cli_version": self.challenge4.cli_version,
+                "remote_evaluation": self.challenge4.remote_evaluation,
             }
         ]
         response = self.client.get(self.url, {}, format="json")
@@ -1166,6 +1174,7 @@ class GetAllChallengesTest(BaseAPITestClass):
                 "slug": self.challenge4.slug,
                 "max_docker_image_size": self.challenge4.max_docker_image_size,
                 "cli_version": self.challenge4.cli_version,
+                "remote_evaluation": self.challenge4.remote_evaluation,
             },
             {
                 "id": self.challenge3.pk,
@@ -1203,6 +1212,7 @@ class GetAllChallengesTest(BaseAPITestClass):
                 "slug": self.challenge3.slug,
                 "max_docker_image_size": self.challenge3.max_docker_image_size,
                 "cli_version": self.challenge3.cli_version,
+                "remote_evaluation": self.challenge3.remote_evaluation,
             },
             {
                 "id": self.challenge2.pk,
@@ -1240,6 +1250,7 @@ class GetAllChallengesTest(BaseAPITestClass):
                 "slug": self.challenge2.slug,
                 "max_docker_image_size": self.challenge2.max_docker_image_size,
                 "cli_version": self.challenge2.cli_version,
+                "remote_evaluation": self.challenge2.remote_evaluation,
             },
         ]
         response = self.client.get(self.url, {}, format="json")
@@ -1338,6 +1349,7 @@ class GetFeaturedChallengesTest(BaseAPITestClass):
                 "slug": self.challenge3.slug,
                 "max_docker_image_size": self.challenge3.max_docker_image_size,
                 "cli_version": self.challenge3.cli_version,
+                "remote_evaluation": self.challenge3.remote_evaluation,
             }
         ]
         response = self.client.get(self.url, {}, format="json")
@@ -1463,6 +1475,7 @@ class GetChallengeByPk(BaseAPITestClass):
             "slug": self.challenge3.slug,
             "max_docker_image_size": self.challenge3.max_docker_image_size,
             "cli_version": self.challenge3.cli_version,
+            "remote_evaluation": self.challenge3.remote_evaluation,
         }
 
         response = self.client.get(self.url, {})
@@ -1524,6 +1537,7 @@ class GetChallengeByPk(BaseAPITestClass):
             "slug": self.challenge4.slug,
             "max_docker_image_size": self.challenge4.max_docker_image_size,
             "cli_version": self.challenge4.cli_version,
+            "remote_evaluation": self.challenge4.remote_evaluation,
         }
 
         self.client.force_authenticate(user=self.user1)
@@ -1641,6 +1655,7 @@ class GetChallengeBasedOnTeams(BaseAPITestClass):
                 "slug": self.challenge2.slug,
                 "max_docker_image_size": self.challenge2.max_docker_image_size,
                 "cli_version": self.challenge2.cli_version,
+                "remote_evaluation": self.challenge2.remote_evaluation,
             }
         ]
 
@@ -1690,6 +1705,7 @@ class GetChallengeBasedOnTeams(BaseAPITestClass):
                 "slug": self.challenge2.slug,
                 "max_docker_image_size": self.challenge2.max_docker_image_size,
                 "cli_version": self.challenge2.cli_version,
+                "remote_evaluation": self.challenge2.remote_evaluation,
             }
         ]
 
@@ -1739,6 +1755,7 @@ class GetChallengeBasedOnTeams(BaseAPITestClass):
                 "slug": self.challenge2.slug,
                 "max_docker_image_size": self.challenge2.max_docker_image_size,
                 "cli_version": self.challenge2.cli_version,
+                "remote_evaluation": self.challenge2.remote_evaluation,
             }
         ]
 
@@ -1786,6 +1803,7 @@ class GetChallengeBasedOnTeams(BaseAPITestClass):
                 "slug": self.challenge.slug,
                 "max_docker_image_size": self.challenge.max_docker_image_size,
                 "cli_version": self.challenge.cli_version,
+                "remote_evaluation": self.challenge.remote_evaluation,
             },
             {
                 "id": self.challenge2.pk,
@@ -1823,6 +1841,7 @@ class GetChallengeBasedOnTeams(BaseAPITestClass):
                 "slug": self.challenge2.slug,
                 "max_docker_image_size": self.challenge2.max_docker_image_size,
                 "cli_version": self.challenge2.cli_version,
+                "remote_evaluation": self.challenge2.remote_evaluation,
             },
         ]
 

--- a/tests/unit/participants/test_views.py
+++ b/tests/unit/participants/test_views.py
@@ -809,6 +809,7 @@ class GetTeamsAndCorrespondingChallengesForAParticipant(BaseAPITestClass):
                         "slug": self.challenge1.slug,
                         "max_docker_image_size": self.challenge1.max_docker_image_size,
                         "cli_version": self.challenge1.cli_version,
+                        "remote_evaluation": self.challenge1.remote_evaluation,
                     },
                     "participant_team": {
                         "id": self.participant_team.id,
@@ -873,6 +874,7 @@ class GetTeamsAndCorrespondingChallengesForAParticipant(BaseAPITestClass):
                 "slug": self.challenge1.slug,
                 "max_docker_image_size": self.challenge1.max_docker_image_size,
                 "cli_version": self.challenge1.cli_version,
+                "remote_evaluation": self.challenge1.remote_evaluation,
             }
         ]
 


### PR DESCRIPTION
### Description

This PR disables manage tab access for remote evaluation challenges. Earlier we were spinning up workers on ECS for remote evaluation challenges too, this PR disables that as remote challenges have their own setup for challenge workers.
