### PR TITLE
Use allowed submission type field from backend

### DIFF
--- a/apps/challenges/serializers.py
+++ b/apps/challenges/serializers.py
@@ -96,6 +96,7 @@ class ChallengePhaseSerializer(serializers.ModelSerializer):
             "is_restricted_to_select_one_submission",
             "submission_meta_attributes",
             "is_partial_submission_evaluation_enabled",
+            "allowed_submission_file_types",
         )
 
 
@@ -326,6 +327,7 @@ class ChallengePhaseCreateSerializer(serializers.ModelSerializer):
             "submission_meta_attributes",
             "is_partial_submission_evaluation_enabled",
             "config_id",
+            "allowed_submission_file_types",
         )
 
 

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -506,6 +506,14 @@
                         vm.subErrors.msg = "Please provide input for meta attributes!";
                         return false;
                     }
+                    if (vm.fileUrl !== null && vm.fileUrl !== "" && vm.fileUrl !== undefined) {
+                        var fileUrlSplit = vm.fileUrl.split(".");
+                        var extension = fileUrlSplit[fileUrlSplit.length - 1];
+                        if (!vm.currentPhaseAllowedSubmissionFileTypes.includes(extension)) {
+                            vm.subErrors.msg = "Please upload file with " + vm.currentPhaseAllowedSubmissionFileTypes + " extensions only!";
+                            return false;
+                        }
+                    }
                     vm.isExistLoader = true;
                     vm.loaderTitle = '';
                     vm.loaderContainer = angular.element('.exist-team-card');
@@ -669,6 +677,7 @@
             vm.currentPhaseAllowedSubmissionFileTypes = vm.allowedSubmissionFileTypes.find(function(element) {
                 return element["phaseId"] == phaseId;
             }).allowedSubmissionFileTypes;
+            vm.subErrors.msg = "";
         };
 
         vm.clearMetaAttributeValues = function(){

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -506,14 +506,6 @@
                         vm.subErrors.msg = "Please provide input for meta attributes!";
                         return false;
                     }
-                    if (vm.fileUrl !== null && vm.fileUrl !== "" && vm.fileUrl !== undefined) {
-                        var fileUrlSplit = vm.fileUrl.split(".");
-                        var extension = fileUrlSplit[fileUrlSplit.length - 1];
-                        if (!vm.currentPhaseAllowedSubmissionFileTypes.includes(extension)) {
-                            vm.subErrors.msg = "Please upload file with " + vm.currentPhaseAllowedSubmissionFileTypes + " extensions only!";
-                            return false;
-                        }
-                    }
                     vm.isExistLoader = true;
                     vm.loaderTitle = '';
                     vm.loaderContainer = angular.element('.exist-team-card');
@@ -528,14 +520,14 @@
                     var formData = new FormData();
                     if (vm.isSubmissionUsingUrl) {
                         var urlRegex = /(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-/]))?/;
-                        var validExtensions = ["json", "zip", "csv"];
+                        var validExtensions = vm.currentPhaseAllowedSubmissionFileTypes;
                         var isUrlValid = urlRegex.test(vm.fileUrl);
                         var extension = vm.fileUrl.split(".").pop();
                         if (isUrlValid && validExtensions.includes(extension)) {
                             formData.append("file_url", vm.fileUrl);
                         } else {
                             vm.stopLoader();
-                            vm.subErrors.msg = "Please enter a valid URL which ends in json, zip or csv file extension!";
+                            vm.subErrors.msg = "Please enter a valid URL which ends in " + validExtensions + " file extension!";
                             return false;
                         }
                     } else {
@@ -650,12 +642,16 @@
                         vm.submissionMetaAttributes.push(data);
                     }
                     if (details.results[k].allowed_submission_file_types != undefined || details.results[k].allowed_submission_file_types != null) {
-                        var data = {"phaseId": details.results[k].id, "allowedSubmissionFileTypes": details.results[k].allowed_submission_file_types};
-                        vm.allowedSubmissionFileTypes.push(data);
+                        vm.allowedSubmissionFileTypes.push({
+                            "phaseId": details.results[k].id,
+                            "allowedSubmissionFileTypes": details.results[k].allowed_submission_file_types
+                        });
                     } else {
                         // Handle case for missing values
-                        var data = {"phaseId": details.results[k].id, "allowedSubmissionFileTypes": ".json, .zip, .txt, .tsv, .gz, .csv, .h5, .npy"};
-                        vm.allowedSubmissionFileTypes.push(data);
+                        vm.allowedSubmissionFileTypes.push({
+                            "phaseId": details.results[k].id,
+                            "allowedSubmissionFileTypes": ".json, .zip, .txt, .tsv, .gz, .csv, .h5, .npy"
+                        });
                     }
                 }
                 utilities.hideLoader();

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -63,6 +63,8 @@
         vm.team = {};
         vm.isSubmissionUsingUrl = null;
         vm.isRemoteChallenge = false;
+        vm.allowedSubmissionFileTypes = [];
+        vm.currentPhaseAllowedSubmissionFileTypes = '';
 
         vm.filter_all_submission_by_team_name = '';
         vm.filter_my_submission_by_team_name = '';
@@ -639,6 +641,14 @@
                         var data = {"phaseId":details.results[k].id, "attributes": null};
                         vm.submissionMetaAttributes.push(data);
                     }
+                    if (details.results[k].allowed_submission_file_types != undefined || details.results[k].allowed_submission_file_types != null) {
+                        var data = {"phaseId": details.results[k].id, "allowedSubmissionFileTypes": details.results[k].allowed_submission_file_types};
+                        vm.allowedSubmissionFileTypes.push(data);
+                    } else {
+                        // Handle case for missing values
+                        var data = {"phaseId": details.results[k].id, "allowedSubmissionFileTypes": ".json, .zip, .txt, .tsv, .gz, .csv, .h5, .npy"};
+                        vm.allowedSubmissionFileTypes.push(data);
+                    }
                 }
                 utilities.hideLoader();
             },
@@ -656,6 +666,9 @@
             vm.metaAttributesforCurrentSubmission = vm.submissionMetaAttributes.find(function(element){
                 return element["phaseId"] == phaseId;
             }).attributes;
+            vm.currentPhaseAllowedSubmissionFileTypes = vm.allowedSubmissionFileTypes.find(function(element) {
+                return element["phaseId"] == phaseId;
+            }).allowedSubmissionFileTypes;
         };
 
         vm.clearMetaAttributeValues = function(){

--- a/frontend/src/views/web/challenge/submission.html
+++ b/frontend/src/views/web/challenge/submission.html
@@ -227,7 +227,7 @@
                                         <span>Upload file</span>
                                         <input type="file" ngf-select ng-model="challenge.input_file"
                                             name="challenge.input_file"
-                                            accept=".json, .zip, .txt, .tsv, .gz, .csv, .h5, .npy, .npz">
+                                            accept="{{challenge.currentPhaseAllowedSubmissionFileTypes}}">
                                     </div>
                                     <div class="file-path-wrapper">
                                         <input class="file-path validate" type="text" readonly>

--- a/tests/unit/challenges/test_serializers.py
+++ b/tests/unit/challenges/test_serializers.py
@@ -122,6 +122,7 @@ class ChallengePhaseCreateSerializerTest(BaseTestCase):
                 "environment_image": self.challenge_phase.environment_image,
                 "is_restricted_to_select_one_submission": self.challenge_phase.is_restricted_to_select_one_submission,
                 "is_partial_submission_evaluation_enabled": self.challenge_phase.is_partial_submission_evaluation_enabled,
+                "allowed_submission_file_types": self.challenge_phase.allowed_submission_file_types,
             }
             self.challenge_phase_create_serializer = ChallengePhaseCreateSerializer(
                 instance=self.challenge_phase
@@ -150,6 +151,7 @@ class ChallengePhaseCreateSerializerTest(BaseTestCase):
                 "environment_image": self.challenge_phase.environment_image,
                 "is_restricted_to_select_one_submission": self.challenge_phase.is_restricted_to_select_one_submission,
                 "is_partial_submission_evaluation_enabled": self.challenge_phase.is_partial_submission_evaluation_enabled,
+                "allowed_submission_file_types": self.challenge_phase.allowed_submission_file_types,
             }
             self.challenge_phase_create_serializer_without_max_submissions_per_month = ChallengePhaseCreateSerializer(
                 instance=self.challenge_phase
@@ -177,6 +179,7 @@ class ChallengePhaseCreateSerializerTest(BaseTestCase):
                 "slug": self.challenge_phase.slug,
                 "is_restricted_to_select_one_submission": self.challenge_phase.is_restricted_to_select_one_submission,
                 "is_partial_submission_evaluation_enabled": self.challenge_phase.is_partial_submission_evaluation_enabled,
+                "allowed_submission_file_types": self.challenge_phase.allowed_submission_file_types,
             }
             self.challenge_phase_create_serializer_without_max_concurrent_submissions_allowed = ChallengePhaseCreateSerializer(
                 instance=self.challenge_phase
@@ -212,6 +215,7 @@ class ChallengePhaseCreateSerializerTest(BaseTestCase):
                     "submission_meta_attributes",
                     "is_partial_submission_evaluation_enabled",
                     "config_id",
+                    "allowed_submission_file_types",
                 ]
             ),
         )
@@ -292,6 +296,7 @@ class ChallengePhaseCreateSerializerTest(BaseTestCase):
                     "submission_meta_attributes",
                     "is_partial_submission_evaluation_enabled",
                     "config_id",
+                    "allowed_submission_file_types",
                 ]
             ),
         )
@@ -368,6 +373,7 @@ class ChallengePhaseCreateSerializerTest(BaseTestCase):
                     "submission_meta_attributes",
                     "is_partial_submission_evaluation_enabled",
                     "config_id",
+                    "allowed_submission_file_types"
                 ]
             ),
         )

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -1977,6 +1977,7 @@ class GetChallengePhaseTest(BaseChallengePhaseClass):
                 "is_restricted_to_select_one_submission": self.challenge_phase.is_restricted_to_select_one_submission,
                 "submission_meta_attributes": None,
                 "is_partial_submission_evaluation_enabled": self.challenge_phase.is_partial_submission_evaluation_enabled,
+                "allowed_submission_file_types": self.challenge_phase.allowed_submission_file_types,
             },
             {
                 "id": self.private_challenge_phase.id,
@@ -2001,6 +2002,7 @@ class GetChallengePhaseTest(BaseChallengePhaseClass):
                 "is_restricted_to_select_one_submission": self.challenge_phase.is_restricted_to_select_one_submission,
                 "submission_meta_attributes": None,
                 "is_partial_submission_evaluation_enabled": self.challenge_phase.is_partial_submission_evaluation_enabled,
+                "allowed_submission_file_types": self.challenge_phase.allowed_submission_file_types,
             },
         ]
 
@@ -2033,6 +2035,7 @@ class GetChallengePhaseTest(BaseChallengePhaseClass):
                 "is_restricted_to_select_one_submission": self.challenge_phase.is_restricted_to_select_one_submission,
                 "submission_meta_attributes": None,
                 "is_partial_submission_evaluation_enabled": self.challenge_phase.is_partial_submission_evaluation_enabled,
+                "allowed_submission_file_types": self.challenge_phase.allowed_submission_file_types,
             }
         ]
         self.client.force_authenticate(user=None)
@@ -2075,6 +2078,7 @@ class GetChallengePhaseTest(BaseChallengePhaseClass):
                 "is_restricted_to_select_one_submission": self.challenge_phase.is_restricted_to_select_one_submission,
                 "submission_meta_attributes": None,
                 "is_partial_submission_evaluation_enabled": self.challenge_phase.is_partial_submission_evaluation_enabled,
+                "allowed_submission_file_types": self.challenge_phase.allowed_submission_file_types,
             },
             {
                 "id": self.private_challenge_phase.id,
@@ -2099,6 +2103,7 @@ class GetChallengePhaseTest(BaseChallengePhaseClass):
                 "is_restricted_to_select_one_submission": self.challenge_phase.is_restricted_to_select_one_submission,
                 "submission_meta_attributes": None,
                 "is_partial_submission_evaluation_enabled": self.challenge_phase.is_partial_submission_evaluation_enabled,
+                "allowed_submission_file_types": self.challenge_phase.allowed_submission_file_types,
             },
         ]
 
@@ -2445,6 +2450,7 @@ class GetParticularChallengePhase(BaseChallengePhaseClass):
             "is_restricted_to_select_one_submission": self.challenge_phase.is_restricted_to_select_one_submission,
             "submission_meta_attributes": None,
             "is_partial_submission_evaluation_enabled": self.challenge_phase.is_partial_submission_evaluation_enabled,
+            "allowed_submission_file_types": self.challenge_phase.allowed_submission_file_types,
         }
         self.client.force_authenticate(user=self.participant_user)
         response = self.client.get(self.url, {})
@@ -2479,7 +2485,8 @@ class GetParticularChallengePhase(BaseChallengePhaseClass):
             "is_restricted_to_select_one_submission": self.challenge_phase.is_restricted_to_select_one_submission,
             "submission_meta_attributes": None,
             "is_partial_submission_evaluation_enabled": self.challenge_phase.is_partial_submission_evaluation_enabled,
-            "config_id": None
+            "config_id": None,
+            "allowed_submission_file_types": self.challenge_phase.allowed_submission_file_types
         }
         self.client.force_authenticate(user=self.user)
         response = self.client.get(self.url, {})
@@ -2538,6 +2545,7 @@ class GetParticularChallengePhase(BaseChallengePhaseClass):
             "is_restricted_to_select_one_submission": self.challenge_phase.is_restricted_to_select_one_submission,
             "submission_meta_attributes": None,
             "is_partial_submission_evaluation_enabled": self.challenge_phase.is_partial_submission_evaluation_enabled,
+            "allowed_submission_file_types": self.challenge_phase.allowed_submission_file_types,
         }
         response = self.client.put(
             self.url, {"name": new_name, "description": new_description}
@@ -2635,6 +2643,7 @@ class UpdateParticularChallengePhase(BaseChallengePhaseClass):
             "is_restricted_to_select_one_submission": self.challenge_phase.is_restricted_to_select_one_submission,
             "submission_meta_attributes": None,
             "is_partial_submission_evaluation_enabled": self.challenge_phase.is_partial_submission_evaluation_enabled,
+            "allowed_submission_file_types": self.challenge_phase.allowed_submission_file_types,
         }
         response = self.client.patch(self.url, self.partial_update_data)
         self.assertEqual(response.data, expected)
@@ -4134,6 +4143,7 @@ class GetChallengePhaseByPkTest(BaseChallengePhaseClass):
             "is_restricted_to_select_one_submission": self.challenge_phase.is_restricted_to_select_one_submission,
             "submission_meta_attributes": None,
             "is_partial_submission_evaluation_enabled": self.challenge_phase.is_partial_submission_evaluation_enabled,
+            "allowed_submission_file_types": self.challenge_phase.allowed_submission_file_types,
         }
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
@@ -4205,6 +4215,7 @@ class GetChallengePhasesByChallengePkTest(BaseChallengePhaseClass):
                 "submission_meta_attributes": None,
                 "is_partial_submission_evaluation_enabled": self.challenge_phase.is_partial_submission_evaluation_enabled,
                 "config_id": None,
+                "allowed_submission_file_types": self.challenge_phase.allowed_submission_file_types,
             },
             {
                 "id": self.challenge_phase.id,
@@ -4234,6 +4245,7 @@ class GetChallengePhasesByChallengePkTest(BaseChallengePhaseClass):
                 "submission_meta_attributes": None,
                 "is_partial_submission_evaluation_enabled": self.challenge_phase.is_partial_submission_evaluation_enabled,
                 "config_id": None,
+                "allowed_submission_file_types": self.challenge_phase.allowed_submission_file_types,
             },
         ]
         response = self.client.get(self.url, {})


### PR DESCRIPTION
### Description

This PR adds changes to use `allowed_submission_types` field value for file upload restriction on submit page. EvalAI-Starters [PR](https://github.com/Cloud-CV/EvalAI-Starters/pull/30)