### PR TITLE
Improve EKS auto scaling script

### DIFF
--- a/scripts/monitoring/auto_scale_eks_nodes.py
+++ b/scripts/monitoring/auto_scale_eks_nodes.py
@@ -84,8 +84,8 @@ def start_eks_worker(challenge, queue_length):
     eks_client, cluster_name, nodegroup_name = get_eks_meta(challenge)
     scaling_config = {
         "minSize": 1,
-        "maxSize": max(5, queue_length),
-        "desiredSize": min(5, queue_length),
+        "maxSize": max(2, queue_length),
+        "desiredSize": min(2, queue_length),
     }
     response = eks_client.update_nodegroup_config(
         clusterName=cluster_name,

--- a/scripts/monitoring/auto_scale_eks_nodes.py
+++ b/scripts/monitoring/auto_scale_eks_nodes.py
@@ -84,8 +84,8 @@ def start_eks_worker(challenge, queue_length):
     eks_client, cluster_name, nodegroup_name = get_eks_meta(challenge)
     scaling_config = {
         "minSize": 1,
-        "maxSize": max(2, queue_length),
-        "desiredSize": min(2, queue_length),
+        "maxSize": max(1, queue_length),
+        "desiredSize": min(1, queue_length),
     }
     response = eks_client.update_nodegroup_config(
         clusterName=cluster_name,


### PR DESCRIPTION
This PR changes the minimum desired size to be 2 when auto-scaling. This is done to prevent excessive use of the EKS nodes when not needed.