### PR TITLE
BugFix: Container monitoring script

### DIFF
--- a/scripts/monitoring/monitor_containers.py
+++ b/scripts/monitoring/monitor_containers.py
@@ -126,9 +126,10 @@ def check_container_status():
 
         if len(failed_containers) > 0:
             notify(failed_containers)
-    except:
+    except Exception:
         message = "{} environment:\n\n Docker client is down\n\n".format(get_environment())
         send_slack_notification(message)
+
 
 if __name__ == "__main__":
     check_container_status()

--- a/scripts/monitoring/monitor_containers.py
+++ b/scripts/monitoring/monitor_containers.py
@@ -111,21 +111,24 @@ def check_container_status():
         send_slack_notification(message)
         return
 
-    # Containers to check status for
-    container_status_map = get_container_status(docker_client)
-    if len(container_status_map.keys()) == 0:
-        message = "{} environment:\n\n No docker container is running\n\n".format(get_environment())
+    try:
+        # Containers to check status for
+        container_status_map = get_container_status(docker_client)
+        if len(container_status_map.keys()) == 0:
+            message = "{} environment:\n\n No docker container is running\n\n".format(get_environment())
+            send_slack_notification(message)
+            return
+
+        failed_containers = []
+        for container, is_running in container_status_map.items():
+            if not is_running:
+                failed_containers.append(container)
+
+        if len(failed_containers) > 0:
+            notify(failed_containers)
+    except:
+        message = "{} environment:\n\n Docker client is down\n\n".format(get_environment())
         send_slack_notification(message)
-        return
-
-    failed_containers = []
-    for container, is_running in container_status_map.items():
-        if not is_running:
-            failed_containers.append(container)
-
-    if len(failed_containers) > 0:
-        notify(failed_containers)
-
 
 if __name__ == "__main__":
     check_container_status()

--- a/scripts/monitoring/run_monitor_containers.sh
+++ b/scripts/monitoring/run_monitor_containers.sh
@@ -4,4 +4,8 @@ if [ ! -z "$1" ]
   then
     path=$1
 fi
+
+# crontab doesn't have access to env variable, define explicitly
+export MONITORING_SLACK_WEBHOOK_URL=x;
+
 python ${path}/scripts/monitoring/monitor_containers.py


### PR DESCRIPTION
### Description

This PR adds -

- [x] Add `MONITORING_SLACK_WEBHOOK_URL` env variable explicitly in `run_monitor_containers.sh` for crontab to be able to access it. Crontab is not able to get env variables from bash_profile and bashrc
- [x] Fix exception handling for case when docker client is down