### PR TITLE
Add multipart upload using presigned URL tests

### DIFF
--- a/apps/challenges/utils.py
+++ b/apps/challenges/utils.py
@@ -168,7 +168,7 @@ def generate_presigned_url_for_multipart_upload(file_key_on_s3, challenge_pk, nu
     Returns:
         response_data {dict} -- Dict containing the presigned_urls or the error if request failed
     """
-    if settings.DEBUG or settings.TEST:
+    if settings.DEBUG:
         return
     response_data = {}
     try:
@@ -218,7 +218,7 @@ def complete_s3_multipart_file_upload(parts, upload_id, file_key_on_s3, challeng
     Returns:
         response_data {dict} -- Dict containing the presigned_urls or the error if request failed
     """
-    if settings.DEBUG or settings.TEST:
+    if settings.DEBUG:
         return
     response_data = {}
     try:

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -2707,9 +2707,6 @@ def get_annotation_file_presigned_url(request, challenge_phase_pk):
     if request.data.get("num_file_chunks"):
         num_file_chunks = int(request.data["num_file_chunks"])
 
-    with open("Data.txt", "w") as f:
-        f.write(json.dumps(request.data))
-
     file_ext = os.path.splitext(request.data["file_name"])[-1]
     random_file_name = uuid.uuid4()
 

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -2672,7 +2672,7 @@ def manage_worker(request, challenge_pk, action):
     return Response(response_data, status=status.HTTP_200_OK)
 
 
-@api_view(["GET"])
+@api_view(["POST"])
 @throttle_classes([UserRateThrottle])
 @permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))
 @authentication_classes((ExpiringTokenAuthentication,))
@@ -2686,7 +2686,7 @@ def get_annotation_file_presigned_url(request, challenge_phase_pk):
     Returns:
          Response Object -- An object containing the presignd url, or an error message if some failure occurs
     """
-    if settings.DEBUG or settings.TEST:
+    if settings.DEBUG:
         response_data = {
             "error": "Sorry, this feature is not available in development or test environment."
         }
@@ -2706,6 +2706,9 @@ def get_annotation_file_presigned_url(request, challenge_phase_pk):
     num_file_chunks = 1
     if request.data.get("num_file_chunks"):
         num_file_chunks = int(request.data["num_file_chunks"])
+
+    with open("Data.txt", "w") as f:
+        f.write(json.dumps(request.data))
 
     file_ext = os.path.splitext(request.data["file_name"])[-1]
     random_file_name = uuid.uuid4()
@@ -2764,7 +2767,7 @@ def finish_annotation_file_upload(request, challenge_phase_pk):
     Returns:
          Response Object -- An object containing the presignd url, or an error message if some failure occurs
     """
-    if settings.DEBUG or settings.TEST:
+    if settings.DEBUG:
         response_data = {
             "error": "Sorry, this feature is not available in development or test environment."
         }

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -2189,7 +2189,7 @@ def get_submission_file_presigned_url(request, challenge_phase_pk):
     Returns:
          Response Object -- An object containing the presignd url and submission id, or an error message if some failure occurs
     """
-    if settings.DEBUG or settings.TEST:
+    if settings.DEBUG:
         response_data = {"error": "Sorry, this feature is not available in development or test environment."}
         return Response(response_data)
 
@@ -2342,7 +2342,7 @@ def finish_submission_file_upload(request, challenge_phase_pk, submission_pk):
     Returns:
          Response Object -- An object containing the presignd url and submission id, or an error message if some failure occurs
     """
-    if settings.DEBUG or settings.TEST:
+    if settings.DEBUG:
         response_data = {"error": "Sorry, this feature is not available in development or test environment."}
         return Response(response_data)
 

--- a/settings/test.py
+++ b/settings/test.py
@@ -28,3 +28,5 @@ CACHES = {
 }
 
 TEST = True
+
+MEDIAFILES_LOCATION = "media"

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -18,7 +18,6 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import override_settings
 from django.utils import timezone
-import mock
 
 from allauth.account.models import EmailAddress
 from rest_framework import status
@@ -4393,7 +4392,6 @@ class GetAWSCredentialsForParticipantTeamTest(BaseChallengePhaseClass):
 class PresignedURLAnnotationTest(BaseChallengePhaseClass):
     def setUp(self):
         super(PresignedURLAnnotationTest, self).setUp()
-
 
     @mock.patch("challenges.utils.get_aws_credentials_for_challenge")
     def test_get_annotation_presigned_url(self, mock_get_aws_creds):

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -1,11 +1,15 @@
+import boto3
 import csv
 import io
 import json
+import mock
 import os
+import requests
 import responses
 import shutil
 
 from datetime import timedelta
+from moto import mock_s3
 from os.path import join
 
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -4383,3 +4387,114 @@ class GetAWSCredentialsForParticipantTeamTest(BaseChallengePhaseClass):
         self.assertTrue("AccessKeyId" in federated_user["Credentials"])
         self.assertTrue("SecretAccessKey" in federated_user["Credentials"])
         self.assertTrue("SessionToken" in federated_user["Credentials"])
+
+
+@mock_s3
+class PresignedURLAnnotationTest(BaseChallengePhaseClass):
+    def setUp(self):
+        super(PresignedURLAnnotationTest, self).setUp()
+
+
+    @mock.patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_get_annotation_presigned_url(self, mock_get_aws_creds):
+        self.url = reverse_lazy(
+            "challenges:get_annotation_file_presigned_url",
+            kwargs={
+                "challenge_phase_pk": self.challenge_phase.pk,
+            },
+        )
+
+        expected = {
+            "presigned_urls": [
+                {
+                    "partNumber": 1,
+                    "url": "https://test-bucket.s3.amazonaws.com/media/annotation_files/"
+                }
+            ]
+        }
+
+        self.client.force_authenticate(user=self.challenge_host.user)
+        mock_get_aws_creds.return_value = {
+            "AWS_ACCESS_KEY_ID": "dummy-key",
+            "AWS_SECRET_ACCESS_KEY": "dummy-access-key",
+            "AWS_STORAGE_BUCKET_NAME": "test-bucket",
+            "AWS_REGION": "us-east-1"
+        }
+        client = boto3.client('s3')
+        client.create_bucket(Bucket="test-bucket")
+
+        num_file_chunks = 1
+        response = self.client.post(
+            self.url,
+            data={"num_file_chunks": num_file_chunks, "file_name": "media/submissions/dummy.txt"}
+        )
+        self.assertEqual(len(response.data["presigned_urls"]), len(expected["presigned_urls"]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    @override_settings(MEDIA_ROOT="/tmp/evalai")
+    @mock.patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_finish_annotation_file_upload(self, mock_get_aws_creds):
+        # Create a annotation using multipart upload
+        self.url = reverse_lazy(
+            "challenges:get_annotation_file_presigned_url",
+            kwargs={
+                "challenge_phase_pk": self.challenge_phase.pk
+            }
+        )
+
+        self.client.force_authenticate(user=self.challenge_host.user)
+        mock_get_aws_creds.return_value = {
+            "AWS_ACCESS_KEY_ID": "dummy-key",
+            "AWS_SECRET_ACCESS_KEY": "dummy-access-key",
+            "AWS_STORAGE_BUCKET_NAME": "test-bucket",
+            "AWS_REGION": "us-east-1"
+        }
+        client = boto3.client('s3')
+        client.create_bucket(Bucket="test-bucket")
+
+        num_file_chunks = 1
+        response = self.client.post(
+            self.url,
+            data={"num_file_chunks": num_file_chunks, "file_name": "media/submissions/dummy.txt"}
+        )
+
+        expected = {
+            "upload_id": response.data["upload_id"],
+            "challenge_phase_pk": self.challenge_phase.pk
+        }
+
+        # Upload submission in parts to mocked S3 bucket
+        parts = []
+
+        presigned_url_object = response.data["presigned_urls"][0]
+        part = presigned_url_object["partNumber"]
+        url = presigned_url_object["url"]
+        file_data = self.challenge_phase.test_annotation.read()
+
+        response = requests.put(url, data=file_data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        etag = response.headers['ETag']
+        parts.append({"ETag": etag, "PartNumber": part})
+
+        # Finish multipart upload
+        self.url = reverse_lazy(
+            "challenges:finish_annotation_file_upload",
+            kwargs={
+                "challenge_phase_pk": self.challenge_phase.pk
+            },
+        )
+
+        response = self.client.post(
+            self.url,
+            data={
+                "parts": json.dumps(parts),
+                "upload_id": expected["upload_id"]
+            }
+        )
+        with open("cmp_1.txt", "w") as f:
+            f.write(json.dumps(response.data))
+
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -4493,8 +4493,6 @@ class PresignedURLAnnotationTest(BaseChallengePhaseClass):
                 "upload_id": expected["upload_id"]
             }
         )
-        with open("cmp_1.txt", "w") as f:
-            f.write(json.dumps(response.data))
 
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -2539,7 +2539,6 @@ class PresignedURLSubmissionTest(BaseAPITestClass):
     def setUp(self):
         super(PresignedURLSubmissionTest, self).setUp()
 
-
     @mock.patch("challenges.utils.get_aws_credentials_for_challenge")
     def test_get_submission_presigned_url(self, mock_get_aws_creds):
         self.url = reverse_lazy(
@@ -2576,7 +2575,6 @@ class PresignedURLSubmissionTest(BaseAPITestClass):
         self.assertEqual(len(response.data["presigned_urls"]), len(expected["presigned_urls"]))
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-
     @mock.patch("challenges.utils.get_aws_credentials_for_challenge")
     def test_finish_submission_file_upload(self, mock_get_aws_creds):
         # Create a submission using multipart upload
@@ -2608,9 +2606,8 @@ class PresignedURLSubmissionTest(BaseAPITestClass):
             "submission_pk": response.data["submission_pk"]
         }
 
-
         # Upload submission in parts to mocked S3 bucket
-        submission = Submission.objects.get(pk = expected["submission_pk"])
+        submission = Submission.objects.get(pk=expected["submission_pk"])
         parts = []
 
         presigned_url_object = response.data["presigned_urls"][0]

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -1,9 +1,13 @@
+import boto3
 import collections
 import json
+import mock
 import os
+import requests
 import shutil
 
 from datetime import timedelta
+from moto import mock_ecs, mock_s3
 
 from django.core.urlresolvers import reverse_lazy
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -2528,3 +2532,116 @@ class UpdateSubmissionTest(BaseAPITestClass):
         response = self.client.put(self.url, self.data)
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+@mock_s3
+class PresignedURLSubmissionTest(BaseAPITestClass):
+    def setUp(self):
+        super(PresignedURLSubmissionTest, self).setUp()
+
+
+    @mock.patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_get_submission_presigned_url(self, mock_get_aws_creds):
+        self.url = reverse_lazy(
+            "jobs:get_submission_file_presigned_url",
+            kwargs={
+                "challenge_phase_pk": self.challenge_phase.pk,
+            },
+        )
+
+        expected = {
+            "presigned_urls": [
+                {
+                    "partNumber": 1,
+                    "url": "https://test-bucket.s3.amazonaws.com/media/submission_files/"
+                }
+            ],
+            "submission_pk": Submission.objects.count() + 1
+        }
+
+        self.client.force_authenticate(user=self.challenge_host.user)
+        mock_get_aws_creds.return_value = {
+            "AWS_ACCESS_KEY_ID": "dummy-key",
+            "AWS_SECRET_ACCESS_KEY": "dummy-access-key",
+            "AWS_STORAGE_BUCKET_NAME": "test-bucket",
+            "AWS_REGION": "us-east-1"
+        }
+        client = boto3.client('s3')
+        client.create_bucket(Bucket="test-bucket")
+
+        num_file_chunks = 1
+        response = self.client.post(
+            self.url,
+            data={"status": "submitting", "num_file_chunks": num_file_chunks, "file_name": "media/submissions/dummy.txt"}
+        )
+        self.assertEqual(len(response.data["presigned_urls"]), len(expected["presigned_urls"]))
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+
+    @mock.patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_finish_submission_file_upload(self, mock_get_aws_creds):
+        # Create a submission using multipart upload
+        self.url = reverse_lazy(
+            "jobs:get_submission_file_presigned_url",
+            kwargs={
+                "challenge_phase_pk": self.challenge_phase.pk
+            }
+        )
+
+        self.client.force_authenticate(user=self.challenge_host.user)
+        mock_get_aws_creds.return_value = {
+            "AWS_ACCESS_KEY_ID": "dummy-key",
+            "AWS_SECRET_ACCESS_KEY": "dummy-access-key",
+            "AWS_STORAGE_BUCKET_NAME": "test-bucket",
+            "AWS_REGION": "us-east-1"
+        }
+        client = boto3.client('s3')
+        client.create_bucket(Bucket="test-bucket")
+
+        num_file_chunks = 1
+        response = self.client.post(
+            self.url,
+            data={"status": "submitting", "num_file_chunks": num_file_chunks, "file_name": "media/submissions/dummy.txt"}
+        )
+
+        expected = {
+            "upload_id": response.data["upload_id"],
+            "submission_pk": response.data["submission_pk"]
+        }
+
+
+        # Upload submission in parts to mocked S3 bucket
+        submission = Submission.objects.get(pk = expected["submission_pk"])
+        parts = []
+
+        presigned_url_object = response.data["presigned_urls"][0]
+        part = presigned_url_object["partNumber"]
+        url = presigned_url_object["url"]
+        file_data = submission.input_file.read()
+
+        response = requests.put(url, data=file_data)
+
+        self.assertEqual(response.status_code, 200)
+
+        etag = response.headers['ETag']
+        parts.append({"ETag": etag, "PartNumber": part})
+
+        # Finish multipart upload
+        self.url = reverse_lazy(
+            "jobs:finish_submission_file_upload",
+            kwargs={
+                "challenge_phase_pk": self.challenge_phase.pk,
+                "submission_pk": expected["submission_pk"]
+            },
+        )
+
+        response = self.client.post(
+            self.url,
+            data={
+                "parts": json.dumps(parts),
+                "upload_id": expected["upload_id"]
+            }
+        )
+
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -7,7 +7,7 @@ import requests
 import shutil
 
 from datetime import timedelta
-from moto import mock_ecs, mock_s3
+from moto import mock_s3
 
 from django.core.urlresolvers import reverse_lazy
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -2555,8 +2555,7 @@ class PresignedURLSubmissionTest(BaseAPITestClass):
                     "partNumber": 1,
                     "url": "https://test-bucket.s3.amazonaws.com/media/submission_files/"
                 }
-            ],
-            "submission_pk": Submission.objects.count() + 1
+            ]
         }
 
         self.client.force_authenticate(user=self.challenge_host.user)
@@ -2621,7 +2620,7 @@ class PresignedURLSubmissionTest(BaseAPITestClass):
 
         response = requests.put(url, data=file_data)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         etag = response.headers['ETag']
         parts.append({"ETag": etag, "PartNumber": part})


### PR DESCRIPTION
### Description

This PR

- [x] Add tests submission upload using multipart upload presigned URLs
- [x] Add tests annotation upload using multipart upload presigned URLs

Merge Evalai-cli [PR](https://github.com/Cloud-CV/evalai-cli/pull/294) too after this change because of request type change.
