### PR TITLE
BugFix: SES Env variable values in task def

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -193,8 +193,8 @@ task_definition = """
                   "value": "{SENTRY_URL}"
                 }},
                 {{
-                    "name": "AWS_SES_REGION_NAME"
-                    "value": "{AWS_SES_REGION_ENDPOINT}"
+                    "name": "AWS_SES_REGION_NAME",
+                    "value": "{AWS_SES_REGION_NAME}"
                 }},
                 {{
                     "name": "AWS_SES_REGION_ENDPOINT",


### PR DESCRIPTION
### Description

Fix syntax error in `AWS_SES_REGION_NAME` env variable declaration task definition.