### PR TITLE
Revert Cilium network policy

### DIFF
--- a/scripts/workers/code_upload_worker_utils/install_dependencies.sh
+++ b/scripts/workers/code_upload_worker_utils/install_dependencies.sh
@@ -45,9 +45,9 @@ echo "### Cilium Installed"
 sleep 120s;
 
 # Apply cilium network policy
-echo "### Setting up Cilium Network Policy..."
-cat /code/scripts/workers/code_upload_worker_utils/network_policies.yaml | sed "s/{{EVALAI_DNS}}/$EVALAI_DNS/" | kubectl apply -f -
-echo "### Cilium EvalAI Network Policy Installed"
+# echo "### Setting up Cilium Network Policy..."
+# cat /code/scripts/workers/code_upload_worker_utils/network_policies.yaml | sed "s/{{EVALAI_DNS}}/$EVALAI_DNS/" | kubectl apply -f -
+# echo "### Cilium EvalAI Network Policy Installed"
 
 # Set ssl-certificate
 echo $CERTIFICATE | base64 --decode > scripts/workers/certificate.crt


### PR DESCRIPTION
### Description


This PR -

- [x] Reverts CNP. CNP keeps failing to allow traffic to whitelisted routes when multiple jobs are running in parallel with following error logs from init-container

```

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Err:1 http://security.ubuntu.com/ubuntu focal-security InRelease
  Temporary failure resolving 'security.ubuntu.com'
Err:2 http://archive.ubuntu.com/ubuntu focal InRelease
  Temporary failure resolving 'archive.ubuntu.com'
Err:3 http://archive.ubuntu.com/ubuntu focal-updates InRelease
  Temporary failure resolving 'archive.ubuntu.com'
Err:4 http://archive.ubuntu.com/ubuntu focal-backports InRelease
  Temporary failure resolving 'archive.ubuntu.com'
Reading package lists...
Building dependency tree...
Reading state information...
All packages are up to date.
W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/focal/InRelease  Temporary failure resolving 'archive.ubuntu.com'
W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/focal-updates/InRelease  Temporary failure resolving 'archive.ubuntu.com'
W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/focal-backports/InRelease  Temporary failure resolving 'archive.ubuntu.com'
W: Failed to fetch http://security.ubuntu.com/ubuntu/dists/focal-security/InRelease  Temporary failure resolving 'security.ubuntu.com'
W: Some index files failed to download. They have been ignored, or old ones used instead.

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...

```