### PR TITLE
Fetch last 1000 lines of logs from the last 72 hours - submission worker

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -805,7 +805,7 @@ def restart_workers_signal_callback(sender, instance, field_name, **kwargs):
 
 
 def get_logs_from_cloudwatch(
-    log_group_name, log_stream_prefix, start_time, end_time, pattern
+    log_group_name, log_stream_prefix, start_time, end_time, pattern, limit
 ):
     """
     To fetch logs of a container from cloudwatch within a specific time frame.
@@ -824,6 +824,7 @@ def get_logs_from_cloudwatch(
                 startTime=start_time,
                 endTime=end_time,
                 filterPattern=pattern,
+                limit=limit
             )
             for event in response["events"]:
                 logs.append(event["message"])

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -2960,7 +2960,7 @@ def get_worker_logs(request, challenge_pk):
 
     # This is to specify the time window for fetching logs: 3 days before from current time.
     timeframe = 4320 # 15
-    limit = 10  # logs for last 10 events
+    limit = 1000  # logs last 1000 lines
     current_time = int(round(time.time() * 1000))
     start_time = current_time - (timeframe * 60000)
     end_time = current_time

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -2959,7 +2959,7 @@ def get_worker_logs(request, challenge_pk):
     pattern = ""  # Empty string to get all logs including container logs.
 
     # This is to specify the time window for fetching logs: 3 days before from current time.
-    timeframe = 4320 # 15
+    timeframe = 4320  # 15
     limit = 1000  # logs last 1000 lines
     current_time = int(round(time.time() * 1000))
     start_time = current_time - (timeframe * 60000)

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -2958,14 +2958,15 @@ def get_worker_logs(request, challenge_pk):
     log_stream_prefix = challenge.queue
     pattern = ""  # Empty string to get all logs including container logs.
 
-    # This is to specify the time window for fetching logs: 15 minutes before from current time.
-    timeframe = 15
+    # This is to specify the time window for fetching logs: 3 days before from current time.
+    timeframe = 4320 # 15
+    limit = 10  # logs for last 10 events
     current_time = int(round(time.time() * 1000))
     start_time = current_time - (timeframe * 60000)
     end_time = current_time
 
     logs = get_logs_from_cloudwatch(
-        log_group_name, log_stream_prefix, start_time, end_time, pattern
+        log_group_name, log_stream_prefix, start_time, end_time, pattern, limit
     )
 
     response_data = {"logs": logs}

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -2959,8 +2959,8 @@ def get_worker_logs(request, challenge_pk):
     pattern = ""  # Empty string to get all logs including container logs.
 
     # This is to specify the time window for fetching logs: 3 days before from current time.
-    timeframe = 4320  # 15
-    limit = 1000  # logs last 1000 lines
+    timeframe = 4320
+    limit = 1000
     current_time = int(round(time.time() * 1000))
     start_time = current_time - (timeframe * 60000)
     end_time = current_time


### PR DESCRIPTION
This PR attempts to address the issue of losing the logs beyond last 15 minutes. Here, we try to fetch the logs for the last 10 events in the past 72 hours.

Please let me know what you think.

@Ram81