### PR TITLE
Add searching by id field and add `raw_id_fields` for foreign keys

### DIFF
--- a/apps/challenges/admin.py
+++ b/apps/challenges/admin.py
@@ -69,6 +69,7 @@ class ChallengeAdmin(ImportExportTimeStampedAdmin):
         "end_date",
     )
     search_fields = (
+        "id",
         "title",
         "creator__team_name",
         "slug",
@@ -222,7 +223,7 @@ class ChallengeConfigurationAdmin(ImportExportTimeStampedAdmin):
         "zip_configuration",
     )
     list_filter = ("is_created", "created_at")
-    search_fields = ("challenge__title",)
+    search_fields = ("id", "challenge__title")
 
 
 @admin.register(ChallengePhase)
@@ -251,6 +252,7 @@ class ChallengePhaseAdmin(ImportExportTimeStampedAdmin):
 
 @admin.register(ChallengePhaseSplit)
 class ChallengePhaseSplitAdmin(ImportExportTimeStampedAdmin):
+    raw_id_fields = ["challenge_phase", "leaderboard", "dataset_split"]
     list_display = (
         "id",
         "get_challenge",
@@ -261,7 +263,7 @@ class ChallengePhaseSplitAdmin(ImportExportTimeStampedAdmin):
         "leaderboard_decimal_precision",
         "is_leaderboard_order_descending",
     )
-    list_filter = ("dataset_split", "leaderboard", "visibility")
+    list_filter = ("visibility",)
     search_fields = (
         "id",
         "challenge_phase__name",
@@ -290,20 +292,27 @@ class ChallengeTemplate(ImportExportTimeStampedAdmin):
         "splits",
     )
     list_filter = ("title", "dataset", "phases", "splits", "eval_metrics")
-    search_fields = ("title", "dataset", "phases", "splits", "eval_metrics")
+    search_fields = (
+        "id",
+        "title",
+        "dataset",
+        "phases",
+        "splits",
+        "eval_metrics",
+    )
 
 
 @admin.register(DatasetSplit)
 class DatasetSplitAdmin(ImportExportTimeStampedAdmin):
     list_display = ("name", "codename")
     list_filter = ("name", "codename")
-    search_fields = ("name", "codename")
+    search_fields = ("id", "name", "codename")
 
 
 @admin.register(Leaderboard)
 class LeaderboardAdmin(ImportExportTimeStampedAdmin):
     list_display = ("id", "schema")
-    search_fields = ("schema",)
+    search_fields = ("id", "schema")
 
 
 @admin.register(LeaderboardData)
@@ -318,6 +327,7 @@ class LeaderboardDataAdmin(ImportExportTimeStampedAdmin):
     )
     list_filter = ("challenge_phase_split", "created_at", "modified_at")
     search_fields = (
+        "id",
         "challenge_phase_split__challenge_phase__name",
         "submission__participant_team__team_name",
         "leaderboard__schema",
@@ -336,7 +346,7 @@ class LeaderboardDataAdmin(ImportExportTimeStampedAdmin):
 class StarChallengeAdmin(ImportExportTimeStampedAdmin):
     list_display = ("user", "challenge", "is_starred")
     list_filter = ("is_starred",)
-    search_fields = ("user__username", "challenge__title")
+    search_fields = ("id", "user__username", "challenge__title")
 
 
 @admin.register(UserInvitation)
@@ -382,7 +392,7 @@ class ChallengeEvaluationClusterAdmin(ImportExportTimeStampedAdmin):
     readonly_fields = ("created_at",)
     list_display = ("id", "name", "cluster_yaml", "kube_config")
     list_filter = ("name",)
-    search_fields = ("name",)
+    search_fields = ("id", "name")
 
 
 @admin.register(PWCChallengeLeaderboard)
@@ -397,9 +407,10 @@ class PWCChallengeLeaderboardAdmin(ImportExportTimeStampedAdmin):
         "area",
         "task",
         "dataset",
+        "enable_sync",
     )
-    list_filter = ("area",)
-    search_fields = ("area", "task", "dataset")
+    list_filter = ("area", "enable_sync")
+    search_fields = ("id", "area", "task", "dataset")
 
     def get_challenge_phase_split_id(self, obj):
         """Return challenge phase split id for a challenge phase and split"""

--- a/apps/hosts/admin.py
+++ b/apps/hosts/admin.py
@@ -7,12 +7,14 @@ from .models import ChallengeHost, ChallengeHostTeam
 
 @admin.register(ChallengeHostTeam)
 class ChallengeHostTeamModelAdmin(ImportExportTimeStampedAdmin):
+    raw_id_fields = ["created_by"]
     list_display = ("id", "team_name", "created_by", "team_url")
-    search_fields = ("team_name", "created_by__username")
+    search_fields = ("id", "team_name", "created_by__username")
 
 
 @admin.register(ChallengeHost)
 class ChallengeHostAdmin(ImportExportTimeStampedAdmin):
-    list_display = ("user", "team_name", "status", "permissions")
+    raw_id_fields = ["user", "team_name"]
+    list_display = ("id", "user", "team_name", "status", "permissions")
     list_filter = ("status", "permissions")
-    search_fields = ("user__username", "team_name__team_name")
+    search_fields = ("id", "user__username", "team_name__team_name")

--- a/apps/participants/admin.py
+++ b/apps/participants/admin.py
@@ -20,8 +20,9 @@ class ParticipantAdmin(ImportExportTimeStampedAdmin):
     interface to display user and team status.
     """
 
-    list_display = ("user", "status", "team")
-    search_fields = ("user__username", "status", "team__team_name")
+    raw_id_fields = ["user", "team"]
+    list_display = ("id", "user", "status", "team")
+    search_fields = ("id", "user__username", "status", "team__team_name")
     list_filter = ("status",)
     resource_class = ParticipantResource
 
@@ -33,5 +34,11 @@ class ParticipantTeamAdmin(ImportExportTimeStampedAdmin):
     and filter team names.
     """
 
-    list_display = ("team_name", "get_all_participants_email", "team_url")
-    search_fields = ("team_name", "team_url", "created_by__username")
+    raw_id_fields = ["created_by"]
+    list_display = (
+        "id",
+        "team_name",
+        "get_all_participants_email",
+        "team_url",
+    )
+    search_fields = ("id", "team_name", "team_url", "created_by__username")


### PR DESCRIPTION
This PR --
- [x] Add `enable_sync` to be displayed in the admin for PWCChallengeLeaderboard table.
- [x] Add filtering by `id` in the admin.
- [x] Add `raw_id_fields` for foreign key in Django admin.