### PR TITLE
[BugFix] Fix hosted challenge page filtering to show private challenges

### DIFF
--- a/apps/challenges/urls.py
+++ b/apps/challenges/urls.py
@@ -40,7 +40,7 @@ urlpatterns = [
     ),
     # `A-Za-z` because it accepts either of `all, future, past or present` in either case
     url(
-        r"^challenge/(?P<challenge_time>[A-Za-z]+)$",
+        r"^challenge/(?P<challenge_time>[A-Za-z]+)/(?P<challenge_approved>[A-Za-z]+)/(?P<challenge_published>[A-Za-z]+)$",
         views.get_all_challenges,
         name="get_all_challenges",
     ),

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -522,7 +522,7 @@ def disable_challenge(request, challenge_pk):
 
 @api_view(["GET"])
 @throttle_classes([AnonRateThrottle])
-def get_all_challenges(request, challenge_time):
+def get_all_challenges(request, challenge_time, challenge_approved, challenge_published):
     """
     Returns the list of all challenges
     """
@@ -530,8 +530,22 @@ def get_all_challenges(request, challenge_time):
     if challenge_time.lower() not in ("all", "future", "past", "present"):
         response_data = {"error": "Wrong url pattern!"}
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
+    
+    if challenge_approved.lower() not in ("all", "approved", "unapproved"):
+        response_data = {"error": "Wrong challenge approval status!"}
+        return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
+    
+    if challenge_published.lower() not in ("all", "public", "private"):
+        response_data = {"error": "Wrong challenge published status!"}
+        return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
-    q_params = {"published": True, "approved_by_admin": True}
+    q_params = {}
+    if challenge_approved.lower() != "all":
+        q_params["approved_by_admin"] =  (challenge_approved.lower() == "approved")
+
+    if challenge_published.lower() != "all":
+        q_params["published"] =  (challenge_published.lower() == "public")
+
     if challenge_time.lower() == "past":
         q_params["end_date__lt"] = timezone.now()
 

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -530,21 +530,21 @@ def get_all_challenges(request, challenge_time, challenge_approved, challenge_pu
     if challenge_time.lower() not in ("all", "future", "past", "present"):
         response_data = {"error": "Wrong url pattern!"}
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
-    
+
     if challenge_approved.lower() not in ("all", "approved", "unapproved"):
         response_data = {"error": "Wrong challenge approval status!"}
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
-    
+
     if challenge_published.lower() not in ("all", "public", "private"):
         response_data = {"error": "Wrong challenge published status!"}
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     q_params = {}
     if challenge_approved.lower() != "all":
-        q_params["approved_by_admin"] =  (challenge_approved.lower() == "approved")
+        q_params["approved_by_admin"] = (challenge_approved.lower() == "approved")
 
     if challenge_published.lower() != "all":
-        q_params["published"] =  (challenge_published.lower() == "public")
+        q_params["published"] = (challenge_published.lower() == "public")
 
     if challenge_time.lower() == "past":
         q_params["end_date__lt"] = timezone.now()

--- a/frontend/src/js/controllers/challengeListCtrl.js
+++ b/frontend/src/js/controllers/challengeListCtrl.js
@@ -32,7 +32,7 @@
         } else {
             parameters.token = null;
         }
-        parameters.url = 'challenges/challenge/present';
+        parameters.url = 'challenges/challenge/present/approved/public';
 
         parameters.callback = {
             onSuccess: function(response) {
@@ -66,7 +66,7 @@
 
                 // dependent api
                 // calls for upcoming challneges
-                parameters.url = 'challenges/challenge/future';
+                parameters.url = 'challenges/challenge/future/approved/public';
                 parameters.method = 'GET';
 
                 parameters.callback = {
@@ -104,7 +104,7 @@
 
                         // dependent api
                         // calls for past challneges
-                        parameters.url = 'challenges/challenge/past';
+                        parameters.url = 'challenges/challenge/past/approved/public';
                         parameters.method = 'GET';
 
                         parameters.callback = {

--- a/frontend/src/js/controllers/dashCtrl.js
+++ b/frontend/src/js/controllers/dashCtrl.js
@@ -59,7 +59,7 @@
         utilities.sendRequest(parameters);
 
         // get all ongoing challenges.
-        parameters.url = 'challenges/challenge/present';
+        parameters.url = 'challenges/challenge/present/approved/public';
         parameters.method = 'GET';
         parameters.token = userKey;
         parameters.callback = {

--- a/frontend/tests/controllers-test/challengeListCtrl.test.js
+++ b/frontend/tests/controllers-test/challengeListCtrl.test.js
@@ -44,15 +44,15 @@ describe('Unit tests for challenge list controller', function () {
             spyOn(utilities, 'storeData');
 
             utilities.sendRequest = function (parameters) {
-                if ((isPresentChallengeSuccess == true && parameters.url == 'challenges/challenge/present') ||
-                (isUpcomingChallengeSucess == true && parameters.url == 'challenges/challenge/future') ||
-                (isPastChallengeSuccess == true && parameters.url == 'challenges/challenge/past')) {
+                if ((isPresentChallengeSuccess == true && parameters.url == 'challenges/challenge/present/approved/public') ||
+                (isUpcomingChallengeSucess == true && parameters.url == 'challenges/challenge/future/approved/public') ||
+                (isPastChallengeSuccess == true && parameters.url == 'challenges/challenge/past/approved/public')) {
                     parameters.callback.onSuccess({
                         data: successResponse
                     });
-                } else if ((isPresentChallengeSuccess == false && parameters.url == 'challenges/challenge/present') ||
-                (isUpcomingChallengeSucess == false && parameters.url == 'challenges/challenge/future') ||
-                (isPastChallengeSuccess == false && parameters.url == 'challenges/challenge/past')){
+                } else if ((isPresentChallengeSuccess == false && parameters.url == 'challenges/challenge/present/approved/public') ||
+                (isUpcomingChallengeSucess == false && parameters.url == 'challenges/challenge/future/approved/public') ||
+                (isPastChallengeSuccess == false && parameters.url == 'challenges/challenge/past/approved/public')){
                     parameters.callback.onError({
                         data: errorResponse
                     });
@@ -60,7 +60,7 @@ describe('Unit tests for challenge list controller', function () {
             };
         });
 
-        it('when no ongoing challenge found `challenges/challenge/present`', function () {
+        it('when no ongoing challenge found `challenges/challenge/present/approved/public`', function () {
             isPresentChallengeSuccess = true;
             isUpcomingChallengeSucess = null;
             isPastChallengeSuccess = null;
@@ -72,7 +72,7 @@ describe('Unit tests for challenge list controller', function () {
             expect(vm.noneCurrentChallenge).toBeTruthy();
         });
 
-        it('check description length and calculate timezone of ongoing challenge `challenges/challenge/present`', function () {
+        it('check description length and calculate timezone of ongoing challenge `challenges/challenge/present/approved/public`', function () {
             isPresentChallengeSuccess = true;
             isUpcomingChallengeSucess = null;
             isPastChallengeSuccess = null;
@@ -120,7 +120,7 @@ describe('Unit tests for challenge list controller', function () {
             }
         });
 
-        it('ongoing challenge backend error `challenges/challenge/present`', function () {
+        it('ongoing challenge backend error `challenges/challenge/present/approved/public`', function () {
             isPresentChallengeSuccess = false; 
             isUpcomingChallengeSucess = null;
             isPastChallengeSuccess = null;
@@ -131,7 +131,7 @@ describe('Unit tests for challenge list controller', function () {
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
 
-        it('when no upcoming `challenges/challenge/present`challenge found `challenges/challenge/future`', function () {
+        it('when no upcoming `challenges/challenge/present/approved/public`challenge found `challenges/challenge/future/approved/public`', function () {
             isUpcomingChallengeSucess = true;
             isPresentChallengeSuccess = true;
             isPastChallengeSuccess = null;
@@ -191,7 +191,7 @@ describe('Unit tests for challenge list controller', function () {
             }
         });
 
-        it('upcoming challenge backend error `challenges/challenge/future`', function () {
+        it('upcoming challenge backend error `challenges/challenge/future/approved/public`', function () {
             isUpcomingChallengeSucess = false;
             isPresentChallengeSuccess = true; 
             isPastChallengeSuccess = null;
@@ -204,7 +204,7 @@ describe('Unit tests for challenge list controller', function () {
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
 
-        it('when no past challenge found `challenges/challenge/past`', function () {
+        it('when no past challenge found `challenges/challenge/past/approved/public`', function () {
             isPastChallengeSuccess = true;
             isPresentChallengeSuccess = true;
             isUpcomingChallengeSucess = true;
@@ -216,7 +216,7 @@ describe('Unit tests for challenge list controller', function () {
             expect(vm.nonePastChallenge).toBeTruthy();
         });
 
-        it('check description length and calculate timezone of past challenge `challenges/challenge/past`', function () {
+        it('check description length and calculate timezone of past challenge `challenges/challenge/past/approved/public`', function () {
             isPastChallengeSuccess = true;
             isPresentChallengeSuccess = true;
             isUpcomingChallengeSucess = true;
@@ -265,7 +265,7 @@ describe('Unit tests for challenge list controller', function () {
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
 
-        it('past challenge backend error `challenges/challenge/past`', function () {
+        it('past challenge backend error `challenges/challenge/past/approved/public`', function () {
             isPastChallengeSuccess = false;
             isPresentChallengeSuccess = true;
             isUpcomingChallengeSucess = true;

--- a/frontend/tests/controllers-test/dashCtrl.test.js
+++ b/frontend/tests/controllers-test/dashCtrl.test.js
@@ -44,7 +44,7 @@ describe('Unit tests for dashboard controller', function () {
 
             utilities.sendRequest = function (parameters) {
                 if ((isUserDetails == true && parameters.url == 'auth/user/') ||
-                (isPresentChallenge == true && parameters.url == 'challenges/challenge/present') ||
+                (isPresentChallenge == true && parameters.url == 'challenges/challenge/present/approved/public') ||
                 (isHostTeam == true && parameters.url == 'hosts/challenge_host_team/') ||
                 (isParticipantTeam == true && parameters.url == 'participants/participant_team')) {
                     parameters.callback.onSuccess({
@@ -52,7 +52,7 @@ describe('Unit tests for dashboard controller', function () {
                         status: 200
                     });
                 } else if ((isUserDetails == false && parameters.url == 'auth/user/') ||
-                (isPresentChallenge == false && parameters.url == 'challenges/challenge/present') ||
+                (isPresentChallenge == false && parameters.url == 'challenges/challenge/present/approved/public') ||
                 (isHostTeam == false && parameters.url == 'hosts/challenge_host_team/') ||
                 (isParticipantTeam == false && parameters.url == 'participants/participant_team')){
                     parameters.callback.onError({
@@ -108,7 +108,7 @@ describe('Unit tests for dashboard controller', function () {
             expect($rootScope.isAuth).toBeFalsy();
         });
 
-        it('get all ongoing challenges `challenges/challenge/present`', function () {
+        it('get all ongoing challenges `challenges/challenge/present/approved/public`', function () {
             isUserDetails = null;
             isPresentChallenge = true;
             isHostTeam = null;
@@ -132,7 +132,7 @@ describe('Unit tests for dashboard controller', function () {
             expect(vm.hostTeamExist).toBeFalsy();
         });
 
-        it('403 backend error on getting all ongoing challenges `challenges/challenge/present`', function () {
+        it('403 backend error on getting all ongoing challenges `challenges/challenge/present/approved/public`', function () {
             isUserDetails = null;
             isPresentChallenge = false;
             isHostTeam = null;
@@ -146,7 +146,7 @@ describe('Unit tests for dashboard controller', function () {
             expect(vm.isPrivileged).toEqual(false);
         });
 
-        it('401 backend error on getting all ongoing challenges `challenges/challenge/present`', function () {
+        it('401 backend error on getting all ongoing challenges `challenges/challenge/present/approved/public`', function () {
             isUserDetails = null;
             isPresentChallenge = false;
             isHostTeam = null;

--- a/frontend_v2/src/app/components/publiclists/challengelist/challengelist.component.ts
+++ b/frontend_v2/src/app/components/publiclists/challengelist/challengelist.component.ts
@@ -338,7 +338,7 @@ export class ChallengelistComponent implements OnInit {
           SELF.allTeams.forEach((team) => {
             SELF.fetchUnapprovedChallengesFromApi(team);
           });
-          SELF.fetchChallenges();
+          SELF.fetchChallenges(null, null, "all", "all");
         }
       },
       (err) => {
@@ -352,21 +352,32 @@ export class ChallengelistComponent implements OnInit {
   }
 
   /**
+   * Append visibility to challenge API
+   * @param approved_status 
+   * @param visibility 
+   */
+  getFetchChallengeApiPathWithVisibility(path, approved_status = "approved", visibility = "public") {
+    return path + "/" + approved_status + "/" + visibility;
+  }
+
+  /**
    * Fetch Challenges function.
    * @param filter  selected filter
    * @param callback  callback function
    */
-  fetchChallenges(filter = null, callback = null) {
+  fetchChallenges(filter = null, callback = null, approved_status = "approved", visibility = "public") {
     if (!filter) {
       const ALL_PATHS = Object.values(this.apiPathMapping);
       const ALL_KEYS = Object.keys(this.apiPathMapping);
       for (let i = 0; i < ALL_PATHS.length; i++) {
         if (this[ALL_KEYS[i]]) {
-          this.fetchChallengesFromApi(ALL_PATHS[i], callback);
+          let apiPath = this.getFetchChallengeApiPathWithVisibility(ALL_PATHS[i], approved_status, visibility);
+          this.fetchChallengesFromApi(apiPath, callback);
         }
       }
     } else {
-      this.fetchChallengesFromApi(this.apiPathMapping[filter], callback);
+      let apiPath = this.getFetchChallengeApiPathWithVisibility(this.apiPathMapping[filter], approved_status, visibility);
+      this.fetchChallengesFromApi(apiPath, callback);
     }
   }
 
@@ -379,11 +390,11 @@ export class ChallengelistComponent implements OnInit {
     const SELF = this;
     SELF.apiService.getUrl(path, true, false).subscribe(
       (data) => {
-        if (path.endsWith('future')) {
+        if (path.includes('future')) {
           SELF.upcomingChallenges = data['results'];
-        } else if (path.endsWith('present')) {
+        } else if (path.includes('present')) {
           SELF.ongoingChallenges = data['results'];
-        } else if (path.endsWith('past')) {
+        } else if (path.includes('past')) {
           SELF.pastChallenges = data['results'];
         }
         SELF.filteredChallenges = SELF.upcomingChallenges.concat(SELF.ongoingChallenges, SELF.pastChallenges);

--- a/tests/unit/challenges/test_urls.py
+++ b/tests/unit/challenges/test_urls.py
@@ -190,9 +190,13 @@ class TestChallengeUrls(BaseAPITestClass):
         )
 
         url = reverse_lazy(
-            "challenges:get_all_challenges", kwargs={"challenge_time": "PAST"}
+            "challenges:get_all_challenges", kwargs={
+                "challenge_time": "PAST",
+                "challenge_approved": "APPROVED",
+                "challenge_published": "PUBLIC",
+            }
         )
-        self.assertEqual(url, "/api/challenges/challenge/PAST")
+        self.assertEqual(url, "/api/challenges/challenge/PAST/APPROVED/PUBLIC")
 
         self.url = reverse_lazy(
             "challenges:download_all_submissions",

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -1001,7 +1001,11 @@ class GetAllChallengesTest(BaseAPITestClass):
     def setUp(self):
         super(GetAllChallengesTest, self).setUp()
         self.url = reverse_lazy(
-            "challenges:get_all_challenges", kwargs={"challenge_time": "PAST"}
+            "challenges:get_all_challenges", kwargs={
+                "challenge_time": "PAST",
+                "challenge_approved": "APPROVED",
+                "challenge_published": "PUBLIC",
+            }
         )
 
         # Present challenge
@@ -1129,7 +1133,11 @@ class GetAllChallengesTest(BaseAPITestClass):
     def test_get_present_challenges(self):
         self.url = reverse_lazy(
             "challenges:get_all_challenges",
-            kwargs={"challenge_time": "PRESENT"},
+            kwargs={
+                "challenge_time": "PRESENT",
+                "challenge_approved": "APPROVED",
+                "challenge_published": "PUBLIC",
+            },
         )
 
         expected = [
@@ -1185,7 +1193,11 @@ class GetAllChallengesTest(BaseAPITestClass):
     def test_get_future_challenges(self):
         self.url = reverse_lazy(
             "challenges:get_all_challenges",
-            kwargs={"challenge_time": "FUTURE"},
+            kwargs={
+                "challenge_time": "FUTURE",
+                "challenge_approved": "APPROVED",
+                "challenge_published": "PUBLIC",
+            },
         )
 
         expected = [
@@ -1240,7 +1252,11 @@ class GetAllChallengesTest(BaseAPITestClass):
 
     def test_get_all_challenges(self):
         self.url = reverse_lazy(
-            "challenges:get_all_challenges", kwargs={"challenge_time": "ALL"}
+            "challenges:get_all_challenges", kwargs={
+                "challenge_time": "ALL",
+                "challenge_approved": "APPROVED",
+                "challenge_published": "PUBLIC",
+            }
         )
 
         expected = [
@@ -1384,7 +1400,11 @@ class GetAllChallengesTest(BaseAPITestClass):
     def test_incorrent_url_pattern_challenges(self):
         self.url = reverse_lazy(
             "challenges:get_all_challenges",
-            kwargs={"challenge_time": "INCORRECT"},
+            kwargs={
+                "challenge_time": "INCORRECT",
+                "challenge_approved": "APPROVED",
+                "challenge_published": "PUBLIC",
+            },
         )
         expected = {"error": "Wrong url pattern!"}
         response = self.client.get(self.url, {}, format="json")


### PR DESCRIPTION
### Description


Currently, hosted challenge page doesn't show private challenges on the tab due to a bug in the API 

This PR - 

- [x] Add support to fetch all challenges with `all, public or private` visibility and `all, approved and unapproved` challenges in `get_all_challenges` API
- [x] Fixes bug in hosted challenge page filtering to show private challenges