### PR TITLE
Fixes #3922 Remove File URL option for submission

### DIFF
--- a/frontend/src/views/web/challenge/submission.html
+++ b/frontend/src/views/web/challenge/submission.html
@@ -222,15 +222,6 @@
                                     <strong class="fs-16 w-300">Use CLI (for file size > 400MB)
                                     </strong>
                                 </div>
-                                <input type="radio" name="submissionOptions" class="with-gap selectPhase" id="fileUrl"
-                                    value="fileUrl" ng-click="challenge.isSubmissionUsingUrl = true; challenge.isSubmissionUsingCli = false; challenge.isSubmissionUsingFile = false;">
-                                <label for="fileUrl"></label>
-                                <div class="show-member-title pointer">
-                                    <strong class="fs-16 w-300">File URL (for file size > 400MB)
-                                    </strong>
-                                </div>
-                                <div class="clearfix"></div>
-
                                 <input type="radio" name="submissionOptions" class="with-gap selectPhase"
                                     id="fileUpload" value="challenge.showFileUploadOption"
                                     ng-click="challenge.isSubmissionUsingFile = true; challenge.isSubmissionUsingUrl = false; challenge.isSubmissionUsingCli = false;">


### PR DESCRIPTION
Aim - remove radio button

Deleting 'File URL (for file size>400MB)' option because CLI is now used for uploading large files.


![Screenshot from 2023-04-05 18-56-22](https://user-images.githubusercontent.com/49990128/230253842-23e88dec-fdc8-433e-8567-8889b5745628.png)
