### PR TITLE
Frontend_V2:Incorrect success message on page access(3376)

### DIFF
--- a/frontend_v2/src/app/services/global.service.ts
+++ b/frontend_v2/src/app/services/global.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Output, EventEmitter } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
+import { Router } from '@angular/router';
 
 @Injectable()
 export class GlobalService {
@@ -84,7 +85,7 @@ export class GlobalService {
   /**
    * constructor
    */
-  constructor() {}
+  constructor(private router: Router) {}
 
   /**
    * Update Scrolled State.
@@ -439,7 +440,9 @@ export class GlobalService {
     if (err.status === 401) {
       this.checkTokenValidity(err, toast);
     } else if (err.status === 403 && toast) {
-      this.showToast('error', err.error['error'], 5);
+      console.log(err.error);
+      this.router.navigate(['permission-denied']);
+      this.showToast('error', err.error['detail'], 5);
     } else if (err.status === 404 && toast) {
       this.showToast('error', err.error['detail'], 5);
     } else if (err.status === 406 && toast) {


### PR DESCRIPTION
Fixes #3376 
The incorrect error message behaviour was due to the user having their email not verified, 
this was fixed by redirecting the user to the permission-denied route upon recieving a status code of 403 
from the API,

Behaviour after commit (for unverified users):

https://user-images.githubusercontent.com/49815751/113205526-0280bc00-928c-11eb-80a9-f93037aed253.mp4



