### PR TITLE
[FrontendV2] Move devDependencies to prod

### DIFF
--- a/frontend_v2/package.json
+++ b/frontend_v2/package.json
@@ -73,6 +73,6 @@
     "pretty-quick": "^2.0.1",
     "protractor": "~5.1.2",
     "ts-node": "~4.1.0",
-    "tslint": "^5.9.1",
+    "tslint": "^5.9.1"
   }
 }


### PR DESCRIPTION
### Description

This PR  -

- [x] Moves `build-angular`, `compiler-cli` and `typescript` to dependencies from devDependencies