### PR TITLE
Move EFS mount target creation after EKS setup

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -3,7 +3,6 @@ import logging
 import os
 import random
 import string
-import time
 import uuid
 import yaml
 
@@ -1371,40 +1370,6 @@ def create_eks_cluster_subnets(challenge):
         )
         efs_id = response["FileSystemId"]
 
-        # Adding custom retry logic to wait for EFS creation
-        # as boto3 doesn't have a EFS waiter
-        max_retries = 5
-        retry = 0
-        while retry < max_retries:
-            describe_efs_response = efs_client.describe_file_systems(
-                CreationToken=efs_creation_token, FileSystemId=efs_id
-            )
-            if (
-                len(describe_efs_response["FileSystems"]) == 1
-                and describe_efs_response["FileSystems"][0]["LifeCycleState"]
-                == "available"
-            ):
-                break
-            # Add 5 second delay before making another boto3 API call
-            time.sleep(5)
-            retry += 1
-
-        # Create mount targets for subnets
-        mount_target_ids = []
-        response = efs_client.create_mount_target(
-            FileSystemId=efs_id,
-            SubnetId=subnet_1_id,
-            SecurityGroups=[efs_security_group_id],
-        )
-        mount_target_ids.append(response["MountTargetId"])
-
-        response = efs_client.create_mount_target(
-            FileSystemId=efs_id,
-            SubnetId=subnet_2_id,
-            SecurityGroups=[efs_security_group_id],
-        )
-        mount_target_ids.append(response["MountTargetId"])
-
         challenge_evaluation_cluster = ChallengeEvaluationCluster.objects.get(
             challenge=challenge_obj
         )
@@ -1420,7 +1385,6 @@ def create_eks_cluster_subnets(challenge):
                 "efs_security_group_id": efs_security_group_id,
                 "efs_id": efs_id,
                 "efs_creation_token": efs_creation_token,
-                "efs_mount_target_ids": mount_target_ids,
             },
             partial=True,
         )
@@ -1520,12 +1484,35 @@ def create_eks_cluster(challenge):
             challenge_evaluation_cluster = (
                 ChallengeEvaluationCluster.objects.get(challenge=challenge_obj)
             )
+
+            efs_client = get_boto3_client("efs", challenge_aws_keys)
+            # Create mount targets for subnets
+            mount_target_ids = []
+            response = efs_client.create_mount_target(
+                FileSystemId=challenge_evaluation_cluster.efs_id,
+                SubnetId=challenge_evaluation_cluster.subnet_1_id,
+                SecurityGroups=[
+                    challenge_evaluation_cluster.efs_security_group_id
+                ],
+            )
+            mount_target_ids.append(response["MountTargetId"])
+
+            response = efs_client.create_mount_target(
+                FileSystemId=challenge_evaluation_cluster.efs_id,
+                SubnetId=challenge_evaluation_cluster.subnet_2_id,
+                SecurityGroups=[
+                    challenge_evaluation_cluster.efs_security_group_id
+                ],
+            )
+            mount_target_ids.append(response["MountTargetId"])
+
             serializer = ChallengeEvaluationClusterSerializer(
                 challenge_evaluation_cluster,
                 data={
                     "name": cluster_name,
                     "cluster_endpoint": cluster_ep,
                     "cluster_ssl": cluster_cert,
+                    "efs_mount_target_ids": mount_target_ids,
                 },
                 partial=True,
             )


### PR DESCRIPTION
### Description

This PR adds - 

- [x] Move EFS mount target creation after EKS cluster is created. EFS creation for code upload challenge is failing because mount targets are not getting created. Mount targets are failing because the EFS is not available. boto3 doesn't have a waiter for EFS creation so we are moving EFS mount target set up to after cluster creation.