### PR TITLE
Reverse Proxy setup for prometheus and grafana

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
     - /code/node_modules
 
   prometheus:
+    hostname: prometheus
     image: prom/prometheus:latest
     user: "1000"
     volumes:
@@ -75,15 +76,20 @@ services:
       - ./monitoring/prometheus/prometheus_db:/etc/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--web.external-url=http://localhost:9090/prometheus'
     restart: unless-stopped
     ports:
       - '9090:9090'
   
   grafana:
+    hostname: grafana
     image: grafana/grafana:latest
     user: "1000"
     env_file:
       - docker/dev/docker.env
+    environment:
+      GF_SERVER_ROOT_URL: http://localhost:3000/grafana
+      GF_SERVER_SERVE_FROM_SUB_PATH: 'true'
     volumes:
       - ./monitoring/grafana/grafana_db:/var/lib/grafana
     depends_on:

--- a/docker/prod/nodejs/nginx_staging.conf
+++ b/docker/prod/nodejs/nginx_staging.conf
@@ -2,6 +2,14 @@ upstream django_app {
   server django:8000 fail_timeout=0;
 }
 
+upstream prometheus_app {
+  server prometheus:9090 fail_timeout=0;
+}
+
+upstream grafana_app {
+  server grafana:3000 fail_timeout=0;
+}
+
 server {
   server_name staging-evalai.cloudcv.org evalai-staging.cloudcv.org;
   listen 80;
@@ -52,6 +60,20 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_pass http://django_app;
   }
+
+  location /prometheus {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_pass http://prometheus_app;
+  }
+
+  location /grafana {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_pass http://grafana_app;
+  }  
 
   ssl on;
   ssl_certificate /etc/ssl/eval_ai.crt;


### PR DESCRIPTION
Add configs to expose prometheus and grafana through endpoints configured by the reverse proxy. Prometheus is available on `ipaddr/prometheus` and Grafana on `ipaddr/grafana`