### PR TITLE
[BugFix] Show public/private option for all phases on submit page

### DIFF
--- a/frontend_v2/src/app/components/challenge/challengesubmit/challengesubmit.component.html
+++ b/frontend_v2/src/app/components/challenge/challengesubmit/challengesubmit.component.html
@@ -328,15 +328,13 @@
             <input 
               type="radio" 
               name="submissionVisibility"
-              *ngIf="isLeaderboardPublic == true"
               class="with-gap selectPhase" 
               id="isPublicSubmission"
               (change)="isPublicSubmission = true"
               />
             <label for="isPublicSubmission" class="radio-button-text pointer">
               <div 
-                class="show-member-title pointer"
-                *ngIf="isLeaderboardPublic == true">
+                class="show-member-title pointer">
                 <strong class="text-med-black fs-16">Public</strong>
               </div>
             </label>


### PR DESCRIPTION
### Description

This PR fixes -

- [x] On Frontend V2 we were not showing the `Public` option in `Select submission visibility` option when a challenge phase has `leaderboard_public` set to `False`. This PR fixes the bug.