### PR TITLE
Add missing starter repo link in challenge create

### DIFF
--- a/frontend/src/views/web/challenge-create.html
+++ b/frontend/src/views/web/challenge-create.html
@@ -6,7 +6,7 @@
                 <div class="ev-md-container ev-card-body exist-team-card">
                     <div class="col">
                         <ol>
-                            <li>Use this repository as <a href="https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template" class="highlight-link" target="_blank">template</a>.</li>
+                            <li>Use <a href="https://github.com/Cloud-CV/EvalAI-Starters" class="highlight-link" target="_blank">this repository</a> as <a href="https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template" class="highlight-link" target="_blank">template</a>.</li>
                             <li>Generate your <a href="https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token" class="highlight-link" target="_blank">github personal acccess token</a> and copy it in clipboard.</li>
                             <li>Add the github personal access token in the forked repository's <a href="https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository">secrets</a> with the name <b>AUTH_TOKEN</b>.</li>
                             <li> Now, go to <a href="https://eval.ai" class="highlight-link" target="_blank">EvalAI</a> to fetch the following details -</li>

--- a/frontend_v2/src/app/components/challenge-create/challenge-create.component.html
+++ b/frontend_v2/src/app/components/challenge-create/challenge-create.component.html
@@ -11,7 +11,7 @@
                 <div class="ev-md-container ev-card-body exist-team-card">
                     <div class="col">
                         <ol>
-                            <li>Use this repository as <a href="https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template" class="highlight-link" target="_blank">template</a>.</li>
+                            <li>Use <a href="https://github.com/Cloud-CV/EvalAI-Starters" class="highlight-link" target="_blank">this repository</a> as <a href="https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template" class="highlight-link" target="_blank">template</a>.</li>
                             <li>Generate your <a href="https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token" class="highlight-link" target="_blank">github personal acccess token</a> and copy it in clipboard.</li>
                             <li>Add the github personal access token in the forked repository's <a href="https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository">secrets</a> with the name <b>AUTH_TOKEN</b>.</li>
                             <li> Now, go to <a href="https://eval.ai" class="highlight-link" target="_blank">EvalAI</a> to fetch the following details -</li>


### PR DESCRIPTION
This PR adds missing repository link for EvalAI-Starters in Challenge Creation components.

@Ram81 