### PR TITLE
[Code Upload Worker] Add worker auto restart for static code upload c…

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -693,7 +693,6 @@ def restart_workers(queryset):
     for challenge in queryset:
         if (
             challenge.is_docker_based
-            and not challenge.is_static_dataset_code_upload
         ):
             response = "Sorry. This feature is not available for code upload/docker based challenges."
             failures.append(


### PR DESCRIPTION
### Description

Currently, we do not auto restart the static code upload challenge worker when a host updates either the annotation or evaluation script. In this PR, we add support to auto restart code upload worker when host updates evaluation script or annotations