### PR TITLE
[BugFix] Fix submission visibility check in large file upload API

### DIFF
--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -2562,7 +2562,6 @@ def get_submission_file_presigned_url(request, challenge_phase_pk):
             }
             response = Response(response_data, status=status.HTTP_201_CREATED)
         return response
-
     response_data = {"error": serializer.errors}
     return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -2513,16 +2513,16 @@ def get_submission_file_presigned_url(request, challenge_phase_pk):
     )
     submission_data = request.data.copy()
 
-    if request.data.get("is_public") is None:
-        request.data["is_public"] = (
+    if submission_data.get("is_public") is None:
+        submission_data["is_public"] = (
             True if challenge_phase.is_submission_public else False
         )
     else:
-        request.data["is_public"] = json.loads(request.data["is_public"])
+        submission_data["is_public"] = json.loads(request.data["is_public"])
 
     # Override submission visibility if leaderboard_public = False for a challenge phase
     if not challenge_phase.leaderboard_public:
-        request.data["is_public"] = challenge_phase.is_submission_public
+        submission_data["is_public"] = challenge_phase.is_submission_public
 
     submission_data["input_file"] = input_file
     serializer = SubmissionSerializer(
@@ -2562,6 +2562,7 @@ def get_submission_file_presigned_url(request, challenge_phase_pk):
             }
             response = Response(response_data, status=status.HTTP_201_CREATED)
         return response
+
     response_data = {"error": serializer.errors}
     return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 


### PR DESCRIPTION
### Description

- Use `submission_data` instead of `request.data` for updating submission visibility
