### PR TITLE
Fix #3643 [Backend] Add support to recreate fargate workers for active challenges from django admin

### DIFF
--- a/apps/challenges/admin.py
+++ b/apps/challenges/admin.py
@@ -83,6 +83,7 @@ class ChallengeAdmin(ImportExportTimeStampedAdmin):
         "scale_selected_workers",
         "restart_selected_workers",
         "delete_selected_workers",
+        "delete_selected_workers_and_start_selected_workers",
     ]
     action_form = UpdateNumOfWorkersForm
 
@@ -213,6 +214,14 @@ class ChallengeAdmin(ImportExportTimeStampedAdmin):
         "Delete all selected challenge workers."
     )
 
+
+    def delete_selected_workers_and_start_selected_workers(self, request, queryset):
+        self.delete_selected_workers(request, queryset)
+        self.start_selected_workers(request, queryset)
+
+    delete_selected_workers_and_start_selected_workers.short_description = (
+        "Delete and Start all selected challenge workers."
+    )
 
 @admin.register(ChallengeConfiguration)
 class ChallengeConfigurationAdmin(ImportExportTimeStampedAdmin):


### PR DESCRIPTION
**Steps to Follow**
1. Select "Ongoing" from "By Challenges" filter for all active challenges to get selected.
2. Select all the Challenges.
3. Go to Action and select "Delete and Start all selected challenge workers". 

![workersGIF](https://user-images.githubusercontent.com/60038994/151308596-4ffa0705-110b-4d1f-a02f-863e2859c3ba.gif)

