### PR TITLE
[Docker] Migrate domain to eval.ai

### DIFF
--- a/docker/prod/nodejs/nginx_production.conf
+++ b/docker/prod/nodejs/nginx_production.conf
@@ -5,10 +5,10 @@ upstream django_app {
 server {
   server_name evalapi.cloudcv.org evalai.cloudcv.org;
   listen 80;
-  listen 443 ssl;
+  listen 443;
   return 301 https://eval.ai$request_uri;
 
-  ssl on;
+  ssl off;
   ssl_certificate /etc/ssl/__cloudcv_org.crt;
   ssl_certificate_key /etc/ssl/cloudcv.key;
   ssl_prefer_server_ciphers on;

--- a/docker/prod/nodejs/nginx_production.conf
+++ b/docker/prod/nodejs/nginx_production.conf
@@ -3,28 +3,27 @@ upstream django_app {
 }
 
 server {
-  server_name evalapi.cloudcv.org;
-  listen 443;
-  return 301 https://evalai.cloudcv.org$request_uri;
+  server_name evalapi.cloudcv.org evalai.cloudcv.org;
+  listen 80;
+  listen 443 ssl;
+  return 301 https://eval.ai$request_uri;
 
   ssl on;
   ssl_certificate /etc/ssl/__cloudcv_org.crt;
   ssl_certificate_key /etc/ssl/cloudcv.key;
   ssl_prefer_server_ciphers on;
-  #enables all versions of TLS, but not SSLv2 or 3 which are weak and now deprecated.
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 }
 
 server {
-  server_name evalai.cloudcv.org;
+  server_name eval.ai;
   listen 80;
-  client_max_body_size 400M;
-  return 301 https://$server_name$request_uri;
+  return 301 https://eval.ai$request_uri;
 }
 
 server {
-  server_name evalai.cloudcv.org;
-  listen 443;
+  server_name eval.ai;
+  listen 443 ssl;
   sendfile on;
   default_type application/octet-stream;
 
@@ -55,10 +54,9 @@ server {
   }
 
   ssl on;
-  ssl_certificate /etc/ssl/__cloudcv_org.crt;
-  ssl_certificate_key /etc/ssl/cloudcv.key;
+  ssl_certificate /etc/ssl/eval_ai.crt;
+  ssl_certificate_key /etc/ssl/eval_ai.key;
   ssl_prefer_server_ciphers on;
-  #enables all versions of TLS, but not SSLv2 or 3 which are weak and now deprecated.
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 
   access_log /var/log/nginx/access.log;

--- a/docker/prod/nodejs/nginx_staging.conf
+++ b/docker/prod/nodejs/nginx_staging.conf
@@ -3,28 +3,27 @@ upstream django_app {
 }
 
 server {
-  server_name staging-evalai.cloudcv.org;
-  listen 443;
-  return 301 https://evalai-staging.cloudcv.org$request_uri;
+  server_name staging-evalai.cloudcv.org evalai-staging.cloudcv.org;
+  listen 80;
+  listen 443 ssl;
+  return 301 https://staging.eval.ai$request_uri;
 
   ssl on;
   ssl_certificate /etc/ssl/__cloudcv_org.crt;
   ssl_certificate_key /etc/ssl/cloudcv.key;
   ssl_prefer_server_ciphers on;
-  #enables all versions of TLS, but not SSLv2 or 3 which are weak and now deprecated.
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 }
 
 server {
-  server_name evalai-staging.cloudcv.org;
+  server_name staging.eval.ai;
   listen 80;
-  client_max_body_size 400M;
-  return 301 https://$server_name$request_uri;
+  return 301 https://eval.ai$request_uri;
 }
 
 server {
-  server_name evalai-staging.cloudcv.org;
-  listen 443;
+  server_name staging.eval.ai;
+  listen 443 ssl;
   sendfile on;
   default_type application/octet-stream;
 
@@ -55,8 +54,8 @@ server {
   }
 
   ssl on;
-  ssl_certificate /etc/ssl/__cloudcv_org.crt;
-  ssl_certificate_key /etc/ssl/cloudcv.key;
+  ssl_certificate /etc/ssl/eval_ai.crt;
+  ssl_certificate_key /etc/ssl/eval_ai.key;
   ssl_prefer_server_ciphers on;
   #enables all versions of TLS, but not SSLv2 or 3 which are weak and now deprecated.
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2;

--- a/docker/prod/nodejs/nginx_staging.conf
+++ b/docker/prod/nodejs/nginx_staging.conf
@@ -5,10 +5,10 @@ upstream django_app {
 server {
   server_name staging-evalai.cloudcv.org evalai-staging.cloudcv.org;
   listen 80;
-  listen 443 ssl;
+  listen 443;
   return 301 https://staging.eval.ai$request_uri;
 
-  ssl on;
+  ssl off;
   ssl_certificate /etc/ssl/__cloudcv_org.crt;
   ssl_certificate_key /etc/ssl/cloudcv.key;
   ssl_prefer_server_ciphers on;
@@ -18,7 +18,7 @@ server {
 server {
   server_name staging.eval.ai;
   listen 80;
-  return 301 https://eval.ai$request_uri;
+  return 301 https://staging.eval.ai$request_uri;
 }
 
 server {

--- a/frontend/src/js/config.json
+++ b/frontend/src/js/config.json
@@ -6,12 +6,12 @@
     },
     "staging": {
         "EnvironmentConfig": {
-            "API": "https://evalai-staging.cloudcv.org/api/"
+            "API": "https://staging.eval.ai/api/"
         }
     },
     "production": {
         "EnvironmentConfig": {
-            "API": "https://evalai.cloudcv.org/api/"
+            "API": "https://eval.ai/api/"
         }
     }
 }

--- a/scripts/deployment/push.sh
+++ b/scripts/deployment/push.sh
@@ -7,7 +7,7 @@ build_and_push() {
         aws configure set default.region us-east-1
         eval $(aws ecr get-login --no-include-email)
         echo "Pulling ssl certificates and nginx configuration..."
-        aws s3 cp s3://cloudcv-secrets/evalai/${TRAVIS_BRANCH}/ssl/ ./ssl/ --recursive
+        aws s3 cp s3://cloudcv-secrets/eval.ai/ssl/ ./ssl/ --recursive
         echo "Pulled ssl certificates and nginx configuration successfully"
         docker-compose -f docker-compose-$1.yml build \
             --build-arg COMMIT_ID=${COMMIT_ID} \

--- a/scripts/deployment/push.sh
+++ b/scripts/deployment/push.sh
@@ -8,6 +8,8 @@ build_and_push() {
         eval $(aws ecr get-login --no-include-email)
         echo "Pulling ssl certificates and nginx configuration..."
         aws s3 cp s3://cloudcv-secrets/eval.ai/ssl/ ./ssl/ --recursive
+        # Need ssl files related to *.cloudcv.org since we want to provide backward compatibility
+        aws s3 cp s3://cloudcv-secrets/evalai/${TRAVIS_BRANCH}/ssl/ ./ssl/ --recursive
         echo "Pulled ssl certificates and nginx configuration successfully"
         docker-compose -f docker-compose-$1.yml build \
             --build-arg COMMIT_ID=${COMMIT_ID} \

--- a/settings/prod.py
+++ b/settings/prod.py
@@ -6,8 +6,7 @@ import raven
 DEBUG = False
 
 ALLOWED_HOSTS = [
-    "*.evalai.cloudcv.org",
-    "evalai.cloudcv.org",
+    "eval.ai",
 ]
 
 # Database

--- a/settings/staging.py
+++ b/settings/staging.py
@@ -1,6 +1,8 @@
 from .prod import *  # noqa: ignore=F405
 
-ALLOWED_HOSTS = ["evalai-staging.cloudcv.org"]
+ALLOWED_HOSTS = [
+    "staging.eval.ai",
+]
 
 CORS_ORIGIN_ALLOW_ALL = False
 


### PR DESCRIPTION
 Includes following changes:
- All previous domains redirect to eval.ai
- Add ssl certificate support for eval.ai