### PR TITLE
Fix #3123 - Shifting from 'django-rest-auth' to 'dj-rest-auth'

### DIFF
--- a/evalai/urls.py
+++ b/evalai/urls.py
@@ -52,13 +52,13 @@ urlpatterns = [
         obtain_expiring_auth_token,
         name="obtain_expiring_auth_token",
     ),
-    url(r"^api/auth/", include("rest_auth.urls")),
+    url(r"^api/auth/", include("dj_rest_auth.urls")),
     url(
         r"^api/auth/registration/account-confirm-email/(?P<key>[-:\w]+)/$",  # noqa
         ConfirmEmailView.as_view(),
         name="account_confirm_email",
     ),
-    url(r"^api/auth/registration/", include("rest_auth.registration.urls")),
+    url(r"^api/auth/registration/", include("dj_rest_auth.registration.urls")),
     url(
         r"^auth/api/password/reset/confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})$",  # noqa
         TemplateView.as_view(template_name="password_reset_confirm.html"),

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -12,6 +12,7 @@ djangorestframework==3.10.3
 djangorestframework-expiring-authtoken==0.1.4
 django-cors-headers==3.5.0
 django-rest-auth[with_social]==0.9.5
+dj-rest-auth[with_social]==2.1.3
 django-ses==1.0.3
 docker-compose==1.27.4
 drfdocs==0.0.11

--- a/settings/common.py
+++ b/settings/common.py
@@ -67,13 +67,13 @@ THIRD_PARTY_APPS = [
     "corsheaders",
     "django_ses",
     "import_export",
-    "rest_auth",
-    "rest_auth.registration",
     "rest_framework.authtoken",
     "rest_framework",
     "rest_framework_expiring_authtoken",
     "drf_yasg",
     "django_filters",
+    "dj_rest_auth",
+    "dj_rest_auth.registration",
 ]
 
 INSTALLED_APPS = DEFAULT_APPS + OUR_APPS + THIRD_PARTY_APPS


### PR DESCRIPTION
* This PR fixes #3123 issue, Shifting from `django-rest-auth` to `dj-rest-auth`.
