### PR TITLE
Fetch private submissions after polling when checkbox ticked

### DIFF
--- a/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.html
+++ b/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.html
@@ -65,11 +65,14 @@
             <div *ngIf="leaderboard.length <= 0 && selectedPhaseSplit == null" class="fw-light result-wrn">
               No phase selected.
             </div>
-            <div *ngIf="leaderboard.length > 0 && selectedPhaseSplit" class="result-wrn content fw-light">
-              <mat-chip-list> <mat-chip>B</mat-chip> - Baseline submission </mat-chip-list>
-              <mat-chip-list class="leaderboard-description-span private">
-                <mat-chip>P</mat-chip> - Private submission
-              </mat-chip-list>
+            <div *ngIf="selectedPhaseSplit" class="result-wrn content fw-light">
+              <div *ngIf="leaderboard.length > 0">
+                <mat-chip-list> 
+                  <mat-chip>B</mat-chip> - Baseline submission 
+                </mat-chip-list>
+                <mat-chip-list class="leaderboard-description-span private">
+                  <mat-chip>P</mat-chip> - Private submission
+                </mat-chip-list>
               <!-- <mat-chip-list class="pull-right" *ngIf="isChallengeHost">
                 <div
                   (click)="showLeaderboardByLatestOrBest()"
@@ -87,14 +90,15 @@
                 </div>
                 <span class="w-400"> {{ sortLeaderboardTextOption }}</span>
               </mat-chip-list> -->
-              <mat-checkbox
-                class="pull-right complete-leaderboard"
-                *ngIf="isChallengeHost && showLeaderboardToggle"
-                (change)="toggleLeaderboard(getAllEntries)"
-                [(ngModel)]="getAllEntries"
-              >
-                <label class="fw-light complete-leaderboard-text"> {{ getAllEntriesTextOption }}</label>
-              </mat-checkbox>
+              </div>
+                <mat-checkbox
+                  class="pull-right complete-leaderboard"
+                  *ngIf="isChallengeHost && showLeaderboardToggle"
+                  (change)="toggleLeaderboard(getAllEntries)"
+                  [(ngModel)]="getAllEntries"
+                >
+                  <label class="fw-light complete-leaderboard-text"> {{ getAllEntriesTextOption }}</label>
+                </mat-checkbox>
             </div>
 
             <table *ngIf="leaderboard.length > 0 && selectedPhaseSplit" class="centered highlight fw-light">
@@ -189,7 +193,7 @@
                     <span *ngIf="key.submission__is_public === false && isSelectedPhaseLeaderboardPublic" class="private">
                       <mat-chip-list>
                         <mat-chip>P</mat-chip>
-                      </mat-chip-list>
+                      </mat-chip-list>&nbsp;
                     </span>
                     <span *ngIf="key.submission__is_baseline">
                       <mat-chip-list>

--- a/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.html
+++ b/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.html
@@ -93,7 +93,7 @@
               </div>
                 <mat-checkbox
                   class="pull-right complete-leaderboard"
-                  *ngIf="isChallengeHost && showLeaderboardToggle"
+                  *ngIf="isChallengeHost && showLeaderboardToggle && numberOfAllEntries > 0"
                   (change)="toggleLeaderboard(getAllEntries)"
                   [(ngModel)]="getAllEntries"
                 >

--- a/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.scss
+++ b/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.scss
@@ -79,6 +79,11 @@
   }
 }
 
+.pull-right {
+  margin-left: auto;
+  margin-top: -3%;
+}
+
 .btn-switch {
   position: relative;
   display: block;

--- a/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.ts
+++ b/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.ts
@@ -541,7 +541,6 @@ export class ChallengeleaderboardComponent implements OnInit, AfterViewInit, OnD
    */
   startLeaderboard(phaseSplitId) {
     let API_PATH;
-    console.log(this.getAllEntriesTextOption);
     if(this.getAllEntriesTextOption == 'Exclude private submissions') {
       API_PATH = this.endpointsService.challengeCompleteLeaderboardURL(phaseSplitId);
     } else {
@@ -550,7 +549,6 @@ export class ChallengeleaderboardComponent implements OnInit, AfterViewInit, OnD
     const SELF = this;
     clearInterval(SELF.pollingInterval);
     SELF.pollingInterval = setInterval(function () {
-      console.log("HELLO");
       SELF.apiService.getUrl(API_PATH, true, false).subscribe(
         (data) => {
           if (SELF.leaderboard.length !== data['results'].length) {

--- a/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.ts
+++ b/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.ts
@@ -360,7 +360,11 @@ export class ChallengeleaderboardComponent implements OnInit, AfterViewInit, OnD
       );
 
       if (SELF.selectedPhaseSplit && SELF.router.url.endsWith('leaderboard/' + phaseSplit['id'])) {
-        SELF.fetchLeaderboard(SELF.selectedPhaseSplit['id']);
+        if(this.getAllEntriesTextOption == 'Exclude private submissions') {
+          SELF.fetchAllEnteriesOnPublicLeaderboard(SELF.selectedPhaseSplit['id']);
+        } else {
+          SELF.fetchLeaderboard(SELF.selectedPhaseSplit['id']);
+        }
         SELF.showLeaderboardByLatest = SELF.selectedPhaseSplit.show_leaderboard_by_latest_submission;
         SELF.sortLeaderboardTextOption = SELF.showLeaderboardByLatest ? 'Sort by best' : 'Sort by latest';
         let selectedPhase = SELF.phases.find((phase) => {
@@ -536,10 +540,17 @@ export class ChallengeleaderboardComponent implements OnInit, AfterViewInit, OnD
    * @param phaseSplitId id of the phase split
    */
   startLeaderboard(phaseSplitId) {
-    const API_PATH = this.endpointsService.challengeLeaderboardURL(phaseSplitId);
+    let API_PATH;
+    console.log(this.getAllEntriesTextOption);
+    if(this.getAllEntriesTextOption == 'Exclude private submissions') {
+      API_PATH = this.endpointsService.challengeCompleteLeaderboardURL(phaseSplitId);
+    } else {
+      API_PATH = this.endpointsService.challengeLeaderboardURL(phaseSplitId);
+    }
     const SELF = this;
     clearInterval(SELF.pollingInterval);
     SELF.pollingInterval = setInterval(function () {
+      console.log("HELLO");
       SELF.apiService.getUrl(API_PATH, true, false).subscribe(
         (data) => {
           if (SELF.leaderboard.length !== data['results'].length) {

--- a/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.ts
+++ b/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.ts
@@ -146,6 +146,11 @@ export class ChallengeleaderboardComponent implements OnInit, AfterViewInit, OnD
   getAllEntries = false;
 
   /**
+   * Number of entries on complete leaderboard
+   */
+   numberOfAllEntries:number = 0;
+
+  /**
    * Current state of whether private leaderboard
    */
   showLeaderboardToggle = true;
@@ -346,8 +351,10 @@ export class ChallengeleaderboardComponent implements OnInit, AfterViewInit, OnD
     phaseSplitSelected(phaseSplit) {
       const SELF = this;
       SELF.selectedPhaseSplit = phaseSplit;
+
+      SELF.fetchNumberOfAllEnteriesOnPublicLeaderboard(SELF.selectedPhaseSplit['id']);
       
-      const API_PATH = SELF.endpointsService.particularChallengePhaseSplitUrl(this.selectedPhaseSplit['id']);
+      const API_PATH = SELF.endpointsService.particularChallengePhaseSplitUrl(SELF.selectedPhaseSplit['id']);
       SELF.apiService.getUrl(API_PATH).subscribe(
         (data) => {
           SELF.leaderboardPrecisionValue = data.leaderboard_decimal_precision;
@@ -360,7 +367,7 @@ export class ChallengeleaderboardComponent implements OnInit, AfterViewInit, OnD
       );
 
       if (SELF.selectedPhaseSplit && SELF.router.url.endsWith('leaderboard/' + phaseSplit['id'])) {
-        if(this.getAllEntriesTextOption == 'Exclude private submissions') {
+        if(SELF.getAllEntriesTextOption == 'Exclude private submissions') {
           SELF.fetchAllEnteriesOnPublicLeaderboard(SELF.selectedPhaseSplit['id']);
         } else {
           SELF.fetchLeaderboard(SELF.selectedPhaseSplit['id']);
@@ -513,6 +520,24 @@ export class ChallengeleaderboardComponent implements OnInit, AfterViewInit, OnD
         SELF.updateLeaderboardResults(data['results'], SELF);
         SELF.updateLeaderboardResults(data['results'], SELF);
         SELF.startLeaderboard(phaseSplitId);
+      },
+      (err) => {
+        SELF.globalService.handleApiError(err);
+      },
+      () => {}
+    );
+  }
+
+  /**
+   * Fetch number of entries of complete leaderboard for a phase split public/private
+   * @param phaseSplitId id of the phase split
+   */
+  fetchNumberOfAllEnteriesOnPublicLeaderboard(phaseSplitId) {
+    const API_PATH = this.endpointsService.challengeCompleteLeaderboardURL(phaseSplitId);
+    const SELF = this;
+    this.apiService.getUrl(API_PATH).subscribe(
+      (data) => {
+        this.numberOfAllEntries = data['results'].length;
       },
       (err) => {
         SELF.globalService.handleApiError(err);


### PR DESCRIPTION
When `Include Private Submission` is checked the private submissions are not fetched after 5seconds of polling. 
Also, when the leaderboard has all private submissions, previously no results are shown, but now the checkbox is also visible.

@Ram81 @Kajol-Kumari 