### PR TITLE
[Travis] Update elasticmq docker repository to softwaremill

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "5432:5432"
 
   sqs:
-    image: pakohan/elasticmq
+    image: softwaremill/elasticmq
     hostname: sqs
     ports:
       - 9324:9324


### PR DESCRIPTION
### Description

This PR -

- [x] Update the elasticmq docker repo to `softwaremill/elasticmq` for travis and local setup as older `pakohan/elasticmq` repo has been [deleted](https://hub.docker.com/r/pakohan/elasticmq).