### PR TITLE
Fixes #3386: Placeholder overlapping with Text being input has been fixed

### DIFF
--- a/frontend_v2/src/app/components/publiclists/teamlist/teamlist.component.ts
+++ b/frontend_v2/src/app/components/publiclists/teamlist/teamlist.component.ts
@@ -594,7 +594,7 @@ export class TeamlistComponent implements OnInit, OnDestroy {
             team_name: '',
           };
 
-          this.isnameFocused = false;
+          this.isnameFocused = true;
           this.isurlFocused = false;
           this.isTeamNameRequired = false;
         },


### PR DESCRIPTION
Fixes #3386 
Placeholder overlapping with Text being input has been fixed.
The problem was occurring in the case when after filing team name, enter is clicked and next team details are typed. This has been fixed. Now the placeholder is not overlapping the text in any case.
Screenshots attached
![Screenshot (127)](https://user-images.githubusercontent.com/28698270/120101543-236a6e00-c164-11eb-86e9-73bd81edeb0e.png)
![Screenshot (128)](https://user-images.githubusercontent.com/28698270/120101555-2c5b3f80-c164-11eb-93e7-f30361018bd6.png)
