### PR TITLE
Fix failing travis build on PR's due to encrypted variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - pip install awscli==1.18.66 flake8==3.8.2
 script:
   - flake8 ./ || travis_terminate 1;
-  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || travis_terminate 1;
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || travis_terminate 1; fi'
   - docker-compose build || travis_terminate 1;
   - docker-compose run nodejs bash -c "gulp dev && karma start --single-run && gulp staging" || travis_terminate 1;
   - docker-compose run -e DJANGO_SETTINGS_MODULE=settings.test django pytest --cov . --cov-config .coveragerc || travis_terminate 1;


### PR DESCRIPTION
This PR --
- [x] Fixes failing Travis build on PR's due to encrypted variables.

Resources --
- https://docs.travis-ci.com/user/pull-requests#pull-requests-and-security-restrictions
- https://github.com/travis-ci/travis-ci/issues/5470#issuecomment-445786898
