### PR TITLE
[BugFix] Fix static code upload worker task definitions

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -872,7 +872,7 @@ def create_eks_nodegroup(challenge, cluster_name):
     try:
         response = client.create_nodegroup(
             clusterName=cluster_name,
-            nodegroupName=nodegroup_name[:60],
+            nodegroupName=nodegroup_name,
             scalingConfig={
                 "minSize": challenge_obj.min_worker_instance,
                 "maxSize": challenge_obj.max_worker_instance,

--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -862,7 +862,7 @@ def create_eks_nodegroup(challenge, cluster_name):
         challenge_obj = obj.object
     environment_suffix = "{}-{}".format(challenge_obj.pk, settings.ENVIRONMENT)
     nodegroup_name = "{}-{}-nodegroup".format(
-        challenge_obj.title.replace(" ", "-"), environment_suffix
+        challenge_obj.title.replace(" ", "-")[:20], environment_suffix
     )
     challenge_aws_keys = get_aws_credentials_for_challenge(challenge_obj.pk)
     client = get_boto3_client("eks", challenge_aws_keys)
@@ -872,7 +872,7 @@ def create_eks_nodegroup(challenge, cluster_name):
     try:
         response = client.create_nodegroup(
             clusterName=cluster_name,
-            nodegroupName=nodegroup_name,
+            nodegroupName=nodegroup_name[:60],
             scalingConfig={
                 "minSize": challenge_obj.min_worker_instance,
                 "maxSize": challenge_obj.max_worker_instance,

--- a/apps/challenges/task_definitions.py
+++ b/apps/challenges/task_definitions.py
@@ -120,7 +120,7 @@ task_definition = """
                 {{
                     "name": "STATSD_PORT",
                     "value": "{STATSD_PORT}"
-                }},
+                }}
             ],
             "workingDirectory": "/code",
             "readonlyRootFilesystem": False,
@@ -361,7 +361,7 @@ container_definition_submission_worker = """
         }},
         {{
             "name": "STATSD_PORT",
-            "value: "{STATSD_PORT}"
+            "value": "{STATSD_PORT}"
         }}
     ],
     "workingDirectory": "/code",
@@ -440,7 +440,7 @@ container_definition_code_upload_worker = """
         }},
         {{
             "name": "STATSD_PORT",
-            "value: "{STATSD_PORT}"
+            "value": "{STATSD_PORT}"
         }}
 
     ],


### PR DESCRIPTION
### Description

This PR fixes - 

- [x] Bug in node group creation API. Boto3 only allows nodegroups with a name with less than <63 characters. In this PR I limit the generated title to 60 characters.
- [x] The task definitions for static code upload worker has a missing `"` bug that is causing failure when registering task definitions.
