### PR TITLE
CrowdAI -> AIcrowd, updated it's feature listing table

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ In recent years, it has become increasingly difficult to compare an algorithm so
 - **Faster evaluation**: We warm-up the worker nodes at start-up by importing the challenge code and pre-loading the dataset in memory. We also split the dataset into small chunks that are simultaneously evaluated on multiple cores. These simple tricks result in faster evaluation and reduces the evaluation time by an order of magnitude in some cases.
 
 ## Platform Comparison
-|          Features          |          OpenML          |         TopCoder         |          Kaggle          |         CrowdAI          |          ParlAI          |         Codalab          |       EvalAI       |
+|          Features          |          OpenML          |         TopCoder         |          Kaggle          |         AIcrowd          |          ParlAI          |         Codalab          |       EvalAI       |
 | :------------------------: | :----------------------: | :----------------------: | :----------------------: | :----------------------: | :----------------------: | :----------------------: | :----------------: |
 |    AI challenge hosting    | :heavy_multiplication_x: |    :white_check_mark:    |    :white_check_mark:    |    :white_check_mark:    | :heavy_multiplication_x: |    :white_check_mark:    | :white_check_mark: |
 |       Custom metrics       | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: |    :white_check_mark:    |    :white_check_mark:    |    :white_check_mark:    | :white_check_mark: |
 |   Multiple phases/splits   | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: |    :white_check_mark:    | :heavy_multiplication_x: |    :white_check_mark:    | :white_check_mark: |
 |        Open source         |    :white_check_mark:    | :heavy_multiplication_x: | :heavy_multiplication_x: |    :white_check_mark:    |    :white_check_mark:    |    :white_check_mark:    | :white_check_mark: |
-|     Remote evaluation      | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: |    :white_check_mark:    |    :white_check_mark:    | :white_check_mark: |
-|      Human evaluation      | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: |    :white_check_mark:    | :heavy_multiplication_x: | :white_check_mark: |
+|     Remote evaluation      | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: |    :white_check_mark:    |    :white_check_mark:    |    :white_check_mark:    | :white_check_mark: |
+|      Human evaluation      | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: |    :white_check_mark:    |    :white_check_mark:    | :heavy_multiplication_x: | :white_check_mark: |
 | Evaluation in Environments | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: |    :white_check_mark:    | :heavy_multiplication_x: | :heavy_multiplication_x: | :white_check_mark: |
 
 ## Goal


### PR DESCRIPTION
Hi team,

Congratulations on trending on HN.
Unfortunately, I noticed there are few updates in features AIcrowd offers and this PR is for the same.

### **Update in name**

CrowdAI is [closed as of early 2019](https://www.crowdai.org/blogs/7), and the new independent entity is called AIcrowd.

### **Remote evaluations**

[1. Mapping Challenge **(2018)**](https://www.crowdai.org/challenges/mapping-challenge)

> upto 8GB of Memory, [..] 1 NVIDIA Titan X (Maxwell Series) GPU, 5 hours
[(source)](https://github.com/crowdAI/mapping-challenge-round2-starter-kit#hardware-limits)

[2. NeurIPS 2020: ProcGen Competition](https://www.aicrowd.com/challenges/neurips-2020-procgen-competition/)

> AIcrowd ran 33,000 models that generated more than 230,000 virtual-CPU and 28.5k GPU hours
[(source)](https://www.amazon.science/blog/neurips-reinforcement-learning-challenge-winners-announced)

[3. NeurIPS 2020: MineRL Challenge](https://www.aicrowd.com/challenges/neurips-2020-minerl-competition/)

Another unique challenge having 4 (to 7) days of online training proceeded by inference.

[4. Airborne Object Tracking Challenge](https://www.aicrowd.com/challenges/airborne-object-tracking-challenge/)

In which p3.2xlarge instances evaluate participant codes on roughly 70 GPU hours+.

_and many more challenges..._

### **Human Evaluation**

[1. AI-generated music challenge **(Dec 2017)**](https://www.crowdai.org/challenges/ai-generated-music-challenge)

> A separate evaluation interface is made available, where all the participants (and other external volunteers) can hear two randomly sampled chunks and then vote for the one they like better

[2. NeurIPS 2021: MineRL Basalt](https://www.aicrowd.com/challenges/neurips-2021-minerl-basalt-competition/).

> Submitted agents will be evaluated based on how well they complete the tasks, as judged by humans given the same description of the tasks.

Let me know in case I can provide any other details.

Cheers.