### PR TITLE
Move to kubernetes 1.16

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -1650,7 +1650,7 @@ def create_eks_cluster(challenge):
         try:
             response = client.create_cluster(
                 name=cluster_name,
-                version="1.18",
+                version="1.16",
                 roleArn=cluster_meta["EKS_CLUSTER_ROLE_ARN"],
                 resourcesVpcConfig={
                     "subnetIds": [


### PR DESCRIPTION
### Description


- [x] Downgrade to kubernetes 1.16. To move to > 1.16 we need to upgrade our kubernetes client and API calls.