### PR TITLE
Fix issue with challenge end date in manage worker

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -3076,7 +3076,7 @@ def manage_worker(request, challenge_pk, action):
 
     challenge = get_challenge_model(challenge_pk)
 
-    if parse(challenge["end_date"]) < datetime.utcnow() and action in ("start", "stop", "restart"):
+    if parse(challenge.end_date) < datetime.utcnow() and action in ("start", "stop", "restart"):
         response_data = {
             "error": "Action {} worker is not supported for an inactive challenge.".format(action)
         }


### PR DESCRIPTION
This PR fixes issues with challenge end date in manage worker API:

```
[TypeError: 'Challenge' object is not subscriptable](https://sentry.io/organizations/cloudcv/issues/3667107151/?referrer=slack)
```