### PR TITLE
Enable DNS resolution for code upload cluster VPC

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -1273,6 +1273,11 @@ def create_eks_cluster_subnets(challenge):
 
     # Create internet gateway and attach to vpc
     try:
+        # Enable DNS resolution for VPC
+        response = client.modify_vpc_attribute(
+            EnableDnsHostnames={"Value": True}, VpcId=vpc_ids[0]
+        )
+
         response = client.create_internet_gateway()
         internet_gateway_id = response["InternetGateway"]["InternetGatewayId"]
         client.attach_internet_gateway(


### PR DESCRIPTION
### Description

This PR adds -

- [x] Boto3 API call to enable DNS resolution for code upload challenge cluster VPC. This is needed for job pods to mount EFS as the EFS is resolved using DNS.