### PR TITLE
fix #3350: fix multiple simultaneous request to fetch leaderboard data and stop polling on tab change

### DIFF
--- a/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.ts
+++ b/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.ts
@@ -335,7 +335,7 @@ export class ChallengeleaderboardComponent implements OnInit, AfterViewInit, OnD
         SELF.router.navigate(['../../' + phaseSplit['id']], { relativeTo: this.route });
       }
       SELF.selectedPhaseSplit = phaseSplit;
-      if (SELF.selectedPhaseSplit) {
+      if (SELF.selectedPhaseSplit && !SELF.router.url.endsWith('leaderboard')) {
         SELF.fetchLeaderboard(SELF.selectedPhaseSplit['id']);
         SELF.showLeaderboardByLatest = SELF.selectedPhaseSplit.show_leaderboard_by_latest_submission;
         SELF.sortLeaderboardTextOption = SELF.showLeaderboardByLatest ? 'Sort by best' : 'Sort by latest';


### PR DESCRIPTION
currently on frontend_v2, multiple request are made on the leaderboard page every 5 seconds to fetch the leaderboard data. This is because when user selects one phasesplit, then he is sent to `leaderboard/phase_split_id`.. But the other parts of `phaseSplitSelected()` keep on executing and start polling. Also, polling is started by the '/leaderboard/80` so multiple requests are made on each poll. Also, we change page from `leaderboard/phase_split_id`, only the polling of this page stops and not the one which started on `/leaderboard`. Hence, this keeps on polling data unnecessarily making the UI slow
resolves #3350 