### PR TITLE
Enable ssh agent on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_cache:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - coveralls --rcfile=.coveragerc
+  - eval "$(ssh-agent -s)"
   - openssl aes-256-cbc -K $encrypted_77d2d82026f6_key -iv $encrypted_77d2d82026f6_iv
     -in scripts/deployment/evalai.pem.enc -out scripts/deployment/evalai.pem -d || true
   - './scripts/deployment/push.sh'


### PR DESCRIPTION
### Description

To run ssh-agent forwarding for deployment in new setup we have to use `ssh-add` to add evalai secret key to ssh agent. Travis doesn't run ssh agent by default. This PR explicitly starts ssh agent before triggering deployment