### PR TITLE
[FrontendV2] Improvements on challenge page

### DIFF
--- a/frontend_v2/src/app/components/challenge-create/challenge-create.component.html
+++ b/frontend_v2/src/app/components/challenge-create/challenge-create.component.html
@@ -62,7 +62,7 @@
         </div>
         <br />
         <div class="center-element fs-20">OR</div><br/>
-        <div class="waves-effect waves-dark btn ev-btn-dark w-300 use-template" [routerLink]="[challengeTemplatesListRoute]">
+        <div class="waves-effect waves-dark btn grad-btn ev-btn-dark w-300 use-template" [routerLink]="[challengeTemplatesListRoute]">
         <span>Use a Template</span>
         </div>
       </section>

--- a/frontend_v2/src/app/components/challenge/challenge.component.html
+++ b/frontend_v2/src/app/components/challenge/challenge.component.html
@@ -57,7 +57,7 @@
                 </div>
                 <div class="col-lg-3 col-md-3">
                   <button
-                    class="stars btn-waves-effect grad-rec-btn grad-btn-dark ev-btn-dark fw-light fs-14"
+                    class="stars btn-waves-effect grad-btn grad-btn-dark ev-btn-dark fw-light fs-14"
                     type="submit"
                     [class.is-clickable]="isLoggedIn"
                     (click)="starToggle(challenge['id'])"

--- a/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.html
+++ b/frontend_v2/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.html
@@ -1,6 +1,6 @@
 <div class="challenge-card">
   <div class="ev-card-panel card-bt-margin">
-    <div class="ev-md-container ev-panel-title" *ngIf="challenge.leaderboard_description">
+    <div class="ev-md-container ev-panel-title">
       <div class="row row-lr-margin">
         <div class="col-sm-12 col-xs-12 col-lr-pad">
           <h5 class="fw-light">Leaderboard</h5>
@@ -8,6 +8,7 @@
         <div
           class="col-sm-12 md-body-1 col-lr-pad fs-16 fw-light"
           [innerHTML]="challenge.leaderboard_description"
+          *ngIf="challenge.leaderboard_description"
         ></div>
       </div>
     </div>

--- a/frontend_v2/src/app/components/challenge/challengephases/phasecard/phasecard.component.html
+++ b/frontend_v2/src/app/components/challenge/challengephases/phasecard/phasecard.component.html
@@ -9,7 +9,7 @@
   <div class="row row-lr-margin">
     <div class="col-sm-12 col-lr-pad">
       <div class="row rm-margin">
-        <div class="col-md-8 col-lg-8 no-pad-lr element">
+        <div class="col-md-4 col-lg-4 no-pad-lr element">
           <p>
             <strong class="text-light-black fw-regular text-med-black fs-16">Starts on</strong> <br />
             <strong class="fw-light fs-14 phase-value">{{ startDate }} {{ phase['start_zone'] }}</strong>
@@ -21,7 +21,12 @@
             <strong class="fw-light fs-14 phase-value">{{ endDate }} {{ phase['end_zone'] }}</strong>
           </p>
         </div>
-        <div [innerHTML]="phase['description']" class="phase-description content fw-light"></div>
+        
+        <div class="row rm-margin">
+          <div class="col-md-11 col-lg-11 no-pad-lr element">
+            <div [innerHTML]="phase['description']" class="phase-description content fw-light"></div>
+          </div>
+        </div>
 
         <div class="row rm-margin">
           <div class="col-lg-4 no-pad-lr element">

--- a/frontend_v2/src/app/components/challenge/challengesubmissions/challengesubmissions.component.html
+++ b/frontend_v2/src/app/components/challenge/challengesubmissions/challengesubmissions.component.html
@@ -36,7 +36,7 @@
             </mat-form-field>
           </div>
           <div class="col-md-2 col-sm-2 col-xs-6 col-lg-6 col-lr-pad download-submissions">
-            <a class="waves-effect waves-dark btn ev-btn-dark fw-light fs-16" (click)="downloadSubmission()">Download </a>
+            <a class="waves-effect waves-dark btn grad-btn ev-btn-dark fw-light fs-16" (click)="downloadSubmission()">Download </a>
           </div>
         </div>
       </div>
@@ -104,18 +104,18 @@
             >
               <div class="elements-detail">
                 <div class="element">
-                  <strong class="element-description-attribution">Submitted At: </strong>&nbsp;
+                  <strong class="element-description-attribution">Submitted at: </strong>&nbsp;
                   <strong class="fw-light fs-14">
                     {{ element.submitted_at | date: 'medium' }}
                   </strong>
                 </div>
               </div>
               <div class="elements-status">
-                <div class="element">
+                <div class="element" *ngIf="!selectedPhase['leaderboard_public'] || !selectedPhase['is_submission_public']">
                   <mat-checkbox
                     class="element-icon fw-light"
                     [checked]="element.is_public"
-                    [disabled]="element.status === 'failed' || element.status === 'cancelled' || !selectedPhase['leaderboard_public'] || !selectedPhase['is_submission_public']"
+                    [disabled]="element.status === 'failed' || element.status === 'cancelled'"
                     (change)="changeSubmissionVisibility(element.id, element.is_public)"
                   >
                     <strong class="fs-14">Show on leaderboard</strong>

--- a/frontend_v2/src/app/components/challenge/challengesubmit/challengesubmit.component.html
+++ b/frontend_v2/src/app/components/challenge/challengesubmit/challengesubmit.component.html
@@ -152,10 +152,12 @@
 
   <!-- If challenge is not docker based -->
   <div *ngIf="!challenge.is_docker_based && isActive" class="ev-md-container ev-card-panel z-depth-5 ev-challenge-view ">
-    <div class="bottom-card-container bottom-hr-line">
-      <div class="col s12">
-        <h5 class="fw-light">Make Submission</h5>
-      </div>
+      <div class="card-bt-margin ev-panel-title">
+        <div class="row row-lr-margin">
+          <div class="col s12">
+            <h5 class="fw-light">Make Submission</h5>
+          </div>
+        </div>
     </div>
     <div class="row margin-bottom-cancel">
       <div class="col-md-7 col-sm-7 col-xs-10">

--- a/frontend_v2/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.html
+++ b/frontend_v2/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.html
@@ -135,13 +135,13 @@
             >
               <div class="elements-detail">
                 <div class="element">
-                    <strong class="element-description-attribution">Submission Id :</strong> &nbsp;
+                    <strong class="element-description-attribution">Submission id :</strong> &nbsp;
                     <strong class="fw-light fs-14">
                       {{ element.id }}
                     </strong>
                 </div>
                 <div class="element">
-                    <strong class="element-description-attribution">Submitted At :</strong> &nbsp;
+                    <strong class="element-description-attribution">Submitted at :</strong> &nbsp;
                     <strong class="fw-light fs-14">
                       {{ element.created_at | date: 'medium' }}
                     </strong>

--- a/frontend_v2/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.scss
+++ b/frontend_v2/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.scss
@@ -59,7 +59,7 @@
 
 tr.element-row:not(.expanded-row):hover {
   cursor: pointer;
-  background: $grad-light-black;
+  background: $super-light-shadow;
 }
 
 tr.element-row.expanded-row {

--- a/frontend_v2/src/app/components/utility/forcelogin/forcelogin.component.html
+++ b/frontend_v2/src/app/components/utility/forcelogin/forcelogin.component.html
@@ -1,1 +1,1 @@
-<div class="content fs-16 fw-light">Please <a (click)="redirectToLogin()">Login</a> to access this section.</div>
+<div class="content fs-16 fw-light">Please <a (click)="redirectToLogin()" class="highlight-link">Login</a> to access this section.</div>

--- a/frontend_v2/src/app/components/utility/input/input.component.html
+++ b/frontend_v2/src/app/components/utility/input/input.component.html
@@ -78,7 +78,6 @@
         accept="{{ accept }}"
         (change)="handleFileInput($event.target.files)"
         type="file"
-        class="text-dark-black"
         [readonly]="isReadonly"
       />
     </div>

--- a/frontend_v2/src/app/components/utility/selectphase/selectphase.component.ts
+++ b/frontend_v2/src/app/components/utility/selectphase/selectphase.component.ts
@@ -127,7 +127,7 @@ export class SelectphaseComponent implements OnInit, OnChanges {
       this.selectedPhaseSplit = this.phaseSplits[0];
       this.phaseName = this.selectedPhaseSplit['challenge_phase_name'];
       this.splitName = this.selectedPhaseSplit['dataset_split_name'];
-      //this.selectPhaseSplit(this.phaseSplits[0], 'selectBox', 'phaseSplit');
+      this.selectPhaseSplit(this.phaseSplits[0], 'selectBox', 'phaseSplit');
     }
   }
 


### PR DESCRIPTION
### Description

This PR - 

- [x] Show start and end dates of phase in consecutive columns.
- [x] Highlight login hyperlink on challenge page
- [x] Fix padding on the submit tab around text `Make submission`
- [x]  Fix leaderboard loading when user switches tabs on the challenge page
- [x]  Rename `Submitted At` -> `Submitted at` and `Submission Id` -> `Submitted id`
- [x] Reduce opacity of hover on all submissions page


![Screenshot from 2022-01-22 17-07-14](https://user-images.githubusercontent.com/16323427/150656962-c737a629-3066-48a6-b5a9-ac989ccba557.png)

![Screenshot from 2022-01-22 16-57-56](https://user-images.githubusercontent.com/16323427/150656966-5bb859fa-132c-433d-bad9-87ef9d13cf3e.png)
