### PR TITLE
[Feature] Admin task to delete challenge evaluation cluster created (Part 2)

### DIFF
--- a/apps/challenges/admin.py
+++ b/apps/challenges/admin.py
@@ -11,6 +11,7 @@ from .aws_utils import (
     scale_workers,
     start_workers,
     stop_workers,
+    delete_only_challenge_evaluation_cluster,
 )
 
 from .admin_filters import ChallengeFilter
@@ -83,6 +84,7 @@ class ChallengeAdmin(ImportExportTimeStampedAdmin):
         "scale_selected_workers",
         "restart_selected_workers",
         "delete_selected_workers",
+        "delete_only_selected_challenge_evaluation_clusters"
     ]
     action_form = UpdateNumOfWorkersForm
 
@@ -211,6 +213,30 @@ class ChallengeAdmin(ImportExportTimeStampedAdmin):
 
     delete_selected_workers.short_description = (
         "Delete all selected challenge workers."
+    )
+
+    def delete_only_selected_challenge_evaluation_clusters(self, request, queryset):
+        """Deletes the selected challenge evaluation clusters only; roles, subnets, etc... not deleted"""
+        response = delete_only_challenge_evaluation_cluster(queryset)
+        count, failures = response["count"], response["failures"]
+
+        if count == queryset.count():
+            message = "All selected challenges' evaluation clusters successfully deleted."
+            messages.success(request, message)
+        else:
+            messages.success(
+                request,
+                "{} challenges' evaluation clusters were successfully deleted.".format(count),
+            )
+            for fail in failures:
+                challenge_pk, message = fail["challenge_pk"], fail["message"]
+                display_message = "Challenge {}: {}".format(
+                    challenge_pk, message
+                )
+                messages.error(request, display_message)
+
+    delete_only_selected_challenge_evaluation_clusters.description = (
+        "Delete only all selected challenges' evaluation clusters."
     )
 
 

--- a/apps/challenges/admin.py
+++ b/apps/challenges/admin.py
@@ -11,6 +11,7 @@ from .aws_utils import (
     scale_workers,
     start_workers,
     stop_workers,
+    delete_challenge_evaluation_cluster_and_roles,
     delete_only_challenge_evaluation_cluster,
 )
 
@@ -84,6 +85,7 @@ class ChallengeAdmin(ImportExportTimeStampedAdmin):
         "scale_selected_workers",
         "restart_selected_workers",
         "delete_selected_workers",
+        "delete_selected_challenge_evaluation_clusters_and_roles",
         "delete_only_selected_challenge_evaluation_clusters"
     ]
     action_form = UpdateNumOfWorkersForm
@@ -213,6 +215,30 @@ class ChallengeAdmin(ImportExportTimeStampedAdmin):
 
     delete_selected_workers.short_description = (
         "Delete all selected challenge workers."
+    )
+
+    def delete_selected_challenge_evaluation_clusters_and_roles(self, request, queryset):
+        """Deletes the selected challenge evaluation clusters"""
+        response = delete_challenge_evaluation_cluster_and_roles(queryset)
+        count, failures = response["count"], response["failures"]
+
+        if count == queryset.count():
+            message = "All selected challenges' evaluation clusters successfully deleted."
+            messages.success(request, message)
+        else:
+            messages.success(
+                request,
+                "{} challenges' evaluation clusters were successfully deleted.".format(count),
+            )
+            for fail in failures:
+                challenge_pk, message = fail["challenge_pk"], fail["message"]
+                display_message = "Challenge {}: {}".format(
+                    challenge_pk, message
+                )
+                messages.error(request, display_message)
+
+    delete_selected_challenge_evaluation_clusters_and_roles.description = (
+        "Delete all selected challenges' evaluation clusters, subnets, roles, etc..."
     )
 
     def delete_only_selected_challenge_evaluation_clusters(self, request, queryset):

--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -14,7 +14,7 @@ from http import HTTPStatus
 
 from .challenge_notification_util import (
     construct_and_send_worker_start_mail,
-    construct_and_send_eks_cluster_creation_mail,
+    construct_and_send_eks_cluster_creation_mail
 )
 from .task_definitions import (
     container_definition_code_upload_worker,
@@ -913,6 +913,8 @@ def delete_only_challenge_evaluation_cluster(queryset):
     dict: keys-> 'count': the number of workers successfully stopped.
                  'failures': a dict of all the failures with their error messages and the challenge pk
     """
+    from .models import ChallengeEvaluationCluster
+
     if settings.DEBUG:
         failures = []
         for challenge in queryset:

--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -900,6 +900,211 @@ def create_eks_nodegroup(challenge, cluster_name):
 
 
 @app.task
+def delete_challenge_evaluation_cluster_and_roles(queryset):
+    """
+    The function called by the admin action method to delete all the challenge evaluation clusters used by the
+    selected challenges. Calls the delete_eks_cluster_and_roles method.
+
+    Parameters:
+    queryset (<class 'django.db.models.query.QuerySet'>): The queryset of selected challenges in the django admin page.
+
+    Returns:
+    dict: keys-> 'count': the number of workers successfully stopped.
+                 'failures': a dict of all the failures with their error messages and the challenge pk
+    """
+    from .models import ChallengeEvaluationCluster
+
+    if settings.DEBUG:
+        failures = []
+        for challenge in queryset:
+            failures.append(
+                {
+                    "message": "Challenge evaluation clusters cannot be deleted in development environment",
+                    "challenge_pk": challenge.pk,
+                }
+            )
+        return {"count": 0, "failures": failures}
+
+    count = 0
+    failures = []
+    for challenge in queryset:
+        try:
+            ChallengeEvaluationCluster.objects.get(challenge=challenge)
+        except ChallengeEvaluationCluster.DoesNotExist:
+            response = "Please select challenges with active evaluation clusters only."
+            failures.append(
+                {"message": response, "challenge_pk": challenge.pk}
+            )
+            continue
+        response = delete_eks_cluster_and_roles(challenge=challenge)
+        if not response or response["ResponseMetadata"]["HTTPStatusCode"] != HTTPStatus.OK:
+            failures.append(
+                {
+                    "message": response["Error"],
+                    "challenge_pk": challenge.pk,
+                }
+            )
+            continue
+        count += 1
+    return {"count": count, "failures": failures}
+
+
+@app.task
+def delete_eks_cluster_and_roles(challenge):
+    """
+    Deletes EKS and NodeGroup ARN roles
+
+    Arguments:
+        instance {<class 'django.db.models.query.QuerySet'>} -- instance of the model calling the post hook
+    """
+    from .models import ChallengeEvaluationCluster
+    from .utils import get_aws_credentials_for_challenge
+
+    for obj in serializers.deserialize("json", challenge):
+        challenge_obj = obj.object
+    challenge_aws_keys = get_aws_credentials_for_challenge(challenge_obj.pk)
+    client = get_boto3_client("iam", challenge_aws_keys)
+    environment_suffix = "{}-{}".format(challenge_obj.pk, settings.ENVIRONMENT)
+    eks_role_name = "evalai-code-upload-eks-role-{}".format(environment_suffix)
+    node_group_role_name = "evalai-code-upload-nodegroup-role-{}".format(
+        environment_suffix
+    )
+    try:
+        # Delete all EKS cluster subnets
+        delete_eks_cluster_subnets.delay(challenge)
+
+        challenge_evaluation_cluster = ChallengeEvaluationCluster.objects.get(
+            challenge=challenge_obj
+        )
+        ecr_all_access_policy_arn = challenge_evaluation_cluster.ecr_all_access_policy_arn
+
+        # Detach role policy and delete policy in reverse order of creation
+        client.detach_role_policy(RoleName=node_group_role_name, PolicyArn=ecr_all_access_policy_arn)
+        client.delete_policy(PolicyArn=ecr_all_access_policy_arn)
+
+        task_execution_policies = settings.EKS_NODE_GROUP_POLICIES
+        for policy_arn in task_execution_policies:
+            # Detach AWS managed EKS worker node policy from the role
+            client.delete_role_policy(
+                RoleName=node_group_role_name,
+                PolicyArn=policy_arn,
+            )
+        client.delete_role(RoleName=node_group_role_name)
+
+        client.delete_role_policy(
+            RoleName=eks_role_name,
+            PolicyArn=settings.EKS_CLUSTER_POLICY
+        )
+        response = client.delete_role(RoleName=eks_role_name)
+
+        # Delete challenge evaluation cluster object
+        challenge_evaluation_cluster.delete()
+        return response
+    except ClientError as e:
+        logger.exception(e)
+        return
+
+
+@app.task
+def delete_eks_cluster_subnets(challenge):
+    """
+    Destroys EKS and NodeGroup ARN roles
+
+    Arguments:
+        instance {<class 'django.db.models.query.QuerySet'>} -- instance of the model calling the post hook
+    """
+    from .models import ChallengeEvaluationCluster
+    from .utils import get_aws_credentials_for_challenge
+
+    for obj in serializers.deserialize("json", challenge):
+        challenge_obj = obj.object
+    challenge_aws_keys = get_aws_credentials_for_challenge(challenge_obj.pk)
+    environment_suffix = "{}-{}".format(challenge_obj.pk, settings.ENVIRONMENT)
+    client = get_boto3_client("ec2", challenge_aws_keys)
+    # Delete vpc and internet gateway
+    try:
+        # Delete eks cluster
+        delete_eks_cluster.delay(challenge)
+
+        challenge_evaluation_cluster = ChallengeEvaluationCluster.objects.get(
+            challenge=challenge_obj
+        )
+        efs_id = challenge_evaluation_cluster.efs_id
+        vpc_id = challenge_evaluation_cluster.vpc_id
+        internet_gateway_id = challenge_evaluation_cluster.internet_gateway_id
+        route_table_id = challenge_evaluation_cluster.route_table_id
+        security_group_id = challenge_evaluation_cluster.security_group_id
+        efs_security_group_id = challenge_evaluation_cluster.efs_security_group_id
+        subnet_1_id = challenge_evaluation_cluster.subnet_1_id
+        subnet_2_id = challenge_evaluation_cluster.subnet_2_id
+        subnet_ids = [subnet_1_id, subnet_2_id]
+
+        # Delete EFS
+        efs_client = get_boto3_client("efs", challenge_aws_keys)
+        efs_client.delete_file_system(
+            FileSystemId=efs_id,
+        )
+
+        # Delete security groups
+        client.delete_security_group(
+            GroupID=efs_security_group_id,
+            GroupName="evalai-code-upload-challenge-efs-{}".format(
+                environment_suffix
+            ),
+        )
+        client.delete_security_group(
+            GroupID=security_group_id,
+            GroupName="EvalAI code upload challenge",
+        )
+
+        # Disassociate route table from subnets
+        route_table_response = client.describe_route_tables(
+            RouteTableIds=[route_table_id],
+        )
+        for route_table in route_table_response['RouteTables']:
+            for route_table_association in route_table['Associations']:
+                client.disassociate_route_table(AssociationId=route_table_association['RouteTableAssociationId'])
+
+        all_instance_ids = []
+        for subnet in subnet_ids:
+            # In case any instances are still running on subnets, terminate them
+            instances = client.describe_instances(Filters=[
+                {
+                    'Name': 'subnet-id',
+                    'Values': [subnet['SubnetId']]
+                }
+            ])
+            instance_ids = []
+            for instance in instances['Reservations']:
+                for instance_name in instance['Instances']:
+                    instance_ids.append(instance_name['InstanceId'])
+            all_instance_ids += instance_ids
+            terminate_instance_response = client.terminate_instances(InstanceIds=instance_ids)
+            for terminated_instance in terminate_instance_response['TerminatingInstances']:
+                if terminated_instance['CurrentState']['Name'] == 'running':
+                    # Could not terminate instance, blocking us from deleting route table.
+                    raise Exception(f"Instance with ID {terminated_instance['InstanceId']} was not terminated \
+                        successfully while deconstructing challenge evaluation cluster for challenge \
+                        {challenge.title} with ID {challenge.pk}.")
+
+        # Wait until all instances are terminated
+        terminate_instances_waiter = client.get_waiter('instance_terminated')
+        terminate_instances_waiter.wait(InstanceIds=all_instance_ids)
+
+        # Delete subnets
+        for subnet in subnet_ids:
+            client.delete_subnet(SubnetId=subnet)
+
+        # Route deleted by deletion of route table
+        client.delete_route_table(RouteTableId=route_table_id)
+        client.detach_internet_gateway(InternetGatewayId=internet_gateway_id)
+        client.delete_vpc(VpcId=vpc_id)
+    except ClientError as e:
+        logger.exception(e)
+        return
+
+
+@app.task
 def delete_only_challenge_evaluation_cluster(queryset):
     """
     The function called by the admin action method to delete all the challenge evaluation clusters used by the


### PR DESCRIPTION
This pull request is part 2 of the cluster deletion API being created. Part 1 can be found [here](https://github.com/Cloud-CV/EvalAI/pull/3844). This commit adds a new Django admin task to fully delete a challenge's evaluation clusters, including its roles, subnets, etc...