### PR TITLE
Backend: Fix bug for not parsing "#" in all_submissions_download

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -1793,7 +1793,6 @@ def download_all_submissions(
                 )
                 # Issue: "#" isn't parsed by writer.writerow(), hence it is replaced by "-"
                 # TODO: Find a better way to solve the above issue.
-                conversion = set("#")
                 for submission in submissions.data:
                     writer.writerow(
                         [
@@ -1828,8 +1827,8 @@ def download_all_submissions(
                             submission["created_at"],
                             submission["submission_result_file"],
                             submission["submission_metadata_file"],
-                            "".join("-" if c in conversion else c for c in submission["method_name"]),
-                            "".join("-" if c in conversion else c for c in submission["method_description"]),
+                            submission["method_name"].replace("#", "-"),
+                            submission["method_description"].replace("#", "-"),
                             submission["publication_url"],
                             submission["project_url"],
                         ]

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -1765,9 +1765,7 @@ def download_all_submissions(
                     submissions, many=True, context={"request": request}
                 )
                 response = HttpResponse(content_type="text/csv")
-                response[
-                    "Content-Disposition"
-                ] = "attachment; filename=all_submissions.csv"
+                response["Content-Disposition"] = "attachment; filename=all_submissions.csv"
                 writer = csv.writer(response)
                 writer.writerow(
                     [
@@ -1793,6 +1791,9 @@ def download_all_submissions(
                         "Project URL",
                     ]
                 )
+                # Issue: "#" isn't parsed by writer.writerow(), hence it is replaced by "-"
+                # TODO: Find a better way to solve the above issue.
+                conversion = set("#")
                 for submission in submissions.data:
                     writer.writerow(
                         [
@@ -1827,8 +1828,8 @@ def download_all_submissions(
                             submission["created_at"],
                             submission["submission_result_file"],
                             submission["submission_metadata_file"],
-                            submission["method_name"],
-                            submission["method_description"],
+                            "".join("-" if c in conversion else c for c in submission["method_name"]),
+                            "".join("-" if c in conversion else c for c in submission["method_description"]),
                             submission["publication_url"],
                             submission["project_url"],
                         ]

--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -604,7 +604,7 @@ def run_submission(
         submission.stdout_file.save("stdout.txt", ContentFile(stdout_content))
     if submission_status is Submission.FAILED:
         with open(stderr_file, "r") as stderr:
-            stderr_content = stderr.read()
+            stderr_content = stderr.read().encode("utf-8")
             submission.stderr_file.save(
                 "stderr.txt", ContentFile(stderr_content)
             )


### PR DESCRIPTION
This PR --
- [x] "#" isn't parsed by writer.writerow(), hence it is replaced by "-" in the `method description` and `method name` fields.
