### PR TITLE
[Monitoring] Auto-scale past and future challenge workers

### DIFF
--- a/scripts/monitoring/auto_scale_workers.py
+++ b/scripts/monitoring/auto_scale_workers.py
@@ -54,7 +54,7 @@ def execute_get_request(url):
 
 def get_challenges():
     all_challenge_endpoint = (
-        "{}/api/challenges/challenge/present/all/all".format(evalai_endpoint)
+        "{}/api/challenges/challenge/all/all/all".format(evalai_endpoint)
     )
     response = execute_get_request(all_challenge_endpoint)
 


### PR DESCRIPTION
This PR changes the API endpoint to fetch past and future challenge workers as well in order to auto-scale them.