### PR TITLE
Fix HTTP protocol for beta EvalAI versions

### DIFF
--- a/settings/prod.py
+++ b/settings/prod.py
@@ -15,7 +15,7 @@ CORS_ORIGIN_ALLOW_ALL = False
 CORS_ORIGIN_WHITELIST = (
     "https://evalai.s3.amazonaws.com",
     "https://eval.ai",
-    "https://beta.eval.ai:9999",
+    "http://beta.eval.ai:9999",
 )
 
 DATABASES = {

--- a/settings/staging.py
+++ b/settings/staging.py
@@ -7,5 +7,5 @@ CORS_ORIGIN_ALLOW_ALL = False
 CORS_ORIGIN_WHITELIST = (
     "https://staging-evalai.s3.amazonaws.com",
     "https://staging.eval.ai",
-    "https://beta-staging.eval.ai:9999",
+    "http://beta-staging.eval.ai:9999",
 )


### PR DESCRIPTION
This PR --
- [x] Covert `https` protocol to `http` protocol for beta EvalAI version in `CORS_ORIGIN_WHITELIST`.