### PR TITLE
Fix ChallengeEvaluationCluster model get call and add fields in serializer

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -1205,7 +1205,7 @@ def setup_eks_cluster(challenge):
         return response
     try:
         challenge_evaluation_cluster = ChallengeEvaluationCluster.objects.get(
-            challenge_obj
+            challenge=challenge_obj
         )
         serializer = ChallengeEvaluationClusterSerializer(
             challenge_evaluation_cluster,

--- a/apps/challenges/serializers.py
+++ b/apps/challenges/serializers.py
@@ -408,6 +408,15 @@ class ChallengeEvaluationClusterSerializer(serializers.ModelSerializer):
             "cluster_ssl",
             "cluster_yaml",
             "kube_config",
+            "eks_arn_role",
+            "node_group_arn_role",
+            "ecr_all_access_policy_arn",
+            "vpc_id",
+            "subnet_1_id",
+            "subnet_2_id",
+            "security_group_id",
+            "internet_gateway_id",
+            "route_table_id",
         )
 
 


### PR DESCRIPTION
### Description

This PR -

- [x] Fix `.get` call for `ChallengeEvaluationCluster` in `setup_eks_cluster`
- [x] Add subnet and arn fields to `ChallengeEvaluationClusterSerializer`