### PR TITLE
Revert ssl port open for frontend v2

### DIFF
--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -69,7 +69,6 @@ services:
         NODE_ENV: staging
     ports:
       - "9999:80"
-      - "443:443"
     volumes:
       - /code/node_modules
     logging:


### PR DESCRIPTION
### Description


Revert exposing 443 port from frontend v2 container. We can't have two containers using 443 port.