### PR TITLE
[Frontendv2] Update metatag when title is updated from setting tab

### DIFF
--- a/frontend_v2/src/app/components/challenge/challengesettings/challengesettings.component.ts
+++ b/frontend_v2/src/app/components/challenge/challengesettings/challengesettings.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { MatChipInputEvent } from '@angular/material/chips';
 import { Router } from '@angular/router';
+import { Meta } from '@angular/platform-browser';
 import { NGXLogger } from 'ngx-logger';
 import * as moment from 'moment';
 
@@ -93,6 +94,7 @@ export class ChallengesettingsComponent implements OnInit, OnDestroy {
     private apiService: ApiService,
     private endpointsService: EndpointsService,
     private router: Router,
+    private meta: Meta,
     private logger: NGXLogger
   ) {}
 
@@ -260,6 +262,10 @@ export class ChallengesettingsComponent implements OnInit, OnDestroy {
         .subscribe(
           (data) => {
             SELF.challenge.title = data.title;
+            SELF.meta.updateTag({
+              property: 'og:title',
+              content: SELF.challenge.title,
+            });
             SELF.globalService.showToast('success', 'The challenge title is  successfully updated!', 5);
           },
           (err) => {


### PR DESCRIPTION
Fixes #3418 

 - [x] Update meta-tag when challenge title is updated from setting tab.
 
 It can be seen in inspect area of the browser in the following clip that now metaTag is also updated when the challenge title is updated. 

https://user-images.githubusercontent.com/57143358/118400491-75e55e00-b67f-11eb-9db0-d130d460742a.mp4

@Ram81 @RishabhJain2018, Please review this PR.