### PR TITLE
Add stderr utf encoding in submission worker

### DIFF
--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -604,7 +604,7 @@ def run_submission(
         submission.stdout_file.save("stdout.txt", ContentFile(stdout_content))
     if submission_status is Submission.FAILED:
         with open(stderr_file, "r") as stderr:
-            stderr_content = stderr.read()
+            stderr_content = stderr.read().encode("utf-8")
             submission.stderr_file.save(
                 "stderr.txt", ContentFile(stderr_content)
             )


### PR DESCRIPTION
### Description

Fix for following error

```
2021-01-29T21:49:25.599+05:30	"stderr.txt", ContentFile(stderr_content)
2021-01-29T21:49:25.599+05:30	File "/usr/local/lib/python3.7/site-packages/django/db/models/fields/files.py", line 87, in save
2021-01-29T21:49:25.599+05:30	self.name = self.storage.save(name, content, max_length=self.field.max_length)
2021-01-29T21:49:25.599+05:30	File "/usr/local/lib/python3.7/site-packages/django/core/files/storage.py", line 52, in save
2021-01-29T21:49:25.599+05:30	return self._save(name, content)
2021-01-29T21:49:25.599+05:30	File "/usr/local/lib/python3.7/site-packages/storages/backends/s3boto.py", line 433, in _save
2021-01-29T21:49:25.599+05:30	self._save_content(key, content, headers=headers)
2021-01-29T21:49:25.599+05:30	File "/usr/local/lib/python3.7/site-packages/storages/backends/s3boto.py", line 444, in _save_content
2021-01-29T21:49:25.599+05:30	rewind=True, **kwargs)
2021-01-29T21:49:25.599+05:30	File "/usr/local/lib/python3.7/site-packages/boto/s3/key.py", line 1309, in set_contents_from_file
2021-01-29T21:49:25.599+05:30	chunked_transfer=chunked_transfer, size=size)
2021-01-29T21:49:25.599+05:30	File "/usr/local/lib/python3.7/site-packages/boto/s3/key.py", line 762, in send_file
2021-01-29T21:49:25.599+05:30	chunked_transfer=chunked_transfer, size=size)
2021-01-29T21:49:25.599+05:30	File "/usr/local/lib/python3.7/site-packages/boto/s3/key.py", line 963, in _send_file_internal
2021-01-29T21:49:25.599+05:30	query_args=query_args
2021-01-29T21:49:25.599+05:30	File "/usr/local/lib/python3.7/site-packages/boto/s3/connection.py", line 671, in make_request
2021-01-29T21:49:25.599+05:30	retry_handler=retry_handler
2021-01-29T21:49:25.599+05:30	File "/usr/local/lib/python3.7/site-packages/boto/connection.py", line 1071, in make_request
2021-01-29T21:49:25.599+05:30	retry_handler=retry_handler)
2021-01-29T21:49:25.599+05:30	File "/usr/local/lib/python3.7/site-packages/boto/connection.py", line 940, in _mexe
2021-01-29T21:49:25.599+05:30	request.body, request.headers)
2021-01-29T21:49:25.599+05:30	File "/usr/local/lib/python3.7/site-packages/boto/s3/key.py", line 896, in sender
2021-01-29T21:49:25.599+05:30	response.status, response.reason, body)
2021-01-29T21:49:25.599+05:30	boto.exception.S3ResponseError: S3ResponseError: 400 Bad Request
2021-01-29T21:49:25.599+05:30	<?xml version="1.0" encoding="UTF-8"?>
2021-01-29T21:49:25.599+05:30	<Error><Code>BadDigest</Code><Message>The Content-MD5 you 
```

[Reference](https://github.com/boto/boto/issues/2868#issuecomment-230083574)

