### PR TITLE
Fix #3644: Update deploy.sh to fetch and run containers for all active challenges

### DIFF
--- a/docker/dev/code-upload-worker/Dockerfile
+++ b/docker/dev/code-upload-worker/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir /code
 WORKDIR /code
 
 RUN apt-get update && \
-  apt-get install --no-install-recommends -y unzip && \
+  apt-get install --no-install-recommends -y unzip jq && \
   rm -rf /var/lib/apt/lists/*
 
 ADD requirements/* /code/


### PR DESCRIPTION
The script when run with this option fetches all active challenges and
their respective queues. Running the docker container for each fetched
queue.
I am not quite sure how active containers are put down, but this PR is based on the assumption that the new started containers won't have conflicts with names since all the old containers have already been stopped.

Closes #3644 