### PR TITLE
[Monitoring] Enable node_exporter route on frontend v1

### DIFF
--- a/docker/prod/nodejs/nginx_production.conf
+++ b/docker/prod/nodejs/nginx_production.conf
@@ -57,6 +57,13 @@ server {
     proxy_pass http://django_app;
   }
 
+  location /node_exporter {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_pass http://node_exporter/metrics;
+  }
+
   ssl on;
   ssl_certificate /etc/ssl/eval_ai.crt;
   ssl_certificate_key /etc/ssl/eval_ai.key;


### PR DESCRIPTION
### Description

This PR - 

- [x] Enables node_exporter route for EvalAI production setup. This will allow prometheus to scrape node exporter metrics