### PR TITLE
Revert boto3 version to old one

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,6 +1,6 @@
 asgi-redis==1.4.3
-boto3==1.16.28
-botocore==1.19.28
+boto3==1.13.16
+botocore==1.16.16
 vine==1.3.0
 celery[sqs]==4.3.0
 commonmark==0.9.1


### PR DESCRIPTION
This PR --
- [x] Reverts the boto3 version to `1.13.16` and botocore version to `1.16.16` due to the following error -- 
![image](https://user-images.githubusercontent.com/12206047/102549058-87ebb200-4089-11eb-80aa-99b2398d3c03.png)
cc: @Ram81 