### PR TITLE
FIX #2691: Update python from 3.6 to 3.7.5 for travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
   - xvfb
 python:
-  - "3.6"
+  - "3.7.5"
 cache:
   directories:
     - "$HOME/.cache/pip"


### PR DESCRIPTION
Solves Issue ##2691, for changing the python version in `.travis.yml` from `3.6` to `3.7.5`.
