### PR TITLE
fix: switch to http for prometheus and grafana

### DIFF
--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -130,7 +130,8 @@ services:
       - '--log.level=info'
       - '--web.telemetry-path=/statsd/metrics'
     ports:
-      - '9125:9125'
+      - '9125:9125/udp'
+      - '9125:9125/tcp'
       - '9102:9102'
   
   node_exporter:

--- a/docker/prod/nginx-ingress/nginx_staging.conf
+++ b/docker/prod/nginx-ingress/nginx_staging.conf
@@ -38,14 +38,14 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_pass https://prometheus;
+    proxy_pass http://prometheus;
   }
 
   location /grafana {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_pass https://grafana;
+    proxy_pass http://grafana;
   }
 
   location /statsd {


### PR DESCRIPTION
Currently using https for prometheus and grafana in our nginx-ingress config throws SSL Handshake error. This PR fixes this to host the services flawlessly