### PR TITLE
[Code Upload Worker] Increase submission monitoring polling frequency

### DIFF
--- a/scripts/workers/code_upload_submission_worker.py
+++ b/scripts/workers/code_upload_submission_worker.py
@@ -284,7 +284,7 @@ def create_static_code_upload_submission_job_object(message):
         value=str(submission_meta["submission_time_limit"]),
     )
     SUBMISSION_TIME_DELTA_ENV = client.V1EnvVar(
-        name="SUBMISSION_TIME_DELTA", value="3600"
+        name="SUBMISSION_TIME_DELTA", value="300"
     )
     AUTH_TOKEN_ENV = client.V1EnvVar(name="AUTH_TOKEN", value=AUTH_TOKEN)
     EVALAI_API_SERVER_ENV = client.V1EnvVar(


### PR DESCRIPTION
### Description

Currently, the code upload evaluation worker polls to check for submission output file after every 1 hour. This adds a decent amount of delay in submission evaluation when docker container completes in few minutes (We are facing this issue in seizure gauge challenge). 

In this PR, we increase the polling frequency by polling after every 5 minutes.