### PR TITLE
Fix worker-logs error notification

### DIFF
--- a/frontend_v2/src/app/components/challenge/challengesettings/challengesettings.component.ts
+++ b/frontend_v2/src/app/components/challenge/challengesettings/challengesettings.component.ts
@@ -667,20 +667,22 @@ export class ChallengesettingsComponent implements OnInit, OnDestroy {
 
   // Get the logs from worker if submissions are failing.
   fetchWorkerLogs() {
-    const API_PATH = this.endpointsService.getLogsURL(this.challenge['id']);
-    const SELF = this;
-    SELF.apiService.getUrl(API_PATH, true, false).subscribe(
-      (data) => {
-        SELF.workerLogs = [];
-        for (let i = 0; i < data.logs.length; i++) {
-          SELF.workerLogs.push(data.logs[i]);
-        }
-      },
-      (err) => {
-        SELF.globalService.handleApiError(err);
-      },
-      () => {}
-    );
+    if(this.challenge['id']) {
+      const API_PATH = this.endpointsService.getLogsURL(this.challenge['id']);
+      const SELF = this;
+      SELF.apiService.getUrl(API_PATH, true, false).subscribe(
+        (data) => {
+          SELF.workerLogs = [];
+          for (let i = 0; i < data.logs.length; i++) {
+            SELF.workerLogs.push(data.logs[i]);
+          }
+        },
+        (err) => {
+          SELF.globalService.handleApiError(err);
+        },
+        () => {}
+      );
+    }
   }
 
   // Get the logs from worker if submissions are failing at an interval of 5sec.


### PR DESCRIPTION
***Error:*** 
```
GET http://localhost:8000/api/challenges/undefined/get_worker_logs/

HttpErrorResponse {headers: HttpHeaders, status: 404, statusText: "Not Found", url: "http://localhost:8000/api/challenges/undefined/get_worker_logs/", ok: false, …}
```

***Fix:***

`fetchWorkerLogs()` was called before we get the `challenge.id`, therefore the error was being seen.

@Ram81 @Kajol-Kumari 
