### PR TITLE
[TravisCI] Fix karma reporting config

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -49,13 +49,14 @@ module.exports = function(config) {
         'karma-jasmine',
         'karma-chrome-launcher',
         'karma-coverage',
-        'karma-coveralls'
+        'karma-coveralls',
+        'karma-brief-reporter',
     ],
 
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress', 'coverage'],
+    reporters: ['coverage', 'brief'],
 
 
     // web server port

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "karma-cli": "^2.0.0",
     "karma-coverage": "^1.1.2",
     "karma-coveralls": "^2.1.0",
+    "karma-brief-reporter": "^0.2.1",
     "karma-jasmine": "^2.0.1",
     "puppeteer": "^1.16.0"
   }


### PR DESCRIPTION
### Description

This PR - 

- [x] Switch to [`karma-brief-reporting`](https://www.npmjs.com/package/karma-brief-reporter) for frontend test status logging. The built-in reporting plugins seem to have some issue which is causing the [log output](https://app.travis-ci.com/github/Cloud-CV/EvalAI/builds/244549300#L2802) to have different text encoding.