### PR TITLE
[Feature] Admin task to delete challenge evaluation cluster created (Part 1)

### DIFF
--- a/apps/challenges/admin.py
+++ b/apps/challenges/admin.py
@@ -11,6 +11,7 @@ from .aws_utils import (
     scale_workers,
     start_workers,
     stop_workers,
+    delete_only_challenge_evaluation_cluster,
 )
 
 from .admin_filters import ChallengeFilter
@@ -83,6 +84,7 @@ class ChallengeAdmin(ImportExportTimeStampedAdmin):
         "scale_selected_workers",
         "restart_selected_workers",
         "delete_selected_workers",
+        "delete_only_selected_challenge_evaluation_clusters"
     ]
     action_form = UpdateNumOfWorkersForm
 
@@ -211,6 +213,30 @@ class ChallengeAdmin(ImportExportTimeStampedAdmin):
 
     delete_selected_workers.short_description = (
         "Delete all selected challenge workers."
+    )
+
+    def delete_only_selected_challenge_evaluation_clusters(self, request, queryset):
+        """Deletes the selected challenge evaluation clusters only; roles, subnets, etc... not deleted"""
+        response = delete_only_challenge_evaluation_cluster(queryset)
+        count, failures = response["count"], response["failures"]
+
+        if count == queryset.count():
+            message = "All selected challenges' evaluation clusters successfully deleted."
+            messages.success(request, message)
+        else:
+            messages.success(
+                request,
+                "{} challenges' evaluation clusters were successfully deleted.".format(count),
+            )
+            for fail in failures:
+                challenge_pk, message = fail["challenge_pk"], fail["message"]
+                display_message = "Challenge {}: {}".format(
+                    challenge_pk, message
+                )
+                messages.error(request, display_message)
+
+    delete_only_selected_challenge_evaluation_clusters.description = (
+        "Delete only all selected challenges' evaluation clusters."
     )
 
 

--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -14,7 +14,7 @@ from http import HTTPStatus
 
 from .challenge_notification_util import (
     construct_and_send_worker_start_mail,
-    construct_and_send_eks_cluster_creation_mail,
+    construct_and_send_eks_cluster_creation_mail
 )
 from .task_definitions import (
     container_definition_code_upload_worker,
@@ -913,6 +913,8 @@ def delete_only_challenge_evaluation_cluster(queryset):
     dict: keys-> 'count': the number of workers successfully stopped.
                  'failures': a dict of all the failures with their error messages and the challenge pk
     """
+    from .models import ChallengeEvaluationCluster
+
     if settings.DEBUG:
         failures = []
         for challenge in queryset:


### PR DESCRIPTION
This commit adds a new Django admin task to specifically delete a challenge's evaluation clusters without deleting its roles, subnets, etc...