### PR TITLE
[Backend] Increase code upload worker sleep interval

### DIFF
--- a/scripts/workers/code_upload_submission_worker.py
+++ b/scripts/workers/code_upload_submission_worker.py
@@ -683,9 +683,7 @@ def main():
         "submission_time_limit"
     )
     while True:
-        # Equal distribution of queue messages among submission worker and code upload worker
-        if challenge.get("is_static_dataset_code_upload"):
-            time.sleep(0.5)
+        time.sleep(2)
         message = evalai.get_message_from_sqs_queue()
         message_body = message.get("body")
         if message_body:

--- a/settings/common.py
+++ b/settings/common.py
@@ -177,7 +177,7 @@ REST_FRAMEWORK = {
     ),
     "DEFAULT_THROTTLE_RATES": {
         "anon": "100/minute",
-        "user": "60/minute",
+        "user": "150/minute",
         "resend_email": "3/hour",
     },
     "DEFAULT_RENDERER_CLASSES": ("rest_framework.renderers.JSONRenderer",),

--- a/settings/common.py
+++ b/settings/common.py
@@ -177,7 +177,7 @@ REST_FRAMEWORK = {
     ),
     "DEFAULT_THROTTLE_RATES": {
         "anon": "100/minute",
-        "user": "150/minute",
+        "user": "60/minute",
         "resend_email": "3/hour",
     },
     "DEFAULT_RENDERER_CLASSES": ("rest_framework.renderers.JSONRenderer",),


### PR DESCRIPTION
### Description

This PR - 

- [x] Increases sleept interval of code upload submission worker API calls due to the following [issue](https://github.com/facebookresearch/habitat-challenge/issues/117). Because we use user auth token for evaluation the throttle limit 60 is likely getting hit in code upload submission worker because of irregular API call intervals.