### PR TITLE
[BugFix] Message field overwritten when user is logged in contact message submit API

### DIFF
--- a/apps/web/views.py
+++ b/apps/web/views.py
@@ -101,8 +101,8 @@ def contact_us(request):
         user_does_not_exist = True
 
     if request.method == "POST" or user_does_not_exist:
-        if request.POST.get("message"):
-            request_data["message"] = request.POST.get("message")
+        if request.data.get("message"):
+            request_data["message"] = request.data.get("message")
         serializer = ContactSerializer(data=request_data)
         if serializer.is_valid():
             serializer.save()


### PR DESCRIPTION
### Description


On line 98 in `web/views.py` we are overwriting request data with just user `name` and `email` field for users submitting contact us page when logged in. This PR populates `message` field from `request.data` instead of `request.POST` as `request.POST` has no post request data.