### PR TITLE
Fix #3908 : Render phases data from API Response 

### DIFF
--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -2562,7 +2562,7 @@
         };
 
         vm.challengePhaseDialog = function(ev, phase) {
-            vm.page.challenge_phase = phase;
+            vm.page.challenge_phase = Object.assign({} ,phase);
             vm.page.max_submissions_per_day = phase.max_submissions_per_day;
             vm.page.max_submissions_per_month = phase.max_submissions_per_month;
             vm.phaseStartDate = moment(phase.start_date);
@@ -2601,6 +2601,12 @@
                     onSuccess: function(response) {
                         var status = response.status;
                         utilities.hideLoader();
+                        var details = response.data
+                        for (var i =0; i<vm.phases.results.length;i++){
+                            if(vm.phases.results[i].id == details.id){
+                                vm.phases.results[i] = details
+                            }
+                        }
                         if (status === 200) {
                             $mdDialog.hide();
                             $rootScope.notify("success", "The challenge phase details are successfully updated!");


### PR DESCRIPTION
Issue - After edit, phases values were not being
updated with the API response.

Solution - Corrected the above behaviour by
considering API response on success.
In case of failures, the original data is not
updated.

IMPORTANT NOTES (please read, then delete):

* The PR title should start with "Fix #bugnum: " (if applicable), followed by a clear one-line present-tense summary of the changes introduced in the PR. For example: "Fix #bugnum: Introduce the first version of the collection editor.".

* Please make sure to mention "#bugnum" somewhere in the description of the PR. This enables GitHub to link the PR to the corresponding bug.

Please also make sure to follow the [style rules](https://github.com/Cloud-CV/EvalAI/blob/master/.github/CONTRIBUTING.md#style-rules).
