### PR TITLE
Update evalai-cli docs link to cli.eval.ai

### DIFF
--- a/docs/source/host_challenge.md
+++ b/docs/source/host_challenge.md
@@ -115,7 +115,7 @@ Finally run the `./run.sh` script in the bundle. It will generate a `challenge_c
 If you have issues in creating a challenge on EvalAI, please feel free to contact us at [team@cloudcv.org](mailto:team@cloudcv.org) create an issue on our [GitHub issues page](https://github.com/Cloud-CV/EvalAI/issues/new).
 
 [evalai-starters]: https://github.com/cloud-CV/evalai-starters
-[evalai-cli]: http://evalai-cli.cloudcv.org
+[evalai-cli]: https://cli.eval.ai/
 [evalai]: http://eval.ai
 [docker-compose]: https://docs.docker.com/compose/install/
 [docker]: https://docs.docker.com/install/linux/docker-ce/ubuntu/

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,4 +42,4 @@ Indices and tables
 * :ref:`search`
 
 .. _EvalAI: http://eval.ai/
-.. _EvalAI-CLI: http://evalai-cli.cloudcv.org/
+.. _EvalAI-CLI: https://cli.eval.ai/

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -30,7 +30,7 @@ Once you have installed [docker] and [docker-compose], please follow these steps
 
 If you are facing any issue during installation, please see our [common errors during installation page](https://evalai.readthedocs.io/en/latest/faq(developers).html#common-errors-during-installation).
 
-[evalai-cli]: http://evalai-cli.cloudcv.org
+[evalai-cli]: https://cli.eval.ai/
 [evalai]: http://eval.ai
 [docker-compose]: https://docs.docker.com/compose/install/
 [docker]: https://docs.docker.com/install/linux/docker-ce/ubuntu/

--- a/docs/source/intro.md
+++ b/docs/source/intro.md
@@ -30,5 +30,5 @@ Certain large-scale challenges need special compute capabilities for evaluation.
 
 We warm-up the worker nodes at start-up by importing the challenge code and pre-loading the dataset in memory. We also split the dataset into small chunks that are simultaneously evaluated on multiple cores. These simple tricks result in faster evaluation and reduces the evaluation time by an order of magnitude in some cases.
 
-[evalai-cli]: http://evalai-cli.cloudcv.org
+[evalai-cli]: https://cli.eval.ai
 [evalai]: http://eval.ai

--- a/frontend/src/views/web/challenge/submission.html
+++ b/frontend/src/views/web/challenge/submission.html
@@ -62,7 +62,7 @@
                         </button>
                     </li>
                     <li>For more commands, please refer to <a class="highlight-link"
-                            href="https://evalai-cli.cloudcv.org/" target="_blank">evalai-cli documentation.</a>
+                            href="https://cli.eval.ai/" target="_blank">evalai-cli documentation.</a>
                     </li>
                 </ol>
             </div>

--- a/frontend_v2/src/app/components/challenge/challengesubmit/challengesubmit.component.html
+++ b/frontend_v2/src/app/components/challenge/challengesubmit/challengesubmit.component.html
@@ -76,7 +76,7 @@
           </li>
           <li class="content">
             For more commands, please refer to
-            <a class="text-highlight" href="https://evalai-cli.cloudcv.org/" target="_blank"
+            <a class="text-highlight" href="https://cli.eval.ai/" target="_blank"
               >evalai-cli documentation.</a
             >
           </li>


### PR DESCRIPTION
This PR --
- [x] Updates all evalai-cli docs link to `https://cli.eval.ai` from `https://evalai-cli.cloudcv.org`
