### PR TITLE
fix: change scheme of alertmanager to https for staging env

### DIFF
--- a/monitoring/prometheus/prometheus_staging.yml
+++ b/monitoring/prometheus/prometheus_staging.yml
@@ -25,5 +25,6 @@ scrape_configs:
 alerting:
   alertmanagers:
   - path_prefix: '/alert_manager'
+    scheme: 'https'
     static_configs:
     - targets: ['monitoring-staging.eval.ai']


### PR DESCRIPTION
Currently, the prometheus make a POST request to the alertmanager using HTTP protocol. Using the Reverse proxy, we redirect all the requests made using using HTTP to HTTPS and return a 301 response. However, this changes the request from POST to GET and alerts are not issued. Thus, this fix allows prometheus to ping the alertmanager using the HTTPS Protocol