### PR TITLE
Frontend: Disable the start/stop/restart buttons avoiding multiple api calls.

### DIFF
--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -10,6 +10,7 @@
 
     function ChallengeCtrl(utilities, loaderService, $scope, $state, $http, $stateParams, $rootScope, $interval, $mdDialog, moment, $location, $anchorScroll, $timeout) {
         var vm = this;
+        vm.disableWorkerButtons = false;
         vm.areSubmissionsFailing = false;
         vm.getAllEntriesTestOption = "Include private submissions";
         vm.showPrivateIds = [];
@@ -150,11 +151,13 @@
         // API call to manage the worker from UI.
         // Response data will be like: {action: "Success" or "Failure", error: <String to include only if action is Failure.>}
         vm.manageWorker = function(action){
+            if (action == "start" || action == "restart") vm.disableWorkerButtons = true;
             parameters.url = 'challenges/' + vm.challengeId + '/manage_worker/' + action +'/';
             parameters.method = 'PUT';
             parameters.data = {};
             parameters.callback = {
                 onSuccess: function(response) {
+                    vm.disableWorkerButtons = false;
                     var details = response.data;
                     if (details.action == "Success"){
                         $rootScope.notify("success", "Worker(s) " + action + "ed succesfully.");
@@ -164,6 +167,7 @@
                     }
                 },
                 onError: function(response) {
+                    vm.disableWorkerButtons = false;
                     var error = response.data.error;
                     if (error == undefined){
                         $rootScope.notify("error", "There was an error.");

--- a/frontend/src/views/web/challenge/manage.html
+++ b/frontend/src/views/web/challenge/manage.html
@@ -7,9 +7,9 @@
         </div>
         <div class="row margin-bottom-cancel">
             <div class="col s12">
-                <button class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-14" ng-click="challenge.manageWorker('start');"><i class="fa fa-play"></i> Start worker</button>
-                <button class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-14" ng-click="challenge.manageWorker('stop');"><i class="fa fa-stop"></i> Stop worker</button>
-                <button class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-14" ng-click="challenge.manageWorker('restart');"><i class="fa fa-refresh"></i> Restart worker</button>
+                <button class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-14" ng-disabled="challenge.disableWorkerButtons" ng-click="challenge.manageWorker('start');"><i class="fa fa-play"></i> Start worker</button>
+                <button class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-14" ng-disabled="challenge.disableWorkerButtons" ng-click="challenge.manageWorker('stop');"><i class="fa fa-stop"></i> Stop worker</button>
+                <button class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-14" ng-disabled="challenge.disableWorkerButtons" ng-click="challenge.manageWorker('restart');"><i class="fa fa-refresh"></i> Restart worker</button>
             </div>
         </div>
         <div class="row margin-bottom-cancel">


### PR DESCRIPTION
This is in reference to the suggestion discussed in https://github.com/Cloud-CV/EvalAI/pull/2918#issuecomment-677794344.

Relevent/Related Issues - #2918, #3301.

Currently, the restart/start/stop buttons on the Manage Worker are active at all times which results in multiple API calls of restarting and starting.

Now, while the event of restarting or starting is in progress these buttons are disabled.

![restart_start_disable_eval](https://user-images.githubusercontent.com/32800267/110846742-24f96800-82d2-11eb-92bf-cbd1a3289ca6.gif)
