### PR TITLE
Remove shadow from view meta attributes button

### DIFF
--- a/frontend/src/views/web/challenge/leaderboard.html
+++ b/frontend/src/views/web/challenge/leaderboard.html
@@ -140,7 +140,7 @@
                             <td>{{ key.submission__submitted_at | number: 0}}&nbsp;{{key.timeSpan}} ago
                             </td>
                             <td ng-if="challenge.showSubmissionMetaAttributesOnLeaderboard">
-                                <button class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-14" ng-disabled="key.submission__submission_metadata == undefined || key.submission__submission_metadata == null;" type="submit" value="view" ng-click="challenge.showMetaAttributesDialog($event, key.submission__submission_metadata);">View</button>
+                                <button class="btn ev-btn-dark waves-effect waves-dark grad-btn fs-14" ng-disabled="key.submission__submission_metadata == undefined || key.submission__submission_metadata == null;" type="submit" value="view" ng-click="challenge.showMetaAttributesDialog($event, key.submission__submission_metadata);">View</button>
                             </td>
                         </tr>
                     </tbody>


### PR DESCRIPTION
### Description

This PR -

- [x] Removes shadow from `View` submission meta attributes button on leaderboard page.


<img width="1440" alt="Screen Shot 2021-01-31 at 11 06 37 PM" src="https://user-images.githubusercontent.com/16323427/106392733-2608c100-6419-11eb-9452-0b1890b09126.png">
