### PR TITLE
[Code Upload Worker] Revert GPU constraint for jobs

### DIFF
--- a/scripts/workers/code_upload_submission_worker.py
+++ b/scripts/workers/code_upload_submission_worker.py
@@ -221,6 +221,9 @@ def create_job_object(message, environment_image):
             EVALAI_API_SERVER_ENV,
             MESSAGE_BODY_ENV,
         ],
+        resources=client.V1ResourceRequirements(
+            limits={"nvidia.com/gpu": "1"}
+        ),
         volume_mounts=volume_mount_list,
     )
     volume_list = get_volume_list()


### PR DESCRIPTION
### Description

This PR - 

- [x] Reverts GPU constraint on the code upload submission job. We need to add this back as removing the constraint causes multiple jobs to be scheduled on the same GPU. 