### PR TITLE
[BugFix] Frontend V2 challenge page improvements

### DIFF
--- a/frontend_v2/src/app/components/challenge/challenge.component.html
+++ b/frontend_v2/src/app/components/challenge/challenge.component.html
@@ -96,7 +96,7 @@
                         <i class="fa fa-level-up"></i> Phases</a
                       >
                     </li>
-                    <li *ngIf="!isParticipated">
+                    <li *ngIf="!isParticipated && !isPast">
                       <a
                         [class.selected]="localRouter.url.endsWith('participate')"
                         [routerLink]="['./participate']"
@@ -135,7 +135,7 @@
                     </li>
                     <li>
                       <a
-                        [class.selected]="localRouter.url.endsWith('leaderboard')"
+                        [class.selected]="localRouter.url.includes('leaderboard')"
                         [routerLink]="['./leaderboard']"
                         class="text-light-black fw-light fs-15"
                       >

--- a/frontend_v2/src/app/components/challenge/challenge.component.ts
+++ b/frontend_v2/src/app/components/challenge/challenge.component.ts
@@ -73,6 +73,11 @@ export class ChallengeComponent implements OnInit {
   isLoggedIn: any = false;
 
   /**
+   * Is past challenge
+   */
+  isPast: any = false;
+
+  /**
    * Constructor.
    * @param router  Router Injection.
    * @param route  ActivatedRoute Injection.
@@ -113,6 +118,7 @@ export class ChallengeComponent implements OnInit {
       this.isForumEnabled = challenge.enable_forum;
       this.forumURL = challenge.forum_url;
       this.isApprovedByAdmin = challenge.approved_by_admin;
+      this.isPast = this.isPastChallenge();
       // update meta tag
       SELF.meta.updateTag({
         property: 'og:title',
@@ -150,5 +156,12 @@ export class ChallengeComponent implements OnInit {
     } else {
       this.globalService.showToast('error', 'Please login to star the challenge!', 5);
     }
+  }
+
+  isPastChallenge() {
+    const PRESENT = new Date();
+    const START_DATE = new Date(Date.parse(this.challenge['start_date']));
+    const END_DATE = new Date(Date.parse(this.challenge['end_date']));
+    return (PRESENT > END_DATE);
   }
 }

--- a/frontend_v2/src/app/components/challenge/challengediscuss/challengediscuss.component.ts
+++ b/frontend_v2/src/app/components/challenge/challengediscuss/challengediscuss.component.ts
@@ -77,8 +77,7 @@ export class ChallengediscussComponent implements OnInit {
             SELF.globalService.showToast('success', 'The challenge forum url is successfully updated!', 5);
           },
           (err) => {
-            SELF.globalService.handleApiError(err, true);
-            SELF.globalService.showToast('error', err);
+            SELF.globalService.showToast('error', 'Please enter a valid URL', 5);
           },
           () => {}
         );
@@ -89,7 +88,7 @@ export class ChallengediscussComponent implements OnInit {
      */
     const PARAMS = {
       title: 'Change Forum URL',
-      content: 'Enter new forum url',
+      content: '',
       confirm: 'Confirm',
       deny: 'Cancel',
       form: [

--- a/frontend_v2/src/app/components/challenge/challengephases/phasecard/phasecard.component.html
+++ b/frontend_v2/src/app/components/challenge/challengephases/phasecard/phasecard.component.html
@@ -26,21 +26,21 @@
         <div class="row rm-margin">
           <div class="col-lg-4 no-pad-lr element">
             <p>
-              <strong class="text-light-black fw-regular text-med-black  fs-16">Submissions/day</strong> <br />
+              <strong class="text-light-black fw-regular text-med-black  fs-16">Submissions/day: </strong>
               <strong class="fs-14 phase-value fw-light">{{ phase['max_submissions_per_day'] }}</strong>
             </p>
           </div>
 
           <div class="col-lg-4 no-pad-lr element">
             <p>
-              <strong class="text-light-black fw-regular text-med-black  fs-16">Submissions/month</strong> <br />
+              <strong class="text-light-black fw-regular text-med-black  fs-16">Submissions/month: </strong>
               <strong class="fs-14 phase-value fw-light">{{ phase['max_submissions_per_month'] }}</strong>
             </p>
           </div>
 
           <div class="col-lg-4 no-pad-lr element">
             <p>
-              <strong class="text-light-black fw-regular text-med-black  fs-16">Total submissions</strong> <br />
+              <strong class="text-light-black fw-regular text-med-black  fs-16">Total submissions: </strong>
               <strong class="fs-14 phase-value fw-light">{{ phase['max_submissions'] }}</strong>
             </p>
           </div>

--- a/frontend_v2/src/app/components/challenge/challengephases/phasecard/phasecard.component.html
+++ b/frontend_v2/src/app/components/challenge/challengephases/phasecard/phasecard.component.html
@@ -26,21 +26,21 @@
         <div class="row rm-margin">
           <div class="col-lg-4 no-pad-lr element">
             <p>
-              <strong class="text-light-black fw-regular text-med-black  fs-16">Max number of submissions/day</strong> <br />
+              <strong class="text-light-black fw-regular text-med-black  fs-16">Submissions/day</strong> <br />
               <strong class="fs-14 phase-value fw-light">{{ phase['max_submissions_per_day'] }}</strong>
             </p>
           </div>
 
           <div class="col-lg-4 no-pad-lr element">
             <p>
-              <strong class="text-light-black fw-regular text-med-black  fs-16">Max number of submissions/month</strong> <br />
+              <strong class="text-light-black fw-regular text-med-black  fs-16">Submissions/month</strong> <br />
               <strong class="fs-14 phase-value fw-light">{{ phase['max_submissions_per_month'] }}</strong>
             </p>
           </div>
 
           <div class="col-lg-4 no-pad-lr element">
             <p>
-              <strong class="text-light-black fw-regular text-med-black  fs-16">Max total submissions</strong> <br />
+              <strong class="text-light-black fw-regular text-med-black  fs-16">Total submissions</strong> <br />
               <strong class="fs-14 phase-value fw-light">{{ phase['max_submissions'] }}</strong>
             </p>
           </div>


### PR DESCRIPTION
### Description


This PR - 

- [x] Hide participate tab for past challenges 
- [x] Show the highlighted underline on the challenge page leaderboard tab after a phase is selected
- [x] Rename `Max submissions` label on the Phases tab to `submissions/day`, `'submission/month`
- [x] Remove redundant `Edit forum URL` text in forum edit tab and fix the URL validation error toast 

Phase tab changes:

![Screenshot from 2022-01-08 14-32-27](https://user-images.githubusercontent.com/16323427/148657691-1e2d7abe-e980-4de7-a91b-8b5116c87126.png)

Leaderboard tab highlight changes:

![Screenshot from 2022-01-08 14-32-27](https://user-images.githubusercontent.com/16323427/148657709-589d926b-d12e-41ee-99e1-65af229043e1.png)
