### PR TITLE
Revert "Upgrade to python 3.7.5"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
   - xvfb
 python:
-  - "3.7.5"
+  - "3.6"
 cache:
   directories:
     - "$HOME/.cache/pip"

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.5
+FROM python:3.6.5
 
 ENV PYTHONUNBUFFERED 1
 
@@ -6,6 +6,7 @@ RUN mkdir /code
 WORKDIR /code
 
 ADD requirements/* /code/
+
 RUN pip install -r dev.txt
 
 CMD ["./docker/wait-for-it.sh", "db:5432", "--", "sh", "/code/docker/dev/django/container-start.sh"]

--- a/docker/prod/django/Dockerfile
+++ b/docker/prod/django/Dockerfile
@@ -1,10 +1,9 @@
-FROM python:3.7.5
+FROM python:3.6.5
 
 ENV PYTHONUNBUFFERED 1
 
 RUN mkdir /code
 WORKDIR /code
-
 ADD requirements/* /code/
 RUN pip install -r prod.txt
 


### PR DESCRIPTION
Reverts Cloud-CV/EvalAI#3072

The uWSGI server isn't working well with the Postgres database for python3.7. Below is the screenshot of the error log --
![Screenshot 2020-11-09 at 11 41 18 PM](https://user-images.githubusercontent.com/12206047/98628713-352e1600-22e5-11eb-84d3-307b07f45528.png)

I googled and found that we will have to update a few more dependencies here --
- https://stackoverflow.com/questions/53498240/uwsgi-segmentation-fault-when-serving-a-django-application
- https://stackoverflow.com/questions/57124267/problem-with-running-django-with-nginx-and-uwsgi-in-ubuntu
cc: @Ram81 
 