### PR TITLE
[Monitoring] Remove staging and prod probe alerts

### DIFF
--- a/monitoring/prometheus/prometheus_production.yml
+++ b/monitoring/prometheus/prometheus_production.yml
@@ -22,11 +22,6 @@ scrape_configs:
     static_configs:
       - targets: ['eval.ai']
 
-  - job_name: 'evalai'
-    metrics_path: '/'
-    static_configs:
-      - targets: ['eval.ai']
-
 alerting:
   alertmanagers:
   - path_prefix: '/alert_manager'

--- a/monitoring/prometheus/prometheus_staging.yml
+++ b/monitoring/prometheus/prometheus_staging.yml
@@ -22,11 +22,6 @@ scrape_configs:
     static_configs:
       - targets: ['staging.eval.ai']
 
-  - job_name: 'evalai'
-    metrics_path: '/'
-    static_configs:
-      - targets: ['staging.eval.ai']
-
 alerting:
   alertmanagers:
   - path_prefix: '/alert_manager'

--- a/monitoring/prometheus/rules.yml
+++ b/monitoring/prometheus/rules.yml
@@ -23,18 +23,6 @@ groups:
       severity: major
       group: 'instance'
 
-- name: EvalAI-Instance-Status
-  rules:
-  - alert: InstanceDown
-    expr: up{job="evalai"} == 0
-    for: 5m
-    annotations:
-      title: "EvalAI is down"
-      description: "*{{ $labels.job }}* on *{{ $labels.instance }}* has been down for more than 5 minutes"
-    labels:
-      severity: major
-      group: 'instance'
-
 - name: Worker-Down
   rules:
   - alert: WorkerDown

--- a/monitoring/prometheus/rules.yml
+++ b/monitoring/prometheus/rules.yml
@@ -26,11 +26,11 @@ groups:
 - name: Worker-Down
   rules:
   - alert: WorkerDown
-    expr: ((count by (queue_name) (num_submissions_in_queue{is_remote="0"})) - (count by (queue_name) (num_processed_submissions{is_remote="0"})))  >= 5
+    expr: ((sum by (queue_name) (num_submissions_in_queue{is_remote="0"})) - (sum by (queue_name) (num_processed_submissions{is_remote="0"}))) or sum by(queue_name)(num_submissions_in_queue{is_remote="0"})  >= 5
     for: 120m
     annotations:
       title: "Worker is down"
-      description: "*{{ $labels.queue_name }}* worker is not processing submissions"
+      description: "*{{ $labels.queue_name }}* worker on *{{ $labels.instance }}* is not processing submissions"
     labels:
       severity: major
       group: 'queue_name'


### PR DESCRIPTION
### Description

Current, set of alerts for monitoring endpoint uptime don't work directly as Prometheus doesn't support black-box probing of endpoints. We need to integrate some service like [black-box exporter](https://github.com/prometheus/blackbox_exporter) for the same

This PR - 

- [x] Removes alerts for probing `staging.eval.ai` and `eval.ai`.  