### PR TITLE
Add challenge queue name and pk in manage tab

### DIFF
--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -94,6 +94,7 @@
 
         vm.isChallengeLeaderboardPrivate = false;
         vm.previousPublicSubmissionId = null;
+        vm.queueName = null;
 
         vm.workerLogs = [];
 
@@ -316,6 +317,7 @@
                 vm.isRegistrationOpen = details.is_registration_open;
                 vm.approved_by_admin = details.approved_by_admin;
                 vm.isRemoteChallenge = details.remote_evaluation;
+                vm.queueName = details.queue;
                 vm.getTeamName(vm.challengeId);
 
                 if (vm.page.image === null) {

--- a/frontend/src/views/web/challenge/manage.html
+++ b/frontend/src/views/web/challenge/manage.html
@@ -1,6 +1,16 @@
 <section class="ev-sm-container ev-view challenge-container" ng-init="challenge.startLoadingLogs();">
     <div class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view">
         <div class="row margin-bottom-cancel">
+            <div class="col s12 m12 l12">
+                <div class="w-300 fs-16">
+                    <strong>Challenge Primary Key</strong>: {{challenge.challengeId}}<br>
+                    <strong>Challenge Queue Name</strong>: {{challenge.queueName}}
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view">
+        <div class="row margin-bottom-cancel">
             <div class="col s12">
                 <h5 class="w-300">Submission worker actions</h5>
             </div>

--- a/frontend/src/views/web/challenge/manage.html
+++ b/frontend/src/views/web/challenge/manage.html
@@ -1,16 +1,6 @@
 <section class="ev-sm-container ev-view challenge-container" ng-init="challenge.startLoadingLogs();">
     <div class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view">
         <div class="row margin-bottom-cancel">
-            <div class="col s12 m12 l12">
-                <div class="w-300 fs-16">
-                    <strong>Challenge Primary Key</strong>: {{challenge.challengeId}}<br>
-                    <strong>Challenge Queue Name</strong>: {{challenge.queueName}}
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view">
-        <div class="row margin-bottom-cancel">
             <div class="col s12">
                 <h5 class="w-300">Submission worker actions</h5>
             </div>
@@ -29,6 +19,21 @@
         </div>
         <div class="ev-logs-card">
             <div ng-repeat="log in challenge.workerLogs track by $index" class="ev-logs">{{log}}</div>
+        </div>
+    </div>
+    <div class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view">
+        <div class="row margin-bottom-cancel">
+            <div class="col s12">
+                <h5 class="w-300">Remote Evaluation Meta</h5>
+            </div>
+        </div>
+        <div class="row margin-bottom-cancel">
+            <div class="col s12 m12 l12">
+                <div class="w-300 fs-16">
+                    <strong>Primary Key</strong>: {{challenge.challengeId}}<br>
+                    <strong>Queue Name</strong>: {{challenge.queueName}}
+                </div>
+            </div>
         </div>
     </div>
 </section>


### PR DESCRIPTION
This PR adds challenge queue name and primary key on the Manage tab (only visible to host).

An example is shown below:

![image](https://user-images.githubusercontent.com/29076344/200409964-2b049306-2fd7-4445-bc78-156970d10b93.png)
