### PR TITLE
[FrontendV2] Incorrect success message on page access (#3376)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,4 @@ ssl/
 *.iws
 out/
 .idea_modules/
-
+Session.vim

--- a/frontend_v2/src/app/services/global.service.ts
+++ b/frontend_v2/src/app/services/global.service.ts
@@ -439,7 +439,7 @@ export class GlobalService {
     if (err.status === 401) {
       this.checkTokenValidity(err, toast);
     } else if (err.status === 403 && toast) {
-      this.showToast('error', err.error['error'], 5);
+      this.showToast('error', err.error['detail'], 5);
     } else if (err.status === 404 && toast) {
       this.showToast('error', err.error['detail'], 5);
     } else if (err.status === 406 && toast) {


### PR DESCRIPTION
Fixed the issue of incorrect success message appearing on page access (when the user's mail is not verified)

Issue was in the access of err.error['error'] rather than err.error['detail'] that the backend api was providing.

after fixing the issue an error message of this form appears (which is what we desire):
![image](https://user-images.githubusercontent.com/49815751/112864522-82b0f100-90d5-11eb-85f1-830d193ec08e.png)
