### PR TITLE
[BugFix] Replace matchName with matchPattern in network policy

### DIFF
--- a/scripts/workers/code_upload_worker_utils/network_policies.yaml
+++ b/scripts/workers/code_upload_worker_utils/network_policies.yaml
@@ -8,7 +8,7 @@ spec:
       {}
   egress:
   - toFQDNs:
-    - matchName: "*.eval.ai"
+    - matchPattern: "*.eval.ai"
   - toEndpoints:
     - matchLabels:
         "k8s:io.kubernetes.pod.namespace": kube-system


### PR DESCRIPTION
### Description

Bugfix, in cilium network policy to whitelist traffic only from `eval.ai` we need to use `matchPattern` instead of `matchName` when passing a regex.