### PR TITLE
BugFix: Monitoring script production message sent as staging

### DIFF
--- a/scripts/monitoring/run_monitor_containers.sh
+++ b/scripts/monitoring/run_monitor_containers.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 path=$PWD
 webhook_url=''
+env='staging'
 if [ ! -z "$1" ]
   then
     path=$1
@@ -11,7 +12,13 @@ if [ ! -z "$2" ]
     webhook_url=$2
 fi
 
+if [ ! -z "$3" ]
+  then
+    env=$3
+fi
+
 # crontab doesn't have access to env variable, define explicitly
 export MONITORING_SLACK_WEBHOOK_URL=${webhook_url};
+export ENV=${env};
 
 python ${path}/scripts/monitoring/monitor_containers.py


### PR DESCRIPTION
### Description

This PR passes `ENV` as a parameter to the container monitoring script because crontab doesn't have access to env variables declared in `docker_env` files. This changes fixes monitoring error messages for production instance. Currently they are being sent as `Staging environment` instead of `Production environment`