### PR TITLE
[BugFix] Add order_by in request data for leaderboard API call

### DIFF
--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -604,7 +604,7 @@ def leaderboard(request, challenge_phase_split_id):
 
 
 @swagger_auto_schema(
-    methods=["get"],
+    methods=["get", "post"],
     manual_parameters=[
         openapi.Parameter(
             name="challenge_phase_split_pk",
@@ -730,7 +730,7 @@ def leaderboard(request, challenge_phase_split_id):
         ),
     },
 )
-@api_view(["GET"])
+@api_view(["GET", "POST"])
 @throttle_classes([AnonRateThrottle])
 @permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))
 @authentication_classes((JWTAuthentication, ExpiringTokenAuthentication))
@@ -794,7 +794,7 @@ def get_all_entries_on_public_leaderboard(request, challenge_phase_split_pk):
             "error": "Sorry, you are not authorized to make this request!"
         }
         return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
-
+    order_by = request.data.get("order_by")
     (
         response_data,
         http_status_code,
@@ -803,6 +803,7 @@ def get_all_entries_on_public_leaderboard(request, challenge_phase_split_pk):
         challenge_obj,
         challenge_phase_split,
         only_public_entries=False,
+        order_by=order_by,
     )
     # The response 400 will be returned if the leaderboard isn't public or `default_order_by` key is missing in leaderboard.
     if http_status_code == status.HTTP_400_BAD_REQUEST:
@@ -2335,6 +2336,7 @@ def get_github_badge_data(
         challenge_obj,
         challenge_phase_split,
         only_public_entries=True,
+        order_by=None,
     )
     if http_status_code == status.HTTP_400_BAD_REQUEST:
         return Response(response_data, status=http_status_code)

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -1461,8 +1461,10 @@
             // Show leaderboard
             vm.leaderboard = {};
             parameters.url = "jobs/" + "phase_split/" + vm.phaseSplitId + "/public_leaderboard_all_entries/?page_size=1000";
-            parameters.method = 'GET';
-            parameters.data = {};
+            parameters.method = 'POST';
+            parameters.data = {
+                "order_by": vm.orderLeaderboardBy
+            };
             parameters.callback = {
                 onSuccess: function(response) {
                     var details = response.data;


### PR DESCRIPTION
### Description


This PR fixes [this issue](https://cloudcv.slack.com/archives/C2P84STC6/p1629587222008200) - 

- [x] Add `order_by` key in request data for leaderboard API calls for multi metric leaderboard.