### PR TITLE
Update to nodejs 14.20.0 base image in NodeJS docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: focal
 language: python
 sudo: false
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 language: python
 sudo: false
 services:

--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -3,7 +3,7 @@ FROM node:8.11.2
 # install chrome for protractor tests
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-RUN apt-get update && apt-get install -yq google-chrome-stable
+RUN apt-get update && apt-get install -fyq google-chrome-stable
 
 WORKDIR /code
 

--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-slim
+FROM node:14.20.0
 
 # install chrome for protractor tests
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -

--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -1,6 +1,7 @@
-FROM node:14.20.0
+FROM node:14-slim
 
 # install chrome for protractor tests
+RUN apt-get update && apt-get install -y wget gnupg
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 RUN apt-get update && apt-get install -yq google-chrome-stable

--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -3,7 +3,7 @@ FROM node:8.11.2
 # install chrome for protractor tests
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-RUN apt-get update && apt-get install -fyq google-chrome-stable
+RUN apt-get update && apt-get install -yq libdrm2 google-chrome-stable --no-install-recommends
 
 WORKDIR /code
 

--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-slim
+FROM node:14.20.0
 
 # install chrome for protractor tests
 RUN apt-get update && apt-get install -y wget gnupg

--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:14.19.3
+FROM node:8.11.2
 
 # install chrome for protractor tests
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-RUN apt-get update && apt-get install -yq libdrm2 google-chrome-stable --no-install-recommends
+RUN apt-get update && apt-get install -yq google-chrome-stable
 
 WORKDIR /code
 

--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11.2
+FROM node:14-slim
 
 # install chrome for protractor tests
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -

--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11.2
+FROM node:14.19.3
 
 # install chrome for protractor tests
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -

--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:14.20.0
 
 # install chrome for protractor tests
-RUN apt-get update && apt-get install -y wget gnupg
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 RUN apt-get update && apt-get install -yq google-chrome-stable


### PR DESCRIPTION
This PR attempts to address the failing chrome install during Travis CI build like these: https://app.travis-ci.com/github/Cloud-CV/EvalAI/builds/252678440
