### PR TITLE
Remove submission count api call from submissions page

### DIFF
--- a/frontend_v2/src/app/components/challenge/challengesubmissions/challengesubmissions.component.ts
+++ b/frontend_v2/src/app/components/challenge/challengesubmissions/challengesubmissions.component.ts
@@ -249,7 +249,6 @@ export class ChallengesubmissionsComponent implements OnInit, AfterViewInit {
       SELF.submissionCount = 0;
       if (SELF.challenge['id'] && phase['id']) {
         SELF.fetchSubmissions(SELF.challenge['id'], phase['id']);
-        SELF.fetchSubmissionCounts(this.challenge['id'], phase['id']);
       }
     };
   }
@@ -265,6 +264,7 @@ export class ChallengesubmissionsComponent implements OnInit, AfterViewInit {
       API_PATH = SELF.endpointsService.challengeSubmissionURL(challenge, phase);
     SELF.apiService.getUrl(API_PATH).subscribe(
       (data) => {
+        SELF.submissionCount = data['count'];
         SELF.submissions = data['results'];
         let index = 0;
         SELF.submissions.forEach((submission) => {
@@ -488,30 +488,7 @@ export class ChallengesubmissionsComponent implements OnInit, AfterViewInit {
       );
     }
   }
-
-  /**
-   * Fetch number of submissions for a challenge phase.
-   * @param challenge  challenge id
-   * @param phase  phase id
-   */
-  fetchSubmissionCounts(challenge, phase) {
-    const API_PATH = this.endpointsService.challengeSubmissionCountURL(challenge, phase);
-    const SELF = this;
-    this.apiService.getUrl(API_PATH).subscribe(
-      (data) => {
-        if (data['participant_team_submission_count']) {
-          SELF.submissionCount = data['participant_team_submission_count'];
-        }
-      },
-      (err) => {
-        SELF.globalService.handleApiError(err);
-      },
-      () => {
-        this.logger.info('Fetched submission counts', challenge, phase);
-      }
-    );
-  }
-
+  
   /**
    * Display Edit Submission Modal.
    * @param submission  Submission being edited

--- a/frontend_v2/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
+++ b/frontend_v2/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
@@ -275,7 +275,6 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
     SELF.apiService.getUrl(API_PATH).subscribe(
       (data) => {
         if(name == SELF.filterSubmissionsQuery) {
-
           SELF.submissionCount = data['count'];
           SELF.submissions = data['results'];
           let index = 0;

--- a/frontend_v2/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
+++ b/frontend_v2/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
@@ -247,7 +247,6 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
       SELF.submissionCount = 0;
       if (SELF.challenge['id'] && phase['id']) {
         SELF.fetchSubmissions(SELF.challenge['id'], phase['id']);
-        SELF.fetchSubmissionCounts(this.challenge['id'], phase['id']);
       }
     };
   }
@@ -276,6 +275,8 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
     SELF.apiService.getUrl(API_PATH).subscribe(
       (data) => {
         if(name == SELF.filterSubmissionsQuery) {
+
+          SELF.submissionCount = data['count'];
           SELF.submissions = data['results'];
           let index = 0;
           SELF.submissions.forEach((submission) => {
@@ -532,29 +533,6 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
       confirmCallback: SELF.apiCall,
     };
     SELF.globalService.showConfirm(PARAMS);
-  }
-
-  /**
-   * Fetch number of submissions for a challenge phase.
-   * @param challenge  challenge id
-   * @param phase  phase id
-   */
-  fetchSubmissionCounts(challenge, phase) {
-    const API_PATH = this.endpointsService.challengeSubmissionCountURL(challenge, phase);
-    const SELF = this;
-    this.apiService.getUrl(API_PATH).subscribe(
-      (data) => {
-        if (data['participant_team_submission_count']) {
-          SELF.submissionCount = data['participant_team_submission_count'];
-        }
-      },
-      (err) => {
-        SELF.globalService.handleApiError(err);
-      },
-      () => {
-        this.logger.info('Fetched submission counts', challenge, phase);
-      }
-    );
   }
 
   /**


### PR DESCRIPTION
Fixes the following points:

- [x] `submissionCount` in the `allSubmissions` page was giving the count of number of submissions of the participant team not all Submissions.
- [x] We don't require any API call for getting the count of submissions for a particular phase, the count is already there while we fetch the submissions.

@Ram81 @Kajol-Kumari 