### PR TITLE
Add challenge phase split ID to search in admin

### DIFF
--- a/apps/challenges/admin.py
+++ b/apps/challenges/admin.py
@@ -263,6 +263,7 @@ class ChallengePhaseSplitAdmin(ImportExportTimeStampedAdmin):
     )
     list_filter = ("dataset_split", "leaderboard", "visibility")
     search_fields = (
+        "id",
         "challenge_phase__name",
         "dataset_split__name",
         "leaderboard__id",


### PR DESCRIPTION
This PR --
- [x] Add `ID` to search in the Django admin for `challenge phase split`.