### PR TITLE
[FrontendV2] Analytics and all submissions page improvements

### DIFF
--- a/frontend_v2/src/app/components/challenge/challengeanalytics/challengeanalytics.component.html
+++ b/frontend_v2/src/app/components/challenge/challengeanalytics/challengeanalytics.component.html
@@ -43,50 +43,51 @@
           </div>
         </div>
       </div>
-      <div class="fw-light fs-16">
-        <div class="analytics-challenge-card">
-          <div class="analytics-phases-card" *ngFor="let item of currentPhase">
-            <h5 class="no-top-para fw-light phase-detail">
-              {{ item.name }}
-            </h5>
-            <div [innerHTML]="challenge['short_description']"></div>
-            <br />
-            <div class="text-light-black fw-semibold phase-duration phase-detail">
-              Challenge Phase Duration
+      
+    </div>
+  </div>
+  <div class="fw-light fs-16">
+    <div class="analytics-challenge-card">
+      <div class="analytics-phases-card ev-card-panel ev-md-container card-bt-margin" *ngFor="let item of currentPhase">
+        <h5 class="no-top-para fw-light phase-detail">
+          {{ item.name }}
+        </h5>
+        <div [innerHTML]="challenge['short_description']"></div>
+        <br />
+        <div class="text-light-black fw-semibold phase-duration phase-detail">
+          Challenge Phase Duration
+        </div>
+        <p class="no-top-para phase-detail">
+          {{ item.start_date | date: 'medium' }} - {{ item.end_date | date: 'medium' }}
+        </p>
+        <br />
+        <div class="row center">
+          <div class="col m3">
+            <div class="text-light-black fw-semibold">
+              Total Submissions
             </div>
-            <p class="no-top-para phase-detail">
-              {{ item.start_date | date: 'medium' }} - {{ item.end_date | date: 'medium' }}
+            <p class="analytics-content no-top-para mb-5">
+              {{ totalSubmission[item.id] || 0 }}
             </p>
-            <br />
-            <div class="row center">
-              <div class="col m3">
-                <div class="text-light-black fw-semibold">
-                  Total Submissions
-                </div>
-                <p class="analytics-content no-top-para mb-5">
-                  {{ totalSubmission[item.id] || 0 }}
-                </p>
-              </div>
-              <div class="col m3">
-                <div class="text-light-black fw-semibold">
-                  Participant Teams
-                </div>
-                <p class="analytics-content no-top-para mb-5">
-                  {{ totalParticipatedTeams[item.id] || 0 }}
-                </p>
-              </div>
-              <div class="col m3">
-                <div class="text-light-black fw-semibold">
-                  Latest Submission At
-                </div>
-                <p *ngIf="lastSubmissionTime[item.id]" class="analytics-content no-top-para mb-5">
-                  {{ lastSubmissionTime[item.id] | date: 'medium' }}
-                </p>
-                <p *ngIf="!lastSubmissionTime[item.id]" class="analytics-content no-top-para mb-5">
-                  None
-                </p>
-              </div>
+          </div>
+          <div class="col m3">
+            <div class="text-light-black fw-semibold">
+              Participant Teams
             </div>
+            <p class="analytics-content no-top-para mb-5">
+              {{ totalParticipatedTeams[item.id] || 0 }}
+            </p>
+          </div>
+          <div class="col m3">
+            <div class="text-light-black fw-semibold">
+              Latest Submission At
+            </div>
+            <p *ngIf="lastSubmissionTime[item.id]" class="analytics-content no-top-para mb-5">
+              {{ lastSubmissionTime[item.id] | date: 'medium' }}
+            </p>
+            <p *ngIf="!lastSubmissionTime[item.id]" class="analytics-content no-top-para mb-5">
+              None
+            </p>
           </div>
         </div>
       </div>

--- a/frontend_v2/src/app/components/challenge/challengeanalytics/challengeanalytics.component.ts
+++ b/frontend_v2/src/app/components/challenge/challengeanalytics/challengeanalytics.component.ts
@@ -67,8 +67,10 @@ export class ChallengeanalyticsComponent implements OnInit {
     this.challengeService.currentChallenge.subscribe((challenge) => {
       this.challenge = challenge;
       this.challengeId = this.challenge['id'];
+      if (this.challengeId !== undefined && this.challengeId !== null) {
+        this.showChallengeAnalysis();
+      }
     });
-    this.showChallengeAnalysis();
   }
 
   errCallBack(err) {

--- a/frontend_v2/src/app/components/challenge/challengesubmit/challengesubmit.component.html
+++ b/frontend_v2/src/app/components/challenge/challengesubmit/challengesubmit.component.html
@@ -15,14 +15,6 @@
         </div>
         <div [innerHTML]="submissionGuidelines" class="submission-guidelines fw-light fs-16"></div>
       </div>
-      <div *ngIf="isChallengeHost" class="col-md-1 col-sm-1 col-xs-2 col-lr-pad">
-        <a class="pointer fs-16" (click)="editSubmissionGuideline()">
-          <i class="fa fa-pencil" aria-hidden="true"> </i>&nbsp;edit
-        </a>
-        <a class="pointer fs-16" (click) = "editSubmissionGuidelineUpload()">
-          <i class="fa fa-upload" aria-hidden="true"> </i>
-        </a>
-      </div>
     </div>
   </div>
   <div *ngIf="challenge.is_docker_based" class="ev-md-container ev-card-panel card-bt-margin">

--- a/frontend_v2/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.html
+++ b/frontend_v2/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.html
@@ -133,32 +133,10 @@
               [class.expanded-row]="element == expandedElement"
               [@detailExpand]="element == expandedElement ? 'expanded' : 'collapsed'"
             >
-              <div class="elements-detail">
-                <div class="element">
-                    <strong class="element-description-attribution">Team Members</strong>&nbsp;
-                    <strong
-                      *ngFor="let team of element.participant_team_members; let i = index"
-                      class="fw-light fs-14"
-                    >
-                      <span *ngIf="element.participant_team_members.length !== i + 1"> {{ team.username + ' ,' }}</span>
-                      <span *ngIf="element.participant_team_members.length === i + 1"> {{ team.username }}</span>
-                    </strong>
-                  <span class=""></span>
-                </div>
-                <div class="element">
-                    <strong class="element-description-attribution">Team Members Email Id</strong>&nbsp;
-                    <strong
-                      *ngFor="let team of element.participant_team_members; let i = index"
-                      class="fw-light fs-14"
-                    >
-                      <span *ngIf="element.participant_team_members.length !== i + 1"> {{ team.email + ' ,' }}</span>
-                      <span *ngIf="element.participant_team_members.length === i + 1"> {{ team.email }}</span>
-                    </strong>
-                </div>
+              <div class="elements-status">
                   <div class="element">
                       <strong class="element-description-attribution"
-                        >Stdout file&nbsp;<i class="fa fa-file fs-12" aria-hidden="true"></i></strong
-                      >&nbsp;
+                        >Stdout file :&nbsp;</strong>&nbsp;
                       <a
                         target="_blank"
                         class="blue-text fs-14"
@@ -173,8 +151,7 @@
                   </div>
                   <div class="element">
                       <strong class="element-description-attribution"
-                        >Stderr file&nbsp;<i class="fa fa-file fs-12" aria-hidden="true"></i></strong
-                      >&nbsp;
+                        >Stderr file :&nbsp;</strong>&nbsp;
                       <a
                         target="_blank"
                         class="blue-text fs-14"
@@ -187,71 +164,47 @@
                         None
                       </strong>
                   </div>
+                  <div class="element">
+                      <strong class="element-description-attribution"
+                        >Metadata file :&nbsp;</strong>&nbsp;
+                      <a
+                        target="_blank"
+                        class="blue-text fs-14"
+                        [href]="element.submission_metadata_file"
+                        *ngIf="element.submission_metadata_file"
+                      >
+                        <i class="fa fa-external-link"></i> Link
+                      </a>
+                      <strong *ngIf="!element.submission_metadata_file" class="fw-light fs-14">
+                        None
+                      </strong>
+                  </div>
               </div>
               <div class="elements-status">
                 <div class="element">
-                    <strong class="element-description-attribution">Status</strong> &nbsp;
-                    <strong class="fw-light fs-14" [ngClass]="element.status" class="fs-12">
-                      {{ element.status | uppercase }}
-                    </strong>
-                </div>
-                <div class="element">
-                    <strong class="element-description-attribution">Submission Number</strong> &nbsp;
+                    <strong class="element-description-attribution">Submission Id :</strong> &nbsp;
                     <strong class="fw-light fs-14">
-                      {{ element.submission_number }}
+                      {{ element.id }}
                     </strong>
                 </div>
                 <div class="element">
-                    <strong class="element-description-attribution">Submitted At</strong> &nbsp;
+                    <strong class="element-description-attribution">Submitted At :</strong> &nbsp;
                     <strong class="fw-light fs-14">
                       {{ element.created_at | date: 'medium' }}
                     </strong>
                 </div>
-                <div class="element">
-                    <strong class="element-description-attribution"
-                      >Metadata file&nbsp;<i class="fa fa-file fs-12" aria-hidden="true"></i></strong
-                    >&nbsp;
-                    <a
-                      target="_blank"
-                      class="blue-text fs-14"
-                      [href]="element.submission_metadata_file"
-                      *ngIf="element.submission_metadata_file"
-                    >
-                      <i class="fa fa-external-link"></i> Link
-                    </a>
-                    <strong *ngIf="!element.submission_metadata_file" class="fw-light fs-14">
-                      None
-                    </strong>
-                </div>
               </div>
               <div class="elements-action">
-                <div class="element">
-                    <mat-checkbox
-                      class="element-icon fw-light"
-                      [checked]="element.is_public"
-                      [disabled]="element.status !== 'finished' || !selectedPhase['leaderboard_public']"
-                      (change)="confirmSubmissionVisibility(element, element.is_public)"
-                    >
-                    <strong class="fs-14">
-                      Show On Leaderboard
-                    </strong>
-                    </mat-checkbox>
-                </div>
-                <div class="element">
-                    <mat-checkbox
-                      class="element-icon"
-                      [checked]="element.is_flagged"
-                      (change)="confirmSubmissionFlagChange(element, element.is_flagged)"
-                    >
-                    <strong class="fs-14">
-                      {{ element.submissionFlagText }}
-                    </strong>
-                    </mat-checkbox>
-                </div>
                 <div class="element element-description-attribution">
                   <a (click)="reRunSubmission(element.id)">
                     <strong class="fa fa-refresh pointer "> &nbsp;</strong>
                     <strong>Re-run submission</strong>
+                  </a>
+                </div>
+                <div class="element element-description-attribution" *ngIf="isChallengeHost">
+                  <a class="pointer" (click)="cancelSubmission(element)">
+                    <i class="fa fa-times" aria-hidden="true"> &nbsp;</i>
+                    <strong>Cancel Submission</strong>
                   </a>
                 </div>
                 <div class="element element-description-attribution" *ngIf="isChallengeHost">

--- a/frontend_v2/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
+++ b/frontend_v2/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
@@ -297,7 +297,6 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
             SELF.submissions[i].submissionVisibilityText = SELF.submissions[i].is_public ? 'Public' : 'Private';
             // Update view for flag submission setting
             SELF.submissions[i].submissionFlagIcon = SELF.submissions[i].is_flagged ? 'flag' : 'outlined_flag';
-            SELF.submissions[i].submissionFlagText = SELF.submissions[i].is_flagged ? 'Flagged' : 'UnFlagged';
           }
 
           SELF.paginationDetails.next = data.next;
@@ -505,7 +504,6 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
       SELF.apiService.patchUrl(API_PATH, BODY).subscribe(
         () => {
           submission.submissionFlagIcon = is_flagged ? 'flag' : 'outlined_flag';
-          submission.submissionFlagText = is_flagged ? 'Flagged' : 'Unflagged';
           const toastMessage = is_flagged ? 'Submission flagged successfully!' : 'Submission unflagged successfully!';
           SELF.globalService.showToast('success', toastMessage);
         },
@@ -613,6 +611,52 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
       isButtonDisabled: true,
       confirm: 'Yes',
       deny: 'No',
+      confirmCallback: SELF.apiCall,
+    };
+    SELF.globalService.showModal(PARAMS);
+  }
+
+  /**
+   * Display Cancel Submission Modal.
+   * @param submission  Submission being cancelled
+   */
+  cancelSubmission(submission) {
+    const SELF = this;
+    if (submission.status != "submitted") {
+      SELF.globalService.showToast('error', 'Only unproccessed submissions can be cancelled', 5);
+      return;
+    }
+    SELF.apiCall = () => {
+      const BODY = JSON.stringify({
+        "status": "cancelled"
+      });
+      SELF.apiService
+        .patchUrl(
+          SELF.endpointsService.updateSubmissionMetaURL(
+            SELF.challenge.id,
+            submission.id
+          ),
+          BODY
+        )
+        .subscribe(
+          () => {
+            // Success Message in data.message
+            SELF.globalService.showToast('success', 'Submission status updated successfully', 5);
+            SELF.fetchSubmissions(SELF.challenge.id, SELF.selectedPhase.id);
+          },
+          (err) => {
+            SELF.globalService.handleApiError(err, true);
+          },
+          () => this.logger.info('SUBMISSION-CANCELLED')
+        );
+    };
+    const PARAMS = {
+      title: 'Are you sure you want to cancel submission?',
+      content: '',
+      isButtonDisabled: true,
+      confirm: 'Submit',
+      deny: 'Cancel',
+      form: [],
       confirmCallback: SELF.apiCall,
     };
     SELF.globalService.showModal(PARAMS);


### PR DESCRIPTION
### Description

This PR - 

- [x] Show cards for phases on the analytics page
- [x] Remove edit options from `Submission guidelines` card on submit page
- [x] Remove `fa fa` icons from `All submissions` page stdout and stderr fields
- [x] Remove `Show on Leaderboard` option from `All submissions` page
- [x] Remove `flagged`, `team name`, `team members`, `status`, `submission number` field from  `All submissions` page
- [x] Add `Cancel submission` feature on `All submissions` page

Analytics page:

![Screenshot from 2022-01-09 15-14-50 (1)](https://user-images.githubusercontent.com/16323427/148700020-7bd4bd14-be2f-4ab9-af39-3c1d1c714b81.png)

All submission page:

![Screenshot from 2022-01-09 15-37-27 (1)](https://user-images.githubusercontent.com/16323427/148700029-e52a0a2b-ab02-410a-9fb7-b8cfdaf41bae.png)
