### PR TITLE
Fix profile link default values

### DIFF
--- a/frontend/src/js/controllers/profileCtrl.js
+++ b/frontend/src/js/controllers/profileCtrl.js
@@ -49,7 +49,11 @@
                 if (status == 200) {
                     for (var i in result) {
                         if (result[i] === "" || result[i] === undefined || result[i] === null) {
-                            result[i] = "-";
+                            if (i === "linkedin_url" || i === "github_url" || i === "google_scholar_url") {
+                                result[i] = "";
+                            } else {
+                                result[i] = "-";
+                            }
                             vm.countLeft = vm.countLeft + 1;
                         }
                         count = count + 1;

--- a/frontend/src/views/web/profile.html
+++ b/frontend/src/views/web/profile.html
@@ -47,20 +47,20 @@
                             </span>
                             <a href="{{profile.user.github_url}}"
                                 target="_blank"
-                                class="text-highlight">{{profile.user.github_url}}</a>
+                                class="text-highlight">{{profile.user.github_url || '-'}}</a>
                         </li>
                         <li>
                             <span class="text-light-black fs-12">
                                 Google Scholar Url<br></span>
                             <a href="{{profile.user.google_scholar_url}}"
                                 target="_blank" class="text-highlight">
-                                {{profile.user.google_scholar_url}}</a>
+                                {{profile.user.google_scholar_url || '-'}}</a>
                         </li>
                         <li>
                             <span class="text-light-black fs-12">Linkedin Url<br></span>
                             <a href="{{profile.user.linkedin_url}}"
                                 target="_blank"
-                                class="text-highlight">{{profile.user.linkedin_url}}</a>
+                                class="text-highlight">{{profile.user.linkedin_url || '-'}}</a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
This PR -- 
- [x] Fixes the profile `github`, `linkedin` and `google_scholar` profile URL when the fields are blank.
