### PR TITLE
Fix Remote Evaluation Meta visibility on Manage tab

### DIFF
--- a/frontend/src/views/web/challenge/challenge-page.html
+++ b/frontend/src/views/web/challenge/challenge-page.html
@@ -119,7 +119,7 @@
                             All Submissions</a></li>
                     <li class="margin-btm-0"><a ui-sref=".leaderboard" ui-sref-active="active-challenge"
                             class="text-light-black w-300"><i class="fa fa-line-chart"></i> Leaderboard</a></li>
-                    <li class="margin-btm-0" ng-if="challenge.isChallengeHost && !challenge.isRemoteChallenge"><a ui-sref=".manage" ui-sref-active="active-challenge"
+                    <li class="margin-btm-0" ng-if="challenge.isChallengeHost"><a ui-sref=".manage" ui-sref-active="active-challenge"
                             class="text-light-black w-300"><i class="fa fa-cogs"></i> Manage</a></li>
                     <li class="margin-btm-0" ng-if="challenge.isForumEnabled && challenge.forumURL"><a
                             href="{{challenge.forumURL}}" target="_blank" class="text-light-black w-300"><i

--- a/frontend/src/views/web/challenge/manage.html
+++ b/frontend/src/views/web/challenge/manage.html
@@ -1,5 +1,5 @@
 <section class="ev-sm-container ev-view challenge-container" ng-init="challenge.startLoadingLogs();">
-    <div class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view">
+    <div class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view" ng-if="!challenge.isRemoteChallenge">
         <div class="row margin-bottom-cancel">
             <div class="col s12 m12 l12">
                 <div class="w-300 fs-16"><strong>Note:</strong>By default, we allocate 0.5 vCPU and 1 GB memory
@@ -9,7 +9,7 @@
             </div>
         </div>
     </div>
-    <div class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view">
+    <div class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view" ng-if="!challenge.isRemoteChallenge">
         
         <div class="row margin-bottom-cancel">
             <div class="col s12">
@@ -56,7 +56,7 @@
             <div ng-repeat="log in challenge.workerLogs track by $index" class="ev-logs">{{log}}</div>
         </div>
     </div>
-    <div class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view">
+    <div class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view" ng-if="challenge.isRemoteChallenge">
         <div class="row margin-bottom-cancel">
             <div class="col s12">
                 <h5 class="w-300">Remote Evaluation Meta</h5>


### PR DESCRIPTION
This PR allows display of remote evaluation meta on the manage tab instead of hiding the manage tab entirely which is the current behaviour. This allows people to switch to `remote_evalution:True` in configuration and then head to manage tab to get these details. 

An alternative is to show `Remote Evaluation Meta` at all times.

Screenshots from current behaviour are added below:

<img width="984" alt="Screenshot 2022-12-26 at 5 46 33 PM" src="https://user-images.githubusercontent.com/29076344/209587183-703aff15-1efb-4d66-9bf3-67aebf3dabd2.png">
<img width="1263" alt="Screenshot 2022-12-26 at 5 46 21 PM" src="https://user-images.githubusercontent.com/29076344/209587184-00006edb-cea7-44ed-96d2-39e2d9ba1e77.png">

