### PR TITLE
[BugFix] Remove leaderboard duplication

### DIFF
--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -1076,11 +1076,6 @@
 
             utilities.sendRequest(parameters);
         };
-
-        if (vm.phaseSplitId) {
-            vm.getLeaderboard(vm.phaseSplitId);
-        }
-
         
         vm.showMetaAttributesDialog = function(ev, attributes){
             if (attributes != false){


### PR DESCRIPTION
### **Preview**
![leaderboard](https://user-images.githubusercontent.com/77075449/234258790-2c37b746-c4ef-4a44-a7e9-0cc9dcf09bfe.gif)

### **Background check**
**Repeated conditional statement at line [1080](https://github.com/Cloud-CV/EvalAI/blob/master/frontend/src/js/controllers/challengeCtrl.js#L1080) and [1545](https://github.com/Cloud-CV/EvalAI/blob/master/frontend/src/js/controllers/challengeCtrl.js#L1545) in `challengeCtrl.js`.**

It's highly possible that the reason for repeating this _if statement_ is to ensure that `vm.getLeaderboard` is called with the correct `phaseSplitId` value in case it has changed since the last time it was called but the problem arises when it causes the duplicate entries on the leaderboard. Removing the former statement fixes the issue because even if the leaderboard has been updated or not, the result can be retrieved by calling the later function and displaying it on the board. The above repetition also calls the API 
`"jobs/" + "challenge_phase_split/" + vm.phaseSplitId + "/leaderboard/?page_size=1000&order_by=" + vm.orderLeaderboardBy` twice which should not be the case ideally. Since, both API response is the same, removing the repeated code works fine.

### Fixes #3902 


