### PR TITLE
[Frontend][Docs] Update references to eval.ai

### DIFF
--- a/apps/base/utils.py
+++ b/apps/base/utils.py
@@ -241,7 +241,7 @@ def send_slack_notification(webhook=settings.SLACK_WEB_HOOK_URL, message=""):
     try:
         data = {
             "attachments": [{"color": "ffaf4b", "fields": message["fields"]}],
-            "icon_url": "https://evalai.cloudcv.org/dist/images/evalai-logo-single.png",
+            "icon_url": "https://eval.ai/dist/images/evalai-logo-single.png",
             "text": message["text"],
             "username": "EvalAI",
         }

--- a/apps/web/templates/notification_email_conformation.html
+++ b/apps/web/templates/notification_email_conformation.html
@@ -43,7 +43,7 @@
         </div>
         <div class="row">
             <div class="col s12 m4 offset-m4 text-highlight center w-300">
-                <a href="https://evalai.cloudcv.org/api/admin" class="waves-effect waves-dark btn ev-btn-dark blue-grey darken-4">Return to Admin</a>
+                <a href="https://eval.ai/api/admin" class="waves-effect waves-dark btn ev-btn-dark blue-grey darken-4">Return to Admin</a>
             </div>
         </div>
     </div>

--- a/docs/source/approve_challenge.md
+++ b/docs/source/approve_challenge.md
@@ -1,6 +1,6 @@
 ## Approve a challenge (for forked version)
 
-**Note:** If you are hosting the challenge on [evalai.cloudcv.org](https://evalai.cloudcv.org), then you cannot approve your challenge. It will be approved by [EvalAI team](https://evalai.cloudcv.org/team). You can skip this section.
+**Note:** If you are hosting the challenge on [eval.ai](https://eval.ai), then you cannot approve your challenge. It will be approved by [EvalAI team](https://eval.ai/team). You can skip this section.
 
 Once a challenge config has been uploaded, the challenge has to be approved by the EvalAI Admin (i.e. you if you are setting up EvalAI yourself on your server) to make it available to everyone. Please follow the following steps to approve a challenge (if you are ):
 

--- a/docs/source/glossary.md
+++ b/docs/source/glossary.md
@@ -16,8 +16,8 @@ A group of challenge hosts who organizes a challenge. They are identified by a u
 
 A challenge phase represents a distinct stage of the challenge. Over a period of time, challenge organizers have started to use the challenge phase as a way to:
 
-1.  Decide when to evaluate submissions on a subset of the test-set or when to evaluate on the whole test-set (for e.g, [VQA Challenge 2019](https://evalai.cloudcv.org/web/challenges/challenge-page/163/overview))
-2.  Use different challenge phases as different tracks of the same challenge (for e.g., [CARLA Autonomous Driving Challenge](https://evalai.cloudcv.org/web/challenges/challenge-page/246/phases))
+1.  Decide when to evaluate submissions on a subset of the test-set or when to evaluate on the whole test-set (for e.g, [VQA Challenge 2019](https://eval.ai/web/challenges/challenge-page/163/overview))
+2.  Use different challenge phases as different tracks of the same challenge (for e.g., [CARLA Autonomous Driving Challenge](https://eval.ai/web/challenges/challenge-page/246/phases))
 
 ### Challenge phase split
 

--- a/docs/source/host_challenge.md
+++ b/docs/source/host_challenge.md
@@ -16,12 +16,12 @@ EvalAI supports hosting challenges with different configurations. Challenge orga
 
 We have hosted challenges from different domains such as:
 
-- Machine learning ([2019 SIOP Machine Learning Competition](https://evalai.cloudcv.org/web/challenges/challenge-page/160/leaderboard/481))
-- Deep learning ([Visual Dialog Challenge 2019 ](https://evalai.cloudcv.org/web/challenges/challenge-page/161/leaderboard/483))
-- Computer vision ([Vision and Language Navigation](https://evalai.cloudcv.org/web/challenges/challenge-page/97/leaderboard/270))
-- Natural language processing ([VQA Challenge 2019](https://evalai.cloudcv.org/web/challenges/challenge-page/163/leaderboard/498))
-- Healthcare ([fastMRI Image Reconstruction ](https://evalai.cloudcv.org/web/challenges/challenge-page/153/leaderboard/447))
-- Self-driving cars ([CARLA Autonomous Driving Challenge](https://evalai.cloudcv.org/web/challenges/challenge-page/246/leaderboard/817))
+- Machine learning ([2019 SIOP Machine Learning Competition](https://eval.ai/web/challenges/challenge-page/160/leaderboard/481))
+- Deep learning ([Visual Dialog Challenge 2019 ](https://eval.ai/web/challenges/challenge-page/161/leaderboard/483))
+- Computer vision ([Vision and Language Navigation](https://eval.ai/web/challenges/challenge-page/97/leaderboard/270))
+- Natural language processing ([VQA Challenge 2019](https://eval.ai/web/challenges/challenge-page/163/leaderboard/498))
+- Healthcare ([fastMRI Image Reconstruction ](https://eval.ai/web/challenges/challenge-page/153/leaderboard/447))
+- Self-driving cars ([CARLA Autonomous Driving Challenge](https://eval.ai/web/challenges/challenge-page/246/leaderboard/817))
 
 We categorize the challenges in two categories:
 
@@ -29,7 +29,7 @@ We categorize the challenges in two categories:
 
    Some of the popular prediction upload based challenges that we have hosted are shown below:
 
-   <a href="https://evalai.cloudcv.org/web/challenges/list" target="_blank"><img src="_static/img/prediction-upload-challenges.png"></a><br />
+   <a href="https://eval.ai/web/challenges/list" target="_blank"><img src="_static/img/prediction-upload-challenges.png"></a><br />
 
    If you are interested in hosting prediction upload based challenges, then [click here](host_challenge.html#host-prediction-upload-based-challenge).
 
@@ -39,7 +39,7 @@ We categorize the challenges in two categories:
 
    Some of the popular code upload based challenges that we have hosted are shown below:
 
-   <a href="https://evalai.cloudcv.org/web/challenges/list" target="_blank"><img src="_static/img/code-upload-challenges.png"></a>
+   <a href="https://eval.ai/web/challenges/list" target="_blank"><img src="_static/img/code-upload-challenges.png"></a>
 
    If you are interested in hosting code upload based challenges, then [click here](host_challenge.html#host-prediction-upload-based-challenge).
 
@@ -69,9 +69,9 @@ EvalAI supports all kinds of HTML tags which means you can add images, videos, t
 
 ### Step 5: Upload configuration on EvalAI
 
-Finally run the `./run.sh` script in the bundle. It will generate a `challenge_config.zip` file that contains all the details related to the challenge. Now, visit [EvalAI - Host challenge page](https://evalai.cloudcv.org/web/challenge-host-teams) and select/create a challenge host team. Then upload the `challenge_config.zip`.
+Finally run the `./run.sh` script in the bundle. It will generate a `challenge_config.zip` file that contains all the details related to the challenge. Now, visit [EvalAI - Host challenge page](https://eval.ai/web/challenge-host-teams) and select/create a challenge host team. Then upload the `challenge_config.zip`.
 
-**Congratulations!** you have submitted your challenge configuration for review and [EvalAI team](https://evalai.cloudcv.org/team) has notified about this. [EvalAI team](https://evalai.cloudcv.org/team) will review and will approve the challenge.
+**Congratulations!** you have submitted your challenge configuration for review and [EvalAI team](https://eval.ai/team) has notified about this. [EvalAI team](https://eval.ai/team) will review and will approve the challenge.
 
 If you have issues in creating a challenge on EvalAI, please feel free to contact us at [team@cloudcv.org](mailto:team@cloudcv.org) create an issue on our [GitHub issues page](https://github.com/Cloud-CV/EvalAI/issues/new).
 
@@ -108,14 +108,14 @@ EvalAI supports all kinds of HTML tags which means you can add images, videos, t
 
 ### Step 5: Upload configuration on EvalAI
 
-Finally run the `./run.sh` script in the bundle. It will generate a `challenge_config.zip` file that contains all the details related to the challenge. Now, visit [EvalAI - Host challenge page](https://evalai.cloudcv.org/web/challenge-host-teams) and select/create a challenge host team. Then upload the `challenge_config.zip`.
+Finally run the `./run.sh` script in the bundle. It will generate a `challenge_config.zip` file that contains all the details related to the challenge. Now, visit [EvalAI - Host challenge page](https://eval.ai/web/challenge-host-teams) and select/create a challenge host team. Then upload the `challenge_config.zip`.
 
-**Congratulations!** you have submitted your challenge configuration for review and [EvalAI team](https://evalai.cloudcv.org/team) has notified about this. [EvalAI team](https://evalai.cloudcv.org/team) will review and will approve the challenge.
+**Congratulations!** you have submitted your challenge configuration for review and [EvalAI team](https://eval.ai/team) has notified about this. [EvalAI team](https://eval.ai/team) will review and will approve the challenge.
 
 If you have issues in creating a challenge on EvalAI, please feel free to contact us at [team@cloudcv.org](mailto:team@cloudcv.org) create an issue on our [GitHub issues page](https://github.com/Cloud-CV/EvalAI/issues/new).
 
 [evalai-starters]: https://github.com/cloud-CV/evalai-starters
 [evalai-cli]: http://evalai-cli.cloudcv.org
-[evalai]: http://evalai.cloudcv.org
+[evalai]: http://eval.ai
 [docker-compose]: https://docs.docker.com/compose/install/
 [docker]: https://docs.docker.com/install/linux/docker-ce/ubuntu/

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,5 +41,5 @@ Indices and tables
 * :ref:`modindex`
 * :ref:`search`
 
-.. _EvalAI: http://evalai.cloudcv.org/
+.. _EvalAI: http://eval.ai/
 .. _EvalAI-CLI: http://evalai-cli.cloudcv.org/

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -31,6 +31,6 @@ Once you have installed [docker] and [docker-compose], please follow these steps
 If you are facing any issue during installation, please see our [common errors during installation page](https://evalai.readthedocs.io/en/latest/faq(developers).html#common-errors-during-installation).
 
 [evalai-cli]: http://evalai-cli.cloudcv.org
-[evalai]: http://evalai.cloudcv.org
+[evalai]: http://eval.ai
 [docker-compose]: https://docs.docker.com/compose/install/
 [docker]: https://docs.docker.com/install/linux/docker-ce/ubuntu/

--- a/docs/source/intro.md
+++ b/docs/source/intro.md
@@ -31,4 +31,4 @@ Certain large-scale challenges need special compute capabilities for evaluation.
 We warm-up the worker nodes at start-up by importing the challenge code and pre-loading the dataset in memory. We also split the dataset into small chunks that are simultaneously evaluated on multiple cores. These simple tricks result in faster evaluation and reduces the evaluation time by an order of magnitude in some cases.
 
 [evalai-cli]: http://evalai-cli.cloudcv.org
-[evalai]: http://evalai.cloudcv.org
+[evalai]: http://eval.ai

--- a/docs/source/participate.md
+++ b/docs/source/participate.md
@@ -1,12 +1,12 @@
 # Participate in a challenge
 
-You have to create an account on [EvalAI](http://evalai.cloudcv.org) and a participant team in order to participate in a challenge.
+You have to create an account on [EvalAI](http://eval.ai) and a participant team in order to participate in a challenge.
 
 If you are already familiar with the flow of EvalAI, you may want to skip this section else please follow the following steps to participate in a challenge (VQA Challenge 2017 in this example):
 
-### 1. Visit evalai.cloudcv.org
+### 1. Visit eval.ai
 
-Open [EvalAI website](https://evalai.cloudcv.org/).
+Open [EvalAI website](https://eval.ai/).
 
 <img src="_static/img/1.png"/>
 

--- a/frontend/base.html
+++ b/frontend/base.html
@@ -9,8 +9,8 @@
     <!--Open Graph Related Stuff-->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="EvalAI: Evaluating state of the art in AI" />
-    <meta property="og:url" content="https://evalai.cloudcv.org" />
-    <meta property="og:image" content="https://evalai.cloudcv.org/dist/images/evalai-cover.png" />
+    <meta property="og:url" content="https://eval.ai" />
+    <meta property="og:image" content="https://eval.ai/dist/images/evalai-cover.png" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:site_name" content="EvalAI" />
     <meta property="og:description" content="EvalAI is an open-source web platform for organizing and participating in challenges to push the state of the art on AI tasks." />

--- a/frontend/src/views/web/error-pages/error-404.html
+++ b/frontend/src/views/web/error-pages/error-404.html
@@ -24,6 +24,6 @@
 	</div>
 
 	<div class="fof-home">
-		Maybe <a ui-sref="home" class="home-link"> evalai.cloudcv.org </a> is what you were looking for.
+		Maybe <a ui-sref="home" class="home-link"> eval.ai </a> is what you were looking for.
 	</div>
 </div>

--- a/frontend/src/views/web/error-pages/error-500.html
+++ b/frontend/src/views/web/error-pages/error-500.html
@@ -10,6 +10,6 @@
   </div>
 
   <div class="ise-home">
-    Go Back to <a ui-sref="home"> evalai.cloudcv.org </a>
+    Go Back to <a ui-sref="home"> eval.ai </a>
   </div>
 </div>

--- a/frontend_v2/src/app/components/not-found/not-found.component.html
+++ b/frontend_v2/src/app/components/not-found/not-found.component.html
@@ -13,5 +13,5 @@
     <div class="_1">THE PAGE</div>
     <div class="_2">WAS NOT FOUND</div>
   </div>
-  <div class="link">Maybe <a href="#">evalai.cloudcv.org</a> is what you were looking for.</div>
+  <div class="link">Maybe <a href="#">eval.ai</a> is what you were looking for.</div>
 </div>

--- a/frontend_v2/src/index.html
+++ b/frontend_v2/src/index.html
@@ -14,8 +14,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="EvalAI: Evaluating state of the art in AI" />
-    <meta property="og:url" content="https://evalai.cloudcv.org" />
-    <meta property="og:image" content="https://evalai.cloudcv.org/dist/images/evalai-cover.png" />
+    <meta property="og:url" content="https://eval.ai" />
+    <meta property="og:image" content="https://eval.ai/dist/images/evalai-cover.png" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:site_name" content="EvalAI" />
     <meta


### PR DESCRIPTION
This PR updates all references to `eval.ai` instead of `evalai.cloudcv.org`