### PR TITLE
[Frontend-v2] Changes in Challenge page

### DIFF
--- a/frontend_v2/src/app/components/challenge/challengeanalytics/challengeanalytics.component.html
+++ b/frontend_v2/src/app/components/challenge/challengeanalytics/challengeanalytics.component.html
@@ -34,8 +34,7 @@
               <span class="show-count fs-16 fw-light">
                 {{ totalChallengeTeams }}
               </span>
-              <br />
-              <a
+               <a
                 class="ev-btn btn-waves-effect waves-dark ev-btn-dark grad-btn-dark fw-light fs-14"
                 (click)="downloadChallengeParticipantTeams()"
                 >Download</a

--- a/frontend_v2/src/app/components/challenge/challengeanalytics/challengeanalytics.component.scss
+++ b/frontend_v2/src/app/components/challenge/challengeanalytics/challengeanalytics.component.scss
@@ -1,6 +1,6 @@
 .analytics-image {
   img {
-    width: 100%;
+    width: 70%;
   }
 }
 
@@ -12,6 +12,7 @@
 
 .ev-btn {
   padding: 8px 20px 8px 20px;
+  margin-left:10px;
   border-radius: 20px;
 }
 

--- a/frontend_v2/src/app/components/challenge/challengeanalytics/challengeanalytics.component.scss
+++ b/frontend_v2/src/app/components/challenge/challengeanalytics/challengeanalytics.component.scss
@@ -12,7 +12,7 @@
 
 .ev-btn {
   padding: 8px 20px 8px 20px;
-  margin-left:10px;
+  margin-left: 10px;
   border-radius: 20px;
 }
 

--- a/frontend_v2/src/app/components/challenge/challengediscuss/challengediscuss.component.html
+++ b/frontend_v2/src/app/components/challenge/challengediscuss/challengediscuss.component.html
@@ -4,7 +4,7 @@
       <div class="row row-lr-margin">
         <div class="col-sm-12 col-xs-12 col-lr-pad">
           <h5 class="fw-light">Discuss</h5>
-          <span class="fs-16"
+          <span class="discuss-intro fs-16"
             >Here you can discuss anything related to the <b>{{ challenge.title }}</b
             >. Get all the answers for your queries, discuss any new idea or get to know the host team and other
             participants at the discussion pannel.</span

--- a/frontend_v2/src/app/components/challenge/challengediscuss/challengediscuss.component.scss
+++ b/frontend_v2/src/app/components/challenge/challengediscuss/challengediscuss.component.scss
@@ -7,6 +7,6 @@
   border-radius: 20px;
 }
 
-.discuss-intro{
-	font-weight:300;
+.discuss-intro {
+  font-weight: 300;
 }

--- a/frontend_v2/src/app/components/challenge/challengediscuss/challengediscuss.component.scss
+++ b/frontend_v2/src/app/components/challenge/challengediscuss/challengediscuss.component.scss
@@ -6,3 +6,7 @@
   padding: 10px 30px 10px 30px;
   border-radius: 20px;
 }
+
+.discuss-intro{
+	font-weight:300;
+}

--- a/frontend_v2/src/app/components/challenge/challengesubmissions/challengesubmissions.component.html
+++ b/frontend_v2/src/app/components/challenge/challengesubmissions/challengesubmissions.component.html
@@ -139,11 +139,11 @@
                   <span class="fw-regular element-description"> {{ element.method_description }} </span>
                 </div>
                 <div class="element">
-                  <span class="element-description-attribution">Project Url</span>
+                  <span class="element-description-attribution">Project URL</span>
                   <span class="fw-regular element-description"> {{ element.project_url }} </span>
                 </div>
                 <div class="element">
-                  <span class="element-description-attribution">Publication Url</span>
+                  <span class="element-description-attribution">Publication URL</span>
                   <span class="fw-regular element-description"> {{ element.publication_url }} </span>
                 </div>
               </div>

--- a/frontend_v2/src/app/components/challenge/challengesubmissions/challengesubmissions.component.ts
+++ b/frontend_v2/src/app/components/challenge/challengesubmissions/challengesubmissions.component.ts
@@ -151,8 +151,9 @@ export class ChallengesubmissionsComponent implements OnInit, AfterViewInit {
    */
   apiCall: any;
 
-  columnsToDisplay = ['s_no', 'status', 'stderr_file', 'stdout_file', 'submission_result_file'];
-  columnsHeadings = ['S.No.', 'Status', 'Stderr File', 'Stdout File', 'Submission Result File'];
+  columnsToDisplay = ['s_no', 'status', 'submission_result_file', 'stdout_file', 'stderr_file'];
+  columnsHeadings = ['S.No.', 'Status', 'Result File', 'Stdout File', 'Stderr File', ];
+
 
   expandedElement: null;
 

--- a/frontend_v2/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.html
+++ b/frontend_v2/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.html
@@ -95,7 +95,6 @@
             >
               {{ element[column] }}</span
             >
-            <span *ngIf="column == 'execution_time'"> {{ element[column] }} sec </span>
             <a
               target="_blank"
               class="blue-text"

--- a/frontend_v2/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
+++ b/frontend_v2/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
@@ -153,7 +153,7 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
     'submitted_file',
     'submission_result_file',
   ];
-  columnsHeadings = ['S.No.', 'Team Name', 'Created By', 'Status', 'Execution Time', 'Submitted File', 'Result File'];
+  columnsHeadings = ['S.No.', 'Team Name', 'Created By', 'Status', 'Execution Time(sec)', 'Submitted File', 'Result File'];
 
   expandedElement: null;
 


### PR DESCRIPTION
1. My Submission Page 
- [x] Make Url → URL
- [x] Change of the order and names of main columns.

![Screenshot from 2020-11-08 01-42-21](https://user-images.githubusercontent.com/24366008/98450579-c6757f00-2163-11eb-9ba4-3ecfadca8519.png)

![Screenshot from 2020-11-08 01-42-00](https://user-images.githubusercontent.com/24366008/98450581-c83f4280-2163-11eb-9fa6-f89c41250ed7.png)

2. All Submission Page
- [x] Add sec in the heading rather than with every submission
- [x] Execution time is appearing once

![Screenshot from 2020-11-08 01-39-31](https://user-images.githubusercontent.com/24366008/98450580-c7a6ac00-2163-11eb-875c-a1b18043ee3a.png)

3. Analytics Page
- [x] The font-weight is 300.
- [x] The VQA logo is smaller on the Analytics Page
- [x] The Download button is in-front of Total Participant Teams. 

![Screenshot from 2020-11-08 01-40-57](https://user-images.githubusercontent.com/24366008/98450582-c8d7d900-2163-11eb-919c-b9495c40bb39.png)


