### PR TITLE
Add auth check in participant team GET api

### DIFF
--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -131,6 +131,14 @@ def participant_team_detail(request, pk):
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     if request.method == "GET":
+        if not is_user_part_of_participant_team(
+            request.user, participant_team
+        ):
+            response_data = {
+                "error": "You are not a authorized to change team details!"
+            }
+            return Response(response_data, status=status.HTTP_403_FORBIDDEN)
+
         serializer = ParticipantTeamDetailSerializer(participant_team)
         response_data = serializer.data
         return Response(response_data, status=status.HTTP_200_OK)

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -135,7 +135,7 @@ def participant_team_detail(request, pk):
             request.user, participant_team
         ):
             response_data = {
-                "error": "You are not a authorized to change team details!"
+                "error": "Sorry, You are not authorized to view team details."
             }
             return Response(response_data, status=status.HTTP_403_FORBIDDEN)
 


### PR DESCRIPTION
### Description


This PR

- [x] Adds a check to make sure only users who are participant of the team can make `GET` api call to fetch team details