### PR TITLE
[BugFix] Auth token refresh API

### DIFF
--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -1,4 +1,3 @@
-from tokenize import Token
 from django.contrib.auth import logout
 from django.contrib.auth.models import User
 

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -1,3 +1,4 @@
+from tokenize import Token
 from django.contrib.auth import logout
 from django.contrib.auth.models import User
 
@@ -97,6 +98,7 @@ def refresh_auth_token(request):
         token = JwtToken.objects.get(user=user)
         existing_token = RefreshToken(token.refresh_token)
         existing_token.blacklist()
+        token.delete()
     except JwtToken.DoesNotExist:
         token = JwtToken(user=user)
 

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -1,4 +1,3 @@
-from shutil import ExecError
 from django.contrib.auth import logout
 from django.contrib.auth.models import User
 

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -1,3 +1,4 @@
+from shutil import ExecError
 from django.contrib.auth import logout
 from django.contrib.auth.models import User
 
@@ -22,6 +23,8 @@ from .permissions import HasVerifiedEmail
 from .serializers import JwtTokenSerializer
 
 from .throttles import ResendEmailThrottle
+
+from datetime import datetime
 
 
 @api_view(["POST"])
@@ -63,8 +66,11 @@ def get_auth_token(request):
         if token_serializer.is_valid():
             token_serializer.save()
         token = token_serializer.instance
-
-    response_data = {"token": "{}".format(token.refresh_token)}
+    jwt_refresh_token = RefreshToken.for_user(user)
+    response_data = {
+        "token": "{}".format(token.refresh_token),
+        "expires_at": datetime.fromtimestamp(jwt_refresh_token.payload["exp"])
+    }
     return Response(response_data, status=status.HTTP_200_OK)
 
 

--- a/docker/dev/django/container-start.sh
+++ b/docker/dev/django/container-start.sh
@@ -2,5 +2,4 @@
 python manage.py migrate --noinput  && \
 python manage.py collectstatic --noinput  && \
 python manage.py seed && \
-#uwsgi --ini /code/docker/dev/django/uwsgi.ini
-python manage.py runserver 0.0.0.0:8000
+uwsgi --ini /code/docker/dev/django/uwsgi.ini

--- a/docker/dev/django/container-start.sh
+++ b/docker/dev/django/container-start.sh
@@ -2,4 +2,5 @@
 python manage.py migrate --noinput  && \
 python manage.py collectstatic --noinput  && \
 python manage.py seed && \
-uwsgi --ini /code/docker/dev/django/uwsgi.ini
+#uwsgi --ini /code/docker/dev/django/uwsgi.ini
+python manage.py runserver 0.0.0.0:8000

--- a/frontend/src/js/controllers/profileCtrl.js
+++ b/frontend/src/js/controllers/profileCtrl.js
@@ -20,6 +20,7 @@
         vm.inputType = 'password';
         vm.status = 'Show';
         vm.token = '';
+        vm.expiresAt = '';
 
         utilities.hideLoader();
 
@@ -80,6 +81,10 @@
             onSuccess: function(response) {
                 vm.jsonResponse = response.data;
                 vm.token = response.data['token'];
+                vm.expiresAt = response.data['expires_at'];
+                let expiresAtOffset = new Date(vm.expiresAt).getTimezoneOffset();
+                var timezone = moment.tz.guess();
+                vm.expiresAtTimezone = moment.tz.zone(timezone).abbr(expiresAtOffset);
             },
             onError: function(response) {
                 var details = response.data;

--- a/frontend/src/js/controllers/profileCtrl.js
+++ b/frontend/src/js/controllers/profileCtrl.js
@@ -8,7 +8,7 @@
         .module('evalai')
         .controller('profileCtrl', profileCtrl);
 
-    profileCtrl.$inject = ['utilities', '$rootScope', '$scope', '$mdDialog'];
+    profileCtrl.$inject = ['utilities', '$rootScope', '$scope', '$mdDialog', 'moment'];
 
     function profileCtrl(utilities, $rootScope, $scope, $mdDialog, moment) {
         var vm = this;

--- a/frontend/src/js/controllers/profileCtrl.js
+++ b/frontend/src/js/controllers/profileCtrl.js
@@ -10,7 +10,7 @@
 
     profileCtrl.$inject = ['utilities', '$rootScope', '$scope', '$mdDialog'];
 
-    function profileCtrl(utilities, $rootScope, $scope, $mdDialog) {
+    function profileCtrl(utilities, $rootScope, $scope, $mdDialog, moment) {
         var vm = this;
 
         vm.user = {};

--- a/frontend/src/views/web/auth/get-token.html
+++ b/frontend/src/views/web/auth/get-token.html
@@ -10,6 +10,7 @@
                             <i class="fa fa-clipboard" aria-hidden="true" alt="Copy to clipboard."></i>
                         </button>
                     </div>
+                    <div><strong>Expires at:</strong> {{profile.expiresAt | date:'medium'}} {{profile.expiresAtTimezone}}</div>
                     <br>
                     <ul class="inline-list">
                         <li>

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -2,6 +2,8 @@ import os
 
 from accounts.models import JwtToken
 
+
+from datetime import datetime
 from django.urls import reverse_lazy
 from django.contrib.auth.models import User
 
@@ -65,7 +67,11 @@ class GetAuthTokenTest(BaseAPITestClass):
     def test_get_auth_token(self):
         response = self.client.get(self.url, {})
         token = JwtToken.objects.get(user=self.user)
-        expected_data = {"token": "{}".format(token.refresh_token)}
+        jwt_refresh_token = RefreshToken.for_user(self.user)
+        expected_data = {
+            "token": "{}".format(token.refresh_token),
+            "expires_at": datetime.fromtimestamp(jwt_refresh_token.payload["exp"])
+        }
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, expected_data)
 
@@ -108,7 +114,11 @@ class RefreshAuthTokenTest(BaseAPITestClass):
         url = reverse_lazy("accounts:get_auth_token")
         response = self.client.get(url, {})
         token = JwtToken.objects.get(user=self.user)
-        expected_data = {"token": "{}".format(token.refresh_token)}
+        jwt_refresh_token = RefreshToken.for_user(self.user)
+        expected_data = {
+            "token": "{}".format(token.refresh_token),
+            "expires_at": datetime.fromtimestamp(jwt_refresh_token.payload["exp"])
+        }
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, expected_data)


### PR DESCRIPTION
### Description

This PR fixes:

- [x] [Refresh auth token API issue](https://sentry.io/organizations/cloudcv/issues/2988106336/?project=130457&referrer=slack). To fix the issue we have to delete the existing token when a user refreshes the token. SimpleJWT API doesn't support API for refreshing tokens for which `refresh_token` has expired. [Reference](https://github.com/jazzband/djangorestframework-simplejwt/blob/master/rest_framework_simplejwt/tokens.py#L43)