### PR TITLE
[FrontendV2] Add *cloudcv.org redirection nginx conf

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -57,7 +57,6 @@ services:
         NODE_ENV: production
     ports:
       - "80:80"
-      - "443:443"
     volumes:
       - /code/node_modules
       - /code/bower_components
@@ -77,6 +76,7 @@ services:
         NODE_ENV: production
     ports:
       - "9999:80"
+      - "443:443"
     volumes:
       - /code/node_modules
     logging:

--- a/docker/prod/nodejs_v2/nginx_production.conf
+++ b/docker/prod/nodejs_v2/nginx_production.conf
@@ -7,6 +7,19 @@ upstream node_exporter {
 }
 
 server {
+  server_name evalapi.cloudcv.org evalai.cloudcv.org;
+  listen 80;
+  listen 443;
+  return 301 https://eval.ai$request_uri;
+
+  ssl off;
+  ssl_certificate /etc/ssl/__cloudcv_org.crt;
+  ssl_certificate_key /etc/ssl/cloudcv.key;
+  ssl_prefer_server_ciphers on;
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+}
+
+server {
   server_name eval.ai;
   listen 80;
   return 301 https://eval.ai$request_uri;


### PR DESCRIPTION
### Description

This PR - 

- [x] Fixes redirection of *.cloudcv.org URL to eval.ai in frontend v2
- [x] Set frontend v2 as default frontend deployment on prod 