### PR TITLE
Add DataDog to requirements in code-upload worker

### DIFF
--- a/requirements/code_upload_worker.txt
+++ b/requirements/code_upload_worker.txt
@@ -1,2 +1,3 @@
+datadog==0.39.0
 kubernetes==12.0.1
 requests==2.25.1


### PR DESCRIPTION
This PR fixes missing DataDog requirements in code-upload worker.