### PR TITLE
Add 120 second delay in cilium network policy installation

### DIFF
--- a/scripts/workers/code_upload_worker_utils/install_dependencies.sh
+++ b/scripts/workers/code_upload_worker_utils/install_dependencies.sh
@@ -36,6 +36,11 @@ echo "### Container Insights Installed"
 kubectl create -f https://raw.githubusercontent.com/cilium/cilium/v1.9/install/kubernetes/quick-install.yaml
 echo "### Cilium Installed"
 
+sleep 120s;
+
+# Apply network policies
+kubectl apply -f /code/scripts/workers/code_upload_worker_utils/network_policies.yaml
+
 # Set ssl-certificate
 echo $CERTIFICATE | base64 --decode > scripts/workers/certificate.crt
 


### PR DESCRIPTION
### Description

This PR adds - 

- [x] Cilium installation setup to block traffic on code upload worker job pods.
- [x] 120 second delay between cilium operator install and network policy install