### PR TITLE
Add importlib metadata version to common req

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -17,6 +17,7 @@ django-ses==1.0.3
 docker-compose==1.27.4
 drfdocs==0.0.11
 drf-yasg==1.17.0
+importlib-metadata<5.0
 kubernetes==12.0.1
 moto==1.3.14
 pika==1.1.0


### PR DESCRIPTION
This PR adds a specific range of `importlib-metadata` in `common` requirements in order to fix the failing build issue.

This fix is suggested in [this StackOverflow link](https://stackoverflow.com/questions/73929564/entrypoints-object-has-no-attribute-get-digital-ocean).