### PR TITLE
Fix #3665 : Change Link in Docs , Host Challenge using github

### DIFF
--- a/docs/source/host_challenge.md
+++ b/docs/source/host_challenge.md
@@ -47,7 +47,7 @@ We categorize the challenges in two categories:
 
 ### Step 1: Use template
 
-Use [EvalAI-Starters](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template) repository as template.
+Use [EvalAI-Starters] repository as template.
 
    <img src="_static/img/github_based_setup/use_template_1.png"><br />
    <img src="_static/img/github_based_setup/use_template_2.png"><br />


### PR DESCRIPTION
Before when we click on **EvalAI-Starters** it use to take to different page Fig: 2. Now it takes to the EvalAI-Starters repository Fig: 3. 
Fig: 1
<img width="1440" alt="ss2" src="https://user-images.githubusercontent.com/60038994/148997507-815eb903-70b9-49cd-8046-1ce0ed6579ff.png">
Fig: 2
<img width="1440" alt="ss1" src="https://user-images.githubusercontent.com/60038994/148997296-1f3f4682-84b8-4e13-8e2a-883a6ee58889.png">
Fig: 3
<img width="1440" alt="ss4" src="https://user-images.githubusercontent.com/60038994/148997772-aa276f64-f71f-4716-8a33-58ca8ea2b994.png">

