### PR TITLE
clear metrics after pushing to pushgateway to avoid duplication of metrics

### DIFF
--- a/apps/jobs/metrics.py
+++ b/apps/jobs/metrics.py
@@ -12,13 +12,6 @@ num_submissions_in_queue = Counter(
     registry=pushgateway_registry,
 )
 
-num_processed_submissions = Counter(
-    "num_processed_submissions",
-    "Counter for number of submissions processed from the queue",
-    ["submission_pk", "queue_name"],
-    registry=pushgateway_registry,
-)
-
 
 def push_metrics_to_pushgateway(job_id):
     pushgateway_endpoint = os.environ.get("PUSHGATEWAY_ENDPOINT")

--- a/apps/jobs/metrics.py
+++ b/apps/jobs/metrics.py
@@ -12,8 +12,14 @@ num_submissions_in_queue = Counter(
     registry=pushgateway_registry,
 )
 
+num_processed_submissions = Counter(
+    "num_processed_submissions",
+    "Counter for number of submissions processed from the queue",
+    ["submission_pk", "queue_name"],
+    registry=pushgateway_registry,
+)
+
 
 def push_metrics_to_pushgateway(job_id):
     pushgateway_endpoint = os.environ.get("PUSHGATEWAY_ENDPOINT")
     pushadd_to_gateway(pushgateway_endpoint, job=job_id, registry=pushgateway_registry)
-    num_submissions_in_queue.clear()

--- a/apps/jobs/metrics.py
+++ b/apps/jobs/metrics.py
@@ -16,3 +16,4 @@ num_submissions_in_queue = Counter(
 def push_metrics_to_pushgateway(job_id):
     pushgateway_endpoint = os.environ.get("PUSHGATEWAY_ENDPOINT")
     pushadd_to_gateway(pushgateway_endpoint, job=job_id, registry=pushgateway_registry)
+    num_submissions_in_queue.clear()

--- a/apps/jobs/sender.py
+++ b/apps/jobs/sender.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from base.utils import send_slack_notification
 from challenges.models import Challenge
 from .utils import get_submission_model
-from .metrics import push_metrics_to_pushgateway, num_submissions_in_queue, num_processed_submissions
+from .metrics import push_metrics_to_pushgateway, num_submissions_in_queue
 
 logger = logging.getLogger(__name__)
 
@@ -87,13 +87,11 @@ def publish_submission_message(message):
     # increase counter for submission pushed into queue
     submission_pk = message["submission_pk"]
     num_submissions_in_queue.labels(submission_pk, queue_name).inc()
-    num_processed_submissions.labels(submission_pk, queue_name).inc(0)
     # push metrics to pushgateway as a submission is pushed into queue
     job_id = "submission_{}".format(submission_pk)
     push_metrics_to_pushgateway(job_id)
     # clear metrics after they are pushed to avoid duplication on next push
     num_submissions_in_queue.clear()
-    num_processed_submissions.clear()
     response = queue.send_message(MessageBody=json.dumps(message))
     # send slack notification
     if slack_url:

--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -766,6 +766,7 @@ def increment_and_push_metrics_to_pushgateway(body, queue_name):
         pushgateway_endpoint = os.environ.get("PUSHGATEWAY_ENDPOINT")
         job_id = "submission_worker_{}".format(submission_pk)
         pushadd_to_gateway(pushgateway_endpoint, job=job_id, registry=pushgateway_registry)
+        num_processed_submissions.clear()
     except Exception as e:
         logger.exception(
             "{} Exception when pushing metrics to push gateway: {}".format(


### PR DESCRIPTION
once metrics are pushed to gateway for a particular submission id and queue, we want to clear that metric from the registry, so that it is not pushed again for the next submission