### PR TITLE
Update boto3 version

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -538,6 +538,12 @@ service_definition = """
     "deploymentController":{{
         "type": "ECS"
     }},
+    "deploymentConfiguration":{{
+        "deploymentCircuitBreaker":{{
+            "enable": True,
+            "rollback": False
+        }}
+    }}
 }}
 """
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,6 +1,6 @@
 asgi-redis==1.4.3
-boto3==1.13.16
-botocore==1.16.16
+boto3==1.17.101
+botocore==1.20.101
 vine==1.3.0
 celery[sqs]==4.3.0
 commonmark==0.9.1


### PR DESCRIPTION
### Description


- [x] Update boto3 to latest version
- [x] Add deployment circuit breaker in fargate task to disable auto restarts

Tested most of the API calls locally. boto3 APIs are backward compatible so we shouldn't face any issues. Previously faced [error](https://github.com/Cloud-CV/EvalAI/pull/3098) was due to `django-storage` package update which we have reverted already.