### PR TITLE
[Backend] Remove participant and host team delete APIs

### DIFF
--- a/apps/hosts/views.py
+++ b/apps/hosts/views.py
@@ -67,7 +67,7 @@ def challenge_host_team_list(request):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-@api_view(["GET", "PUT", "PATCH", "DELETE"])
+@api_view(["GET", "PUT", "PATCH"])
 @throttle_classes([UserRateThrottle])
 @permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))
 @authentication_classes((JWTAuthentication, ExpiringTokenAuthentication))
@@ -106,10 +106,6 @@ def challenge_host_team_detail(request, pk):
             return Response(
                 serializer.errors, status=status.HTTP_400_BAD_REQUEST
             )
-
-    elif request.method == "DELETE":
-        challenge_host_team.delete()
-        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 @api_view(["GET", "POST"])

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -179,7 +179,6 @@ def participant_team_detail(request, pk):
             return Response(errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-
 @api_view(["POST"])
 @throttle_classes([UserRateThrottle])
 @permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -120,7 +120,7 @@ def get_participant_team_challenge_list(request, participant_team_pk):
         return paginator.get_paginated_response(response_data)
 
 
-@api_view(["GET", "PUT", "PATCH", "DELETE"])
+@api_view(["GET", "PUT", "PATCH"])
 @throttle_classes([UserRateThrottle])
 @permission_classes((permissions.IsAuthenticated, HasVerifiedEmail))
 @authentication_classes((JWTAuthentication, ExpiringTokenAuthentication))
@@ -178,9 +178,6 @@ def participant_team_detail(request, pk):
             errors = "\n".join(serializer.errors)
             return Response(errors, status=status.HTTP_400_BAD_REQUEST)
 
-    elif request.method == "DELETE":
-        participant_team.delete()
-        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 @api_view(["POST"])

--- a/tests/unit/hosts/test_views.py
+++ b/tests/unit/hosts/test_views.py
@@ -250,9 +250,10 @@ class DeleteParticularChallengeHostTeam(BaseAPITestClass):
             kwargs={"pk": self.challenge_host_team.pk},
         )
 
-    def test_particular_challenge_host_team_delete(self):
-        response = self.client.delete(self.url, {})
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+    # TODO: Add test back with API
+    # def test_particular_challenge_host_team_delete(self):
+    #     response = self.client.delete(self.url, {})
+    #     self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
 
 class GetChallengeHostTest(BaseAPITestClass):

--- a/tests/unit/participants/test_views.py
+++ b/tests/unit/participants/test_views.py
@@ -249,9 +249,10 @@ class DeleteParticularParticipantTeam(BaseAPITestClass):
             kwargs={"pk": self.participant_team.pk},
         )
 
-    def test_particular_participant_team_delete(self):
-        response = self.client.delete(self.url, {})
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+    # TODO: Add the test back with the API
+    # def test_particular_participant_team_delete(self):
+    #     response = self.client.delete(self.url, {})
+    #     self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
 
 class InviteParticipantToTeamTest(BaseAPITestClass):


### PR DESCRIPTION
### Description

This PR - 

- [x]  Disables `DELETE` APis for host team and participant team