### PR TITLE
Show error message when downloading submissions that has > 5k results

### DIFF
--- a/frontend_v2/src/app/services/endpoints.service.ts
+++ b/frontend_v2/src/app/services/endpoints.service.ts
@@ -309,7 +309,7 @@ ${phase}/submission?participant_team__team_name=${participantTeamName}`;
   }
 
   /**
-   * Challenge Submission Counts
+   * Challenge Submission Counts of the participant Team 
    * @param challenge  challenge id
    * @param phase  phase id
    */


### PR DESCRIPTION
When downloading results for a phase that has > 5k results, an error is shown to use the `get_all_submissions API` to download the results. 

Also, removed the code where we are fetching the number of submissions of the participant Team on `all-submissions` page since we do not need it here.

@Ram81 @Kajol-Kumari 

![Screenshot from 2021-05-31 00-39-39](https://user-images.githubusercontent.com/24366008/120117173-80d4de00-c1a9-11eb-9c9b-00dd809d4e94.png)


