### PR TITLE
[Frontendv2][Backend] Added changes to redirect user to newly created challenge page once a user uploads a challenge

### DIFF
--- a/.angulardoc.json
+++ b/.angulardoc.json
@@ -1,0 +1,4 @@
+{
+  "repoId": "240f6f1e-e905-4c16-9c16-5ad3b6da1163",
+  "lastSync": 0
+}

--- a/.angulardoc.json
+++ b/.angulardoc.json
@@ -1,4 +1,0 @@
-{
-  "repoId": "240f6f1e-e905-4c16-9c16-5ad3b6da1163",
-  "lastSync": 0
-}

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -1494,7 +1494,8 @@ def create_challenge_using_zip_file(request, challenge_host_team_pk):
 
             response_data = {
                 "success": "Challenge {} has been created successfully and"
-                " sent for review to EvalAI Admin.".format(challenge.title)
+                " sent for review to EvalAI Admin.".format(challenge.title),
+                "challenge_id": challenge.id
             }
             return Response(response_data, status=status.HTTP_201_CREATED)
 

--- a/frontend_v2/src/app/components/challenge-create/challenge-create.component.ts
+++ b/frontend_v2/src/app/components/challenge-create/challenge-create.component.ts
@@ -44,11 +44,6 @@ export class ChallengeCreateComponent implements OnInit {
   hostTeam: any = null;
 
   /**
-   * Route for hosted challenges
-   */
-  hostedChallengesRoute = '/challenges/me';
-
-  /**
    * Route path for host teams
    */
   hostTeamsRoute = '/teams/hosts';
@@ -57,6 +52,11 @@ export class ChallengeCreateComponent implements OnInit {
    * Route path for listing all challenge templates
    */
   challengeTemplatesListRoute = '/challenges/templates';
+
+  /**
+   * Challenge common path
+   */
+  challengeRoutePathCommon = '/challenge';
 
   /**
    * Constructor.
@@ -105,7 +105,7 @@ export class ChallengeCreateComponent implements OnInit {
         (data) => {
           this.globalService.stopLoader();
           this.globalService.showToast('success', 'Successfuly sent to EvalAI admin for approval.');
-          this.router.navigate([this.hostedChallengesRoute]);
+          this.router.navigate([this.challengeRoutePathCommon, data.challenge_id]);
         },
         (err) => {
           this.globalService.stopLoader();


### PR DESCRIPTION
- [x] Add changes to redirect user to newly created challenge page once a user uploads a challenge

Currently, users are redirected to the `Hosted Challenge` page once they create a challenge by unloading. In this PR, changes are made so the user will be redirected to the challenge page once a user uploads a challenge.

https://user-images.githubusercontent.com/57143358/114854571-94e39c80-9e02-11eb-9187-1b3ca83fa57d.mp4

I will soon create PR for Frontendv1
@RishabhJain2018, @Ram81 Please review this PR,
 