### PR TITLE
Fixes #3628, #3629 and #3623: Added `pakohan/elasticmq` Alternative

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "5432:5432"
 
   sqs:
-    image: pakohan/elasticmq
+    image: softwaremill/elasticmq
     hostname: sqs
     ports:
       - 9324:9324


### PR DESCRIPTION
https://hub.docker.com/r/softwaremill/elasticmq
is an alternative to https://hub.docker.com/r/pakohan/elasticmq
Which is now removed from the docker hub and thus failing installation

Closes: #3628, #3629 and #3623
