### PR TITLE
Docs: Fixed some typos in docs

### DIFF
--- a/docs/source/approve_challenge.md
+++ b/docs/source/approve_challenge.md
@@ -2,7 +2,7 @@
 
 **Note:** If you are hosting the challenge on [eval.ai](https://eval.ai), then you cannot approve your challenge. It will be approved by [EvalAI team](https://eval.ai/team). You can skip this section.
 
-Once a challenge config has been uploaded, the challenge has to be approved by the EvalAI Admin (i.e. you if you are setting up EvalAI yourself on your server) to make it available to everyone. Please follow the following steps to approve a challenge (if you are ):
+Once a challenge config has been uploaded, the challenge has to be approved by the EvalAI Admin (i.e. you if you are setting up EvalAI yourself on your server) to make it available to everyone. Please follow the following steps to approve a challenge (if you are):
 
 Let's assume that we want to approve a challenge with name `Random Number Generator Challenge`.
 

--- a/docs/source/configuration.md
+++ b/docs/source/configuration.md
@@ -91,7 +91,7 @@ Following fields are required (and can be customized) in the [`challenge_config.
 
   Dataset splits define the subset of test-set on which the submissions will be evaluated on. Generally, most challenges have two splits:
 
-  1. **test-dev** (Allow participants to make large number of submissions, let them see how they are doing, and let them overfit)
+  1. **test-dev** (Allow participants to make a large number of submissions, let them see how they are doing, and let them overfit)
   2. **test-challenge** (Allow small number of submissions so that they cannot mimic test-set. Use this split to decide the winners for the challenge)
 
   A dataset split has the following subfields:

--- a/docs/source/faq(developers).md
+++ b/docs/source/faq(developers).md
@@ -46,17 +46,19 @@ Use the following commands in order to solve the error:
 #### Q. While using `pip install -r dev/requirement.txt`
 
 ```
-Command “python setup.py egg_info” failed with error code 1 in
+Command "python setup.py egg_info" failed with error code 1 in
 /private/var/folders/c7/b45s17816zn_b1dh3g7yzxrm0000gn/T/pip-build- GM2AG/psycopg2/
 ```
 
-Firstly check that you have installed all the mentioned dependencies.
-Then, Upgrade the version of postgresql to 10.1 in order to solve it.
+Firstly, check that you have installed all the mentioned dependencies.
+Then, upgrade the version of postgresql to 10.1 in order to solve it.
 
 #### Q. Getting an import error
 
+If you got an import error like below while using command `python manage.py migrate`,
+
 ```
-Couldn't import Django,"when using command python manage.py migrate
+ImportError: Couldn't import Django
 ```
 
 Firstly, check that you have activated the virtualenv.
@@ -70,7 +72,7 @@ pip install -r requirements/dev.txt
 #### Q. Getting Mocha Error
 
 ```
-Can not load reporter “mocha”,it is not registered
+Can not load reporter "mocha", it is not registered
 ```
 
 Uninstall karma and then install


### PR DESCRIPTION
While reading documentaions for gsoc,
I found these small typos in docs.
This commit amends those typos.

Signed-off-by: Kang Minchul <tegongkang@gmail.com>