### PR TITLE
Pass slack webhook url as param to deployment monitoring script 

### DIFF
--- a/scripts/monitoring/run_monitor_containers.sh
+++ b/scripts/monitoring/run_monitor_containers.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 path=$PWD
+webhook_url=''
 if [ ! -z "$1" ]
   then
     path=$1
 fi
 
+if [ ! -z "$2" ]
+  then
+    webhook_url=$2
+fi
+
 # crontab doesn't have access to env variable, define explicitly
-export MONITORING_SLACK_WEBHOOK_URL=x;
+export MONITORING_SLACK_WEBHOOK_URL=${webhook_url};
 
 python ${path}/scripts/monitoring/monitor_containers.py


### PR DESCRIPTION
### Description

This PR adds `MONITORING_SLACK_WEBHOOK_URL` as a bash script param instead of hardcoding it in staging and production environment scripts.