### PR TITLE
[Code Upload Worker] Add submission time limit env variable in environment docker

### DIFF
--- a/scripts/workers/code_upload_submission_worker.py
+++ b/scripts/workers/code_upload_submission_worker.py
@@ -216,7 +216,7 @@ def create_job_object(message, environment_image, challenge):
     image = message["submitted_image_uri"]
     submission_meta = message["submission_meta"]
     SUBMISSION_TIME_LIMIT_ENV = client.V1EnvVar(
-        name="EVAL_TIMEOUT",
+        name="SUBMISSION_TIME_LIMIT",
         value=str(submission_meta["submission_time_limit"]),
     )
     # Configure Pod agent container

--- a/scripts/workers/code_upload_submission_worker.py
+++ b/scripts/workers/code_upload_submission_worker.py
@@ -214,6 +214,11 @@ def create_job_object(message, environment_image, challenge):
     MESSAGE_BODY_ENV = client.V1EnvVar(name="BODY", value=json.dumps(message))
     submission_pk = message["submission_pk"]
     image = message["submitted_image_uri"]
+    submission_meta = message["submission_meta"]
+    SUBMISSION_TIME_LIMIT_ENV = client.V1EnvVar(
+        name="EVAL_TIMEOUT",
+        value=str(submission_meta["submission_time_limit"]),
+    )
     # Configure Pod agent container
     agent_container = client.V1Container(
         name="agent", image=image, env=[PYTHONUNBUFFERED_ENV]
@@ -231,6 +236,7 @@ def create_job_object(message, environment_image, challenge):
             AUTH_TOKEN_ENV,
             EVALAI_API_SERVER_ENV,
             MESSAGE_BODY_ENV,
+            SUBMISSION_TIME_LIMIT_ENV,
         ],
         resources=client.V1ResourceRequirements(
             limits=job_constraints


### PR DESCRIPTION
### Description

This PR -

- [x] Pass a submission time limit envrionment variable to code upload submission environment docker.

Currently, updating the submission time limit for a code upload challenge requires hosts to update the docker image every time. In this PR, we pass a environment variable for submission time limit to the environment docker container when scheduling the job. The environment variable is configurable through challenge config. This would enable hosts to update time limits without needing to reupload the docker container every time they want to update the limits.