### PR TITLE
Fix #3676 [Frontend] Fix the twitter feed loading when user navigates back to homepage

### DIFF
--- a/frontend_v2/src/app/components/home/home.component.ts
+++ b/frontend_v2/src/app/components/home/home.component.ts
@@ -94,9 +94,11 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
 
   /**
    * Set SUBSCRIBE_FORM to this.components after view initialization
+   * (<any>window).twttr.widgets.load() this load Twitter Feed
    */
   ngAfterViewInit() {
     this.SUBSCRIBE_FORM[this.subscribeForm] = this.components;
+    (<any>window).twttr.widgets.load();
   }
 
   init() {

--- a/frontend_v2/src/app/components/home/home.component.ts
+++ b/frontend_v2/src/app/components/home/home.component.ts
@@ -94,7 +94,6 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
 
   /**
    * Set SUBSCRIBE_FORM to this.components after view initialization
-   * (<any>window).twttr.widgets.load() this load Twitter Feed
    */
   ngAfterViewInit() {
     this.SUBSCRIBE_FORM[this.subscribeForm] = this.components;


### PR DESCRIPTION
**Description**

The twitter feed homepage use to fails when a users visits some other page after visiting the homepage and then comes back to the homepage. 

**Steps to reproduce:**

Open EvalAI homepage on FrontendV2
Navigate to login/signup page
Navigate back to homepage and check the twitter feed

**GIF for reference:**
![twitterFeedIssue](https://user-images.githubusercontent.com/60038994/149905111-7d2483e5-4cdd-4857-a6e6-b2b548a0239e.gif)


