### PR TITLE
Fix statsd increment in code-upload challenges

### DIFF
--- a/scripts/workers/code_upload_submission_worker.py
+++ b/scripts/workers/code_upload_submission_worker.py
@@ -521,7 +521,7 @@ def cleanup_submission(
     stderr,
     message,
     queue_name,
-    is_remote
+    is_remote,
 ):
     """Function to update status of submission to EvalAi, Delete corrosponding job from cluster and message from SQS.
     Arguments:
@@ -573,7 +573,7 @@ def update_failed_jobs_and_send_logs(
     phase_pk,
     message,
     queue_name,
-    is_remote
+    is_remote,
 ):
     clean_submission = False
     try:
@@ -648,7 +648,7 @@ def update_failed_jobs_and_send_logs(
             submission_error,
             message,
             queue_name,
-            is_remote
+            is_remote,
         )
 
 
@@ -776,7 +776,7 @@ def main():
                         phase_pk,
                         message,
                         QUEUE_NAME,
-                        is_remote
+                        is_remote,
                     )
                 else:
                     logger.info(

--- a/scripts/workers/code_upload_submission_worker.py
+++ b/scripts/workers/code_upload_submission_worker.py
@@ -3,16 +3,13 @@ import logging
 import os
 import signal
 import sys
-import yaml
 import time
 
-
-from worker_utils import EvalAI_Interface
-
+import yaml
 from kubernetes import client
-
 # TODO: Add exception in all the commands
 from kubernetes.client.rest import ApiException
+from worker_utils import EvalAI_Interface
 
 from .submission_worker import increment_and_push_metrics_to_statsd
 


### PR DESCRIPTION
This PR fixes the issue of not incrementing of `num_processed_submissions` when the submission is `finished`, `failed` or `cancelled` in case of code-upload challenge workers.

**Note**: I have changed the import order (fixed by isort).