### PR TITLE
[BugFix] Allow updating is_leaderboard_order_descending using github

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -3333,7 +3333,7 @@ def create_or_update_github_challenge(request, challenge_host_team_pk):
                         ]
                         visibility = data["visibility"]
                         leaderboard_decimal_precision = data["leaderboard_decimal_precision"]
-                        is_leaderboard_order_descending = data["leaderboard_decimal_precision"]
+                        is_leaderboard_order_descending = data["is_leaderboard_order_descending"]
 
                         data = {
                             "challenge_phase": challenge_phase,


### PR DESCRIPTION
### Description


This PR- 

- [x] Fixes bug in `ChallengePhaseSplit` field `is_leaderboard_order_descending` update in github based challenge creation pipeline