### PR TITLE
Remove parser from date check in manage worker

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -13,7 +13,6 @@ import zipfile
 
 from os.path import basename, isfile, join
 from datetime import datetime
-from dateutil.parser import parse
 
 
 from django.conf import settings
@@ -3076,7 +3075,7 @@ def manage_worker(request, challenge_pk, action):
 
     challenge = get_challenge_model(challenge_pk)
 
-    if parse(challenge.end_date) < datetime.utcnow() and action in ("start", "stop", "restart"):
+    if challenge.end_date < datetime.utcnow() and action in ("start", "stop", "restart"):
         response_data = {
             "error": "Action {} worker is not supported for an inactive challenge.".format(action)
         }


### PR DESCRIPTION
This PR attempts to fix the issue causing:

```
TypeError: Parser must be a string or character stream, not datetime
```

Error can be checked here: https://sentry.io/organizations/cloudcv/issues/3673494439/?referrer=slack