### PR TITLE
[BugFix] Handle the case when submission meta attributes are removed …

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -3596,6 +3596,10 @@ def create_or_update_github_challenge(request, challenge_host_team_pk):
                             partial=True,
                         )
                     else:
+                        # Override the submission_meta_attributes when they are missing
+                        submission_meta_attributes = data.get("submission_meta_attributes")
+                        if submission_meta_attributes is None:
+                            data["submission_meta_attributes"] = None
                         serializer = ChallengePhaseCreateSerializer(
                             challenge_phase,
                             data=data,


### PR DESCRIPTION
### Description

This PR -

- [x] Fixes bug in github based challenge setup `ChallengePhase` update. When `submission_meta_attributes` are removed from challenge_config.yaml, current API doesn't handle the case of overwriting DB entry with empty meta attributes. This PR resets meta attributes to `None` when the challenge config doesn't contain `submission_meta_attribute` key