### PR TITLE
Fix console error of change in expression value

### DIFF
--- a/frontend_v2/src/app/components/publiclists/publiclists.component.ts
+++ b/frontend_v2/src/app/components/publiclists/publiclists.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Inject, OnDestroy } from '@angular/core';
+import { Component, OnInit, Inject, OnDestroy, AfterViewChecked, ChangeDetectorRef } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { DOCUMENT } from '@angular/common';
 import { GlobalService } from '../../services/global.service';
@@ -12,7 +12,10 @@ import { AuthService } from '../../services/auth.service';
   templateUrl: './publiclists.component.html',
   styleUrls: ['./publiclists.component.scss'],
 })
-export class PubliclistsComponent {
+export class PubliclistsComponent implements AfterViewChecked {
+
+  isAuth = false;
+
   /**
    * Constructor.
    * @param document  Window document Injection.
@@ -26,6 +29,20 @@ export class PubliclistsComponent {
     private route: ActivatedRoute,
     @Inject(DOCUMENT) private document: Document,
     public authService: AuthService,
-    private globalService: GlobalService
+    private globalService: GlobalService,
+    private cdRef : ChangeDetectorRef
   ) {}
+
+  /**
+   * DEV MODE:
+   * For resolving change in expression value after it is checked
+   */
+
+  ngAfterViewChecked() {
+    let isAuth = this.authService.isAuth;
+    if(isAuth != this.isAuth) {
+      this.isAuth = isAuth;
+      this.cdRef.detectChanges();
+    }
+  }
 }


### PR DESCRIPTION
Fix the error that occurs in dev mode when the change detection run twice.

**Before**
![image](https://user-images.githubusercontent.com/24366008/126907984-66954493-00ff-4766-8956-0518ea0400b8.png)

**After**
No error in console.

@Ram81 @Kajol-Kumari 