### PR TITLE
[Worker] Upgrade to kubernetes version 1.21

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -1204,7 +1204,7 @@ def create_eks_cluster(challenge):
         try:
             response = client.create_cluster(
                 name=cluster_name,
-                version="1.16",
+                version="1.21",
                 roleArn=cluster_meta["EKS_CLUSTER_ROLE_ARN"],
                 resourcesVpcConfig={
                     "subnetIds": [


### PR DESCRIPTION
### Description

This PR - 

- [x] Upgrade the Kubernetes cluster version to 1.21 in code upload cluster creation API. AWS recently dropped support for [cluster versions 1.16-1.17](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html).