### PR TITLE
fix: pakohan/elasticmq docker image not found

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "5432:5432"
 
   sqs:
-    image: pakohan/elasticmq
+    image: softwaremill/elasticmq
     hostname: sqs
     ports:
       - 9324:9324


### PR DESCRIPTION
 Solved: #3629
    problem :- there is no pakohan/elasticmq docker image available on docker hub 
    solution :- this is softwaremill/elasticmq alternative and most updated image
