### PR TITLE
Fixes negative execution time

### DIFF
--- a/apps/jobs/models.py
+++ b/apps/jobs/models.py
@@ -147,12 +147,13 @@ class Submission(TimeStampedModel):
     def execution_time(self):
         """Returns the execution time of a submission"""
         # if self.self.completed_at and self.started_at:
-        try:
+
+        if self.completed_at and self.started_at:
             return (self.completed_at - self.started_at).total_seconds()
-        except:  # noqa: E722
-            return "None"
-        # else:
-        #     return None
+        elif self.started_at and not self.completed_at:
+            return (timezone.now() - self.started_at).total_seconds()
+        else:
+            return None
 
     def save(self, *args, **kwargs):
 


### PR DESCRIPTION
Case 1: when submission status is finished and completed_at and started_at values exist, execution_time is from the values 
Case 2: When the submission is running and only the started_at value exists, then execution_time is elapsed_time 
Case 3: Submission status is Submitted and Neither values are initialized then execution_time is None

Tested the above cases in admin site