### PR TITLE
[Worker] Enable cilium network policy for code upload evaluation

### DIFF
--- a/scripts/workers/code_upload_worker_utils/install_dependencies.sh
+++ b/scripts/workers/code_upload_worker_utils/install_dependencies.sh
@@ -39,13 +39,15 @@ kubectl apply -f /code/scripts/workers/code_upload_worker_utils/persistent_volum
 
 # Install cilium
 # Cilium is being used to provide networking and network policy
-# kubectl create -f https://raw.githubusercontent.com/cilium/cilium/v1.9/install/kubernetes/quick-install.yaml
-# echo "### Cilium Installed"
+kubectl create -f https://raw.githubusercontent.com/cilium/cilium/v1.9/install/kubernetes/quick-install.yaml
+echo "### Cilium Installed"
 
 sleep 120s;
 
 # Apply cilium network policy
-# cat /code/scripts/workers/code_upload_worker_utils/network_policies.yaml | sed "s/{{EVALAI_DNS}}/$EVALAI_DNS/" | kubectl apply -f -
+echo "### Setting up Cilium Network Policy..."
+cat /code/scripts/workers/code_upload_worker_utils/network_policies.yaml | sed "s/{{EVALAI_DNS}}/$EVALAI_DNS/" | kubectl apply -f -
+echo "### Cilium EvalAI Network Policy Installed"
 
 # Set ssl-certificate
 echo $CERTIFICATE | base64 --decode > scripts/workers/certificate.crt

--- a/scripts/workers/code_upload_worker_utils/network_policies.yaml
+++ b/scripts/workers/code_upload_worker_utils/network_policies.yaml
@@ -8,6 +8,7 @@ spec:
       {}
   egress:
   - toFQDNs:
+    - matchName: archive.ubuntu.com
     - matchName: {{EVALAI_DNS}}
   - toEndpoints:
     - matchLabels:


### PR DESCRIPTION
### Description


This PR - 

- [x] Enables cilium network policy in code upload evaluation setup to only allow connections from job pods to EvalAI and `archive.ubuntu.com` (to setup ubuntu packages for init-container).
- [x] Add additional log statements in worker setup 

Changes verified using worker setup on EC2 instance. 