### PR TITLE
Fix challenge notification email URLs

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -925,11 +925,11 @@ def restart_workers_signal_callback(sender, instance, field_name, **kwargs):
                 )
             )
         else:
-            challenge_url = "https://{}/web/challenges/challenge-page/{}".format(
-                settings.HOSTNAME, challenge.id
+            challenge_url = "{}/web/challenges/challenge-page/{}".format(
+                settings.EVALAI_API_SERVER, challenge.id
             )
-            challenge_manage_url = "https://{}/web/challenges/challenge-page/{}/manage".format(
-                settings.HOSTNAME, challenge.id
+            challenge_manage_url = "{}/web/challenges/challenge-page/{}/manage".format(
+                settings.EVALAI_API_SERVER, challenge.id
             )
 
             if field_name == "test_annotation":

--- a/apps/challenges/challenge_notification_util.py
+++ b/apps/challenges/challenge_notification_util.py
@@ -11,8 +11,8 @@ def construct_and_send_worker_start_mail(challenge):
     if settings.DEBUG:
         return
 
-    challenge_url = "https://{}/web/challenges/challenge-page/{}".format(
-        settings.HOSTNAME, challenge.pk
+    challenge_url = "{}/web/challenges/challenge-page/{}".format(
+        settings.EVALAI_API_SERVER, challenge.pk
     )
 
     template_data = {

--- a/apps/challenges/utils.py
+++ b/apps/challenges/utils.py
@@ -422,11 +422,11 @@ def get_challenge_template_data(challenge):
         Returns:
             template_data {dict} -- a dict for sendgrid email template data
     """
-    challenge_url = "https://{}/web/challenges/challenge-page/{}".format(
-        settings.HOSTNAME, challenge.id
+    challenge_url = "{}/web/challenges/challenge-page/{}".format(
+        settings.EVALAI_API_SERVER, challenge.id
     )
-    challenge_manage_url = "https://{}/web/challenges/challenge-page/{}/manage".format(
-        settings.HOSTNAME, challenge.id
+    challenge_manage_url = "{}/web/challenges/challenge-page/{}/manage".format(
+        settings.EVALAI_API_SERVER, challenge.id
     )
     template_data = {
         "CHALLENGE_NAME": challenge.title,

--- a/tests/unit/challenges/test_challenge_notification_util.py
+++ b/tests/unit/challenges/test_challenge_notification_util.py
@@ -92,7 +92,7 @@ class TestChallengeStartNotifier(BaseTestClass):
     @mock.patch("challenges.challenge_notification_util.send_email")
     @mock.patch("challenges.aws_utils.start_workers")
     def test_feature(self, mock_start_workers, mock_send_email):
-        challenge_url = "https://{}/web/challenges/challenge-page/{}".format(settings.HOSTNAME, self.challenge.id)
+        challenge_url = "{}/web/challenges/challenge-page/{}".format(settings.EVALAI_API_SERVER, self.challenge.id)
         host_emails = [self.user.email]
         template_id = settings.SENDGRID_SETTINGS.get("TEMPLATES").get("CHALLENGE_APPROVAL_EMAIL")
         template_data = {"CHALLENGE_NAME": self.challenge.title, "CHALLENGE_URL": challenge_url}


### PR DESCRIPTION
### Description

This PR adds

- [x] Use `EVALAI_API_SERVER` for notification email URLs