### PR TITLE
Fix #3350: Fixed multiple simultaneous requests and unnecessary polling when user switches tab

### DIFF
--- a/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.html
+++ b/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.html
@@ -23,7 +23,7 @@
             [phases]="filteredPhaseSplits"
             [phaseSelectionType]="phaseSelectionType"
             [phaseSelectionListType]="phaseSelectionListType"
-            [phaseSplitSelected]="phaseSplitSelected()"
+            [changeUrlWithPhaseSplit]="changeUrlWithPhaseSplit"
             #phasesplitselect
           >
           </app-selectphase>

--- a/frontend_v2/src/app/components/utility/selectphase/selectphase.component.ts
+++ b/frontend_v2/src/app/components/utility/selectphase/selectphase.component.ts
@@ -22,9 +22,9 @@ export class SelectphaseComponent implements OnInit, OnChanges {
   @Input() phaseSelected: any;
 
   /**
-   * Selected phase split callback
+   * Selected phase split callback to update the URL
    */
-  @Input() phaseSplitSelected: any;
+  @Input() changeUrlWithPhaseSplit: any;
 
   /**
    * Phase selection type (radio button or select box)
@@ -111,7 +111,7 @@ export class SelectphaseComponent implements OnInit, OnChanges {
     this.phaseName = phaseSplit.challenge_phase_name;
     this.splitName = phaseSplit.dataset_split_name;
     this.phaseVisibility = phaseSplit.showPrivate;
-    this.phaseSplitSelected(phaseSplit);
+    this.changeUrlWithPhaseSplit(phaseSplit);
   }
 
   /**


### PR DESCRIPTION
Fixes: #3350

Similar to #3382

- [x] Fixes multiple simultaneous request polling 
- [x] Stops polling when user switches to another tab or page

https://user-images.githubusercontent.com/31778302/113473178-910c5d80-9485-11eb-9b2a-cbf408eeb6a1.mp4

cc: @Ram81 @RishabhJain2018 
@burnerlee 