### PR TITLE
Fixes #3346: Center the content for Large Screens

### DIFF
--- a/frontend_v2/src/styles/base.scss
+++ b/frontend_v2/src/styles/base.scss
@@ -2167,6 +2167,7 @@ tr {
   .dashboard-content {
     min-height: calc(90vh - 64px) !important;
     width: calc(1440px - 223px) !important;
+    margin:auto;
   }
 
   .grad-vh {


### PR DESCRIPTION
Fixes #3346 
Site content left aligned when viewed at 50-60% zoom is fixed.
when the site viewed at 50-60% zoom ration the content was left aligned but the expected behaviour was it should be aligned in the center. This has been fixed. 
 
![Screenshot (10)](https://user-images.githubusercontent.com/81849181/120216709-ff3a8a00-c254-11eb-8160-b150857b2db6.png)

![Screenshot (11)](https://user-images.githubusercontent.com/81849181/120216747-0b264c00-c255-11eb-8813-3391ea1b96a2.png)



