### PR TITLE
BugFix: Fix AWS_DEFAULT_REGION env variable in task definition

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -94,7 +94,7 @@ task_definition = """
             "environment": [
                 {{
                   "name": "AWS_DEFAULT_REGION",
-                  "value": "{AWS_DEFAULT_REGION}"
+                  "value": "{AWS_REGION}"
                 }},
                 {{
                   "name": "AWS_ACCOUNT_ID",
@@ -231,7 +231,7 @@ task_definition_code_upload_worker = """
             "environment": [
                 {{
                   "name": "AWS_DEFAULT_REGION",
-                  "value": "{AWS_DEFAULT_REGION}"
+                  "value": "{AWS_REGION}"
                 }},
                 {{
                   "name": "AWS_ACCESS_KEY_ID",


### PR DESCRIPTION
### Description

Pass `AWS_REGION` variable to task definition returned by `get_aws_credentials_for_challenge`.