### PR TITLE
Fix #2994: Handle exception when submission is not found

### DIFF
--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -1445,7 +1445,7 @@ def update_partially_evaluated_submission(request, challenge_pk):
             submission = get_submission_model(submission_pk)
         except NotFound:
             response_data = {
-                "error": "Submission does not exist with submission_id {}".format(
+                "error": "Submission with submission_pk {} does not exist".format(
                     submission_pk
                 )
             }
@@ -1601,7 +1601,7 @@ def update_partially_evaluated_submission(request, challenge_pk):
             submission = get_submission_model(submission_pk)
         except NotFound:
             response_data = {
-                "error": "Submission does not exist with submission_id {}".format(
+                "error": "Submission with submission_pk {} does not exist".format(
                     submission_pk
                 )
             }


### PR DESCRIPTION
Handle exception when `get_model_object` throws an error in `update_partially_evaluated_submission` API when submission is not found for given submission_id
