### PR TITLE
Fix frontend pagination for challenge list

### DIFF
--- a/frontend/src/js/controllers/challengeListCtrl.js
+++ b/frontend/src/js/controllers/challengeListCtrl.js
@@ -24,18 +24,12 @@
         vm.nonePastChallenge = false;
 
         // helper function to get all challenge results
-        function getAllResults(parameters, resultsArray, noneResults) {
+        function getAllResults(parameters, resultsArray) {
             parameters.callback = {
                 onSuccess: function(response) {
                     var data = response.data;
                     var results = data.results;
-
-                    if (results.length === 0) {
-                        noneResults = true;
-                    } else {
-                        noneResults = false;
-                    }
-
+                    
                     var timezone = moment.tz.guess();
                     for (var i in results) {
 
@@ -76,30 +70,50 @@
             utilities.sendRequest(parameters);
         }
 
-        // calls for ongoing challenges
+        
         vm.challengeCreator = {};
         var parameters = {};
-        parameters.method = 'GET';
         if (userKey) {
             parameters.token = userKey;
         } else {
             parameters.token = null;
         }
-        parameters.url = 'challenges/challenge/present/approved/public';
 
-        getAllResults(parameters, vm.currentList, vm.noneCurrentChallenge);
+        // calls for ongoing challenges
+        parameters.url = 'challenges/challenge/present/approved/public';
+        parameters.method = 'GET';
+        
+        getAllResults(parameters, vm.currentList);
+
+        if (vm.currentList.length === 0) {
+            vm.noneCurrentChallenge = true;
+        } else {
+            vm.noneCurrentChallenge = false;
+        }
 
         // calls for upcoming challneges
         parameters.url = 'challenges/challenge/future/approved/public';
         parameters.method = 'GET';
 
-        getAllResults(parameters, vm.upcomingList, vm.noneUpcomingChallenge);
+        getAllResults(parameters, vm.upcomingList);
+
+        if (vm.upcomingList.length === 0) {
+            vm.noneUpcomingChallenge = true;
+        } else {
+            vm.noneUpcomingChallenge = false;
+        }
 
         // calls for past challneges
         parameters.url = 'challenges/challenge/past/approved/public';
         parameters.method = 'GET';
 
-        getAllResults(parameters, vm.pastList, vm.nonePastChallenge);
+        getAllResults(parameters, vm.pastList);
+
+        if (vm.pastList.length === 0) {
+            vm.nonePastChallenge = true;
+        } else {
+            vm.nonePastChallenge = false;
+        }
 
         vm.scrollUp = function() {
             angular.element($window).bind('scroll', function() {

--- a/frontend/src/js/controllers/challengeListCtrl.js
+++ b/frontend/src/js/controllers/challengeListCtrl.js
@@ -15,9 +15,9 @@
         utilities.showLoader();
         utilities.hideButton();
 
-        vm.currentList = {};
-        vm.upcomingList = {};
-        vm.pastList = {};
+        vm.currentList = [];
+        vm.upcomingList = [];
+        vm.pastList = [];
 
         vm.noneCurrentChallenge = false;
         vm.noneUpcomingChallenge = false;
@@ -60,10 +60,11 @@
 
                     // check for the next page
                     if (data.next !== null) {
-                        parameters.url = data.next;
-                        utilities.sendRequest(parameters).then(function() {
-                            getAllResults(parameters, resultsArray, noneResults);
-                        });
+                        console.log(data.next);
+                        var url = data.next;
+                        var slicedUrl = url.substring(url.indexOf('challenges/challenge'), url.length);
+                        parameters.url = slicedUrl;
+                        getAllResults(parameters, resultsArray, noneResults);
                     } else {
                         utilities.hideLoader();
                     }

--- a/frontend/src/js/controllers/challengeListCtrl.js
+++ b/frontend/src/js/controllers/challengeListCtrl.js
@@ -23,6 +23,59 @@
         vm.noneUpcomingChallenge = false;
         vm.nonePastChallenge = false;
 
+        // helper function to get all challenge results
+        function getAllResults(parameters, resultsArray, noneResults) {
+            parameters.callback = {
+                onSuccess: function(response) {
+                    var data = response.data;
+                    var results = data.results;
+
+                    if (results.length === 0) {
+                        noneResults = true;
+                    } else {
+                        noneResults = false;
+                    }
+
+                    var timezone = moment.tz.guess();
+                    for (var i in results) {
+
+                        var descLength = results[i].description.length;
+                        if (descLength >= 50) {
+                            results[i].isLarge = "...";
+                        } else {
+                            results[i].isLarge = "";
+                        }
+
+                        var offset = new Date(results[i].start_date).getTimezoneOffset();
+                        results[i].start_zone = moment.tz.zone(timezone).abbr(offset);
+                        offset = new Date(results[i].end_date).getTimezoneOffset();
+                        results[i].end_zone = moment.tz.zone(timezone).abbr(offset);
+
+                        var id = results[i].id;
+                        vm.challengeCreator[id] = results[i].creator.id;
+                        utilities.storeData("challengeCreator", vm.challengeCreator);
+
+                        resultsArray.push(results[i]);
+                    }
+
+                    // check for the next page
+                    if (data.next !== null) {
+                        parameters.url = data.next;
+                        utilities.sendRequest(parameters).then(function() {
+                            getAllResults(parameters, resultsArray, noneResults);
+                        });
+                    } else {
+                        utilities.hideLoader();
+                    }
+                },
+                onError: function() {
+                    utilities.hideLoader();
+                }
+            };
+
+            utilities.sendRequest(parameters);
+        }
+
         // calls for ongoing challenges
         vm.challengeCreator = {};
         var parameters = {};
@@ -34,137 +87,19 @@
         }
         parameters.url = 'challenges/challenge/present/approved/public';
 
-        parameters.callback = {
-            onSuccess: function(response) {
-                var data = response.data;
-                vm.currentList = data.results;
+        getAllResults(parameters, vm.currentList, vm.noneCurrentChallenge);
 
-                if (vm.currentList.length === 0) {
-                    vm.noneCurrentChallenge = true;
-                } else {
-                    vm.noneCurrentChallenge = false;
-                }
+        // calls for upcoming challneges
+        parameters.url = 'challenges/challenge/future/approved/public';
+        parameters.method = 'GET';
 
-                var timezone = moment.tz.guess();
-                for (var i in vm.currentList) {
+        getAllResults(parameters, vm.upcomingList, vm.noneUpcomingChallenge);
 
-                    var descLength = vm.currentList[i].description.length;
-                    if (descLength >= 50) {
-                        vm.currentList[i].isLarge = "...";
-                    } else {
-                        vm.currentList[i].isLarge = "";
-                    }
-                    var offset = new Date(vm.currentList[i].start_date).getTimezoneOffset();
-                    vm.currentList[i].start_zone = moment.tz.zone(timezone).abbr(offset);
-                    offset = new Date(vm.currentList[i].end_date).getTimezoneOffset();
-                    vm.currentList[i].end_zone = moment.tz.zone(timezone).abbr(offset);
+        // calls for past challneges
+        parameters.url = 'challenges/challenge/past/approved/public';
+        parameters.method = 'GET';
 
-                    var id = vm.currentList[i].id;
-                    vm.challengeCreator[id] = vm.currentList[i].creator.id;
-                    utilities.storeData("challengeCreator", vm.challengeCreator);
-                }
-
-                // dependent api
-                // calls for upcoming challneges
-                parameters.url = 'challenges/challenge/future/approved/public';
-                parameters.method = 'GET';
-
-                parameters.callback = {
-                    onSuccess: function(response) {
-                        var data = response.data;
-                        vm.upcomingList = data.results;
-
-                        if (vm.upcomingList.length === 0) {
-                            vm.noneUpcomingChallenge = true;
-                        } else {
-                            vm.noneUpcomingChallenge = false;
-                        }
-
-                        var timezone = moment.tz.guess();
-                        for (var i in vm.upcomingList) {
-
-                            var descLength = vm.upcomingList[i].description.length;
-
-                            if (descLength >= 50) {
-                                vm.upcomingList[i].isLarge = "...";
-                            } else {
-                                vm.upcomingList[i].isLarge = "";
-                            }
-                            
-                            var offset = new Date(vm.upcomingList[i].start_date).getTimezoneOffset();
-                            vm.upcomingList[i].start_zone = moment.tz.zone(timezone).abbr(offset);
-                            offset = new Date(vm.upcomingList[i].end_date).getTimezoneOffset();
-                            vm.upcomingList[i].end_zone = moment.tz.zone(timezone).abbr(offset);
-
-                            
-                            var id = vm.upcomingList[i].id;
-                            vm.challengeCreator[id] = vm.upcomingList[i].creator.id;
-                            utilities.storeData("challengeCreator", vm.challengeCreator);
-                        }
-
-                        // dependent api
-                        // calls for past challneges
-                        parameters.url = 'challenges/challenge/past/approved/public';
-                        parameters.method = 'GET';
-
-                        parameters.callback = {
-                            onSuccess: function(response) {
-                                var data = response.data;
-                                vm.pastList = data.results;
-
-                                if (vm.pastList.length === 0) {
-                                    vm.nonePastChallenge = true;
-                                } else {
-                                    vm.nonePastChallenge = false;
-                                }
-
-                                var timezone = moment.tz.guess();
-                                for (var i in vm.pastList) {
-
-
-                                    var descLength = vm.pastList[i].description.length;
-                                    if (descLength >= 50) {
-                                        vm.pastList[i].isLarge = "...";
-                                    } else {
-                                        vm.pastList[i].isLarge = "";
-                                    }
-
-                                    var offset = new Date(vm.pastList[i].start_date).getTimezoneOffset();
-                                    vm.pastList[i].start_zone = moment.tz.zone(timezone).abbr(offset);
-                                    offset = new Date(vm.pastList[i].end_date).getTimezoneOffset();
-                                    vm.pastList[i].end_zone = moment.tz.zone(timezone).abbr(offset);
-
-                                    var id = vm.pastList[i].id;
-                                    vm.challengeCreator[id] = vm.pastList[i].creator.id;
-                                    utilities.storeData("challengeCreator", vm.challengeCreator);
-                                }
-
-                                utilities.hideLoader();
-
-                            },
-                            onError: function() {
-                                utilities.hideLoader();
-                            }
-                        };
-
-                        utilities.sendRequest(parameters);
-
-                    },
-                    onError: function() {
-                        utilities.hideLoader();
-                    }
-                };
-
-                utilities.sendRequest(parameters);
-
-            },
-            onError: function() {
-
-                utilities.hideLoader();
-            }
-        };
-
-        utilities.sendRequest(parameters);
+        getAllResults(parameters, vm.pastList, vm.nonePastChallenge);
 
         vm.scrollUp = function() {
             angular.element($window).bind('scroll', function() {

--- a/frontend/src/js/controllers/challengeListCtrl.js
+++ b/frontend/src/js/controllers/challengeListCtrl.js
@@ -105,7 +105,7 @@
         parameters.url = 'challenges/challenge/past/approved/public';
         parameters.method = 'GET';
 
-        vm.noneCurrentChallengegetAllResults(parameters, vm.pastList);
+        vm.getAllResults(parameters, vm.pastList);
 
         if (vm.pastList.length === 0) {
             vm.nonePastChallenge = true;

--- a/frontend/src/js/controllers/challengeListCtrl.js
+++ b/frontend/src/js/controllers/challengeListCtrl.js
@@ -91,7 +91,7 @@
             vm.noneCurrentChallenge = false;
         }
 
-        // calls for upcoming challneges
+        // calls for upcoming challenges
         parameters.url = 'challenges/challenge/future/approved/public';
         parameters.method = 'GET';
 
@@ -103,7 +103,7 @@
             vm.noneUpcomingChallenge = false;
         }
 
-        // calls for past challneges
+        // calls for past challenges
         parameters.url = 'challenges/challenge/past/approved/public';
         parameters.method = 'GET';
 

--- a/frontend/src/js/controllers/challengeListCtrl.js
+++ b/frontend/src/js/controllers/challengeListCtrl.js
@@ -22,9 +22,7 @@
         vm.noneCurrentChallenge = true;
         vm.noneUpcomingChallenge = true;
         vm.nonePastChallenge = true;
-
-        // helper function to get all challenge results
-        function getAllResults(parameters, resultsArray) {
+        vm.getAllResults = function(parameters, resultsArray){
             parameters.callback = {
                 onSuccess: function(response) {
                     var data = response.data;
@@ -83,7 +81,7 @@
         parameters.url = 'challenges/challenge/present/approved/public';
         parameters.method = 'GET';
         
-        getAllResults(parameters, vm.currentList);
+        vm.getAllResults(parameters, vm.currentList);
 
         if (vm.currentList.length === 0) {
             vm.noneCurrentChallenge = true;
@@ -95,7 +93,7 @@
         parameters.url = 'challenges/challenge/future/approved/public';
         parameters.method = 'GET';
 
-        getAllResults(parameters, vm.upcomingList);
+        vm.getAllResults(parameters, vm.upcomingList);
 
         if (vm.upcomingList.length === 0) {
             vm.noneUpcomingChallenge = true;
@@ -107,7 +105,7 @@
         parameters.url = 'challenges/challenge/past/approved/public';
         parameters.method = 'GET';
 
-        getAllResults(parameters, vm.pastList);
+        vm.noneCurrentChallengegetAllResults(parameters, vm.pastList);
 
         if (vm.pastList.length === 0) {
             vm.nonePastChallenge = true;

--- a/frontend/src/js/controllers/challengeListCtrl.js
+++ b/frontend/src/js/controllers/challengeListCtrl.js
@@ -57,7 +57,7 @@
                         var url = data.next;
                         var slicedUrl = url.substring(url.indexOf('challenges/challenge'), url.length);
                         parameters.url = slicedUrl;
-                        getAllResults(parameters, resultsArray, noneResults);
+                        getAllResults(parameters, resultsArray);
                     } else {
                         utilities.hideLoader();
                     }

--- a/frontend/src/js/controllers/challengeListCtrl.js
+++ b/frontend/src/js/controllers/challengeListCtrl.js
@@ -60,7 +60,6 @@
 
                     // check for the next page
                     if (data.next !== null) {
-                        console.log(data.next);
                         var url = data.next;
                         var slicedUrl = url.substring(url.indexOf('challenges/challenge'), url.length);
                         parameters.url = slicedUrl;

--- a/frontend/src/js/controllers/challengeListCtrl.js
+++ b/frontend/src/js/controllers/challengeListCtrl.js
@@ -19,9 +19,9 @@
         vm.upcomingList = [];
         vm.pastList = [];
 
-        vm.noneCurrentChallenge = false;
-        vm.noneUpcomingChallenge = false;
-        vm.nonePastChallenge = false;
+        vm.noneCurrentChallenge = true;
+        vm.noneUpcomingChallenge = true;
+        vm.nonePastChallenge = true;
 
         // helper function to get all challenge results
         function getAllResults(parameters, resultsArray) {

--- a/frontend/src/js/controllers/challengeListCtrl.js
+++ b/frontend/src/js/controllers/challengeListCtrl.js
@@ -66,7 +66,7 @@
             };
 
             utilities.sendRequest(parameters);
-        }
+        };
 
         
         vm.challengeCreator = {};

--- a/frontend/src/js/controllers/challengeListCtrl.js
+++ b/frontend/src/js/controllers/challengeListCtrl.js
@@ -55,7 +55,7 @@
                         var url = data.next;
                         var slicedUrl = url.substring(url.indexOf('challenges/challenge'), url.length);
                         parameters.url = slicedUrl;
-                        getAllResults(parameters, resultsArray);
+                        vm.getAllResults(parameters, resultsArray);
                     } else {
                         utilities.hideLoader();
                     }

--- a/frontend/tests/controllers-test/challengeListCtrl.test.js
+++ b/frontend/tests/controllers-test/challengeListCtrl.test.js
@@ -289,7 +289,7 @@ describe('Unit tests for challenge list controller', function () {
         });
 
         it('should call getAllResults method recursively when next is not null', function () {
-            spyOn(vm, 'getAllResults').and.callThrough(); // spy on getAllResults method
+            spyOn(vm, 'getAllResults'); // spy on getAllResults method
 
             isPresentChallengeSuccess = true;
             isUpcomingChallengeSucess = null;
@@ -314,7 +314,7 @@ describe('Unit tests for challenge list controller', function () {
             vm = createController();
             expect(vm.currentList).toEqual(successResponse.results);
             expect(vm.noneCurrentChallenge).toBeFalsy();
-            expect(vm.getAllResults).toHaveBeenCalledWith('http://example.com/challenges/?page=2', [], jasmine.any(Function));
+            expect(vm.getAllResults).toHaveBeenCalledWith('http://example.com/challenges/?page=2', vm.currentList);
         });
 
 

--- a/frontend/tests/controllers-test/challengeListCtrl.test.js
+++ b/frontend/tests/controllers-test/challengeListCtrl.test.js
@@ -289,8 +289,6 @@ describe('Unit tests for challenge list controller', function () {
         });
 
         it('should call getAllResults method recursively when next is not null', function () {
-            spyOn(vm, 'getAllResults'); // spy on getAllResults method
-
             isPresentChallengeSuccess = true;
             isUpcomingChallengeSucess = null;
             isPastChallengeSuccess = null;
@@ -312,9 +310,16 @@ describe('Unit tests for challenge list controller', function () {
             };
 
             vm = createController();
+            spyOn(vm, 'getAllResults').and.callThrough();
+            const parameters = {
+                url: 'challenges/challenge/present/approved/public',
+                method: 'GET',
+                callback: jasmine.any(Function)
+            };
+            vm.getAllResults(parameters, []);
             expect(vm.currentList).toEqual(successResponse.results);
             expect(vm.noneCurrentChallenge).toBeFalsy();
-            expect(vm.getAllResults).toHaveBeenCalledWith('http://example.com/challenges/?page=2', vm.currentList);
+            expect(vm.getAllResults).toHaveBeenCalledTimes(2);
         });
 
 

--- a/frontend/tests/controllers-test/challengeListCtrl.test.js
+++ b/frontend/tests/controllers-test/challengeListCtrl.test.js
@@ -290,9 +290,7 @@ describe('Unit tests for challenge list controller', function () {
 
         it('should call getAllResults method recursively when next is not null', function () {
             spyOn(vm, 'getAllResults').and.callThrough(); // spy on getAllResults method
-            spyOn(utilities, 'hideLoader');
-            spyOn(utilities, 'storeData');
-            
+
             isPresentChallengeSuccess = true;
             isUpcomingChallengeSucess = null;
             isPastChallengeSuccess = null;

--- a/frontend/tests/controllers-test/challengeListCtrl.test.js
+++ b/frontend/tests/controllers-test/challengeListCtrl.test.js
@@ -29,9 +29,9 @@ describe('Unit tests for challenge list controller', function () {
             expect(vm.currentList).toEqual([]);
             expect(vm.upcomingList).toEqual([]);
             expect(vm.pastList).toEqual([]);
-            expect(vm.noneCurrentChallenge).toBeFalsy();
-            expect(vm.noneUpcomingChallenge).toBeFalsy();
-            expect(vm.nonePastChallenge).toBeFalsy();
+            expect(vm.noneCurrentChallenge).toBeTruthy();
+            expect(vm.noneUpcomingChallenge).toBeTruthy();
+            expect(vm.nonePastChallenge).toBeTruthy();
             expect(vm.challengeCreator).toEqual({});
         });
     });

--- a/frontend/tests/controllers-test/challengeListCtrl.test.js
+++ b/frontend/tests/controllers-test/challengeListCtrl.test.js
@@ -287,5 +287,38 @@ describe('Unit tests for challenge list controller', function () {
             expect(vm.upcomingList).toEqual(successResponse.results);
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
+
+        it('should call getAllResults method recursively when next is not null', function () {
+            spyOn(utilities, 'getAllResults').and.callThrough(); // spy on getAllResults method
+            spyOn(utilities, 'hideLoader');
+            spyOn(utilities, 'storeData');
+            
+            isPresentChallengeSuccess = true;
+            isUpcomingChallengeSucess = null;
+            isPastChallengeSuccess = null;
+
+            // mock response with next property set to a non-null value
+            successResponse = {
+                next: 'http://example.com/challenges/?page=2',
+                results: [
+                    {
+                        id: 1,
+                        description: "the length of the ongoing challenge description is greater than or equal to 50",
+                        creator: {
+                        id: 1
+                        },
+                        start_date: "Fri June 12 2018 22:41:51 GMT+0530",
+                        end_date: "Fri June 12 2099 22:41:51 GMT+0530"
+                    }
+                ]
+            };
+
+            vm = createController();
+            expect(vm.currentList).toEqual(successResponse.results);
+            expect(vm.noneCurrentChallenge).toBeFalsy();
+            expect(utilities.getAllResults).toHaveBeenCalledWith('http://example.com/challenges/?page=2', [], jasmine.any(Function));
+        });
+
+
     });
 });

--- a/frontend/tests/controllers-test/challengeListCtrl.test.js
+++ b/frontend/tests/controllers-test/challengeListCtrl.test.js
@@ -289,7 +289,7 @@ describe('Unit tests for challenge list controller', function () {
         });
 
         it('should call getAllResults method recursively when next is not null', function () {
-            spyOn(utilities, 'getAllResults').and.callThrough(); // spy on getAllResults method
+            spyOn(vm, 'getAllResults').and.callThrough(); // spy on getAllResults method
             spyOn(utilities, 'hideLoader');
             spyOn(utilities, 'storeData');
             
@@ -316,7 +316,7 @@ describe('Unit tests for challenge list controller', function () {
             vm = createController();
             expect(vm.currentList).toEqual(successResponse.results);
             expect(vm.noneCurrentChallenge).toBeFalsy();
-            expect(utilities.getAllResults).toHaveBeenCalledWith('http://example.com/challenges/?page=2', [], jasmine.any(Function));
+            expect(vm.getAllResults).toHaveBeenCalledWith('http://example.com/challenges/?page=2', [], jasmine.any(Function));
         });
 
 

--- a/frontend/tests/controllers-test/challengeListCtrl.test.js
+++ b/frontend/tests/controllers-test/challengeListCtrl.test.js
@@ -26,9 +26,9 @@ describe('Unit tests for challenge list controller', function () {
             expect(utilities.getData).toHaveBeenCalledWith('userKey');
             expect(vm.userKey).toEqual(utilities.getData('userKey'));
             expect(utilities.showLoader).toHaveBeenCalled();
-            expect(vm.currentList).toEqual({});
-            expect(vm.upcomingList).toEqual({});
-            expect(vm.pastList).toEqual({});
+            expect(vm.currentList).toEqual([]);
+            expect(vm.upcomingList).toEqual([]);
+            expect(vm.pastList).toEqual([]);
             expect(vm.noneCurrentChallenge).toBeFalsy();
             expect(vm.noneUpcomingChallenge).toBeFalsy();
             expect(vm.nonePastChallenge).toBeFalsy();

--- a/frontend/tests/controllers-test/challengeListCtrl.test.js
+++ b/frontend/tests/controllers-test/challengeListCtrl.test.js
@@ -65,6 +65,7 @@ describe('Unit tests for challenge list controller', function () {
             isUpcomingChallengeSucess = null;
             isPastChallengeSuccess = null;
             successResponse = {
+                next: null,
                 results: []
             };
             vm = createController();
@@ -77,6 +78,7 @@ describe('Unit tests for challenge list controller', function () {
             isUpcomingChallengeSucess = null;
             isPastChallengeSuccess = null;
             successResponse = {
+                next: null,
                 results: [
                     {
                         id: 1,
@@ -125,6 +127,7 @@ describe('Unit tests for challenge list controller', function () {
             isUpcomingChallengeSucess = null;
             isPastChallengeSuccess = null;
             errorResponse = {
+                next: null,
                 error: 'error'
             };
             vm = createController();
@@ -136,6 +139,7 @@ describe('Unit tests for challenge list controller', function () {
             isPresentChallengeSuccess = true;
             isPastChallengeSuccess = null;
             successResponse = {
+                next: null,
                 results: []
             };
             vm = createController();
@@ -148,6 +152,7 @@ describe('Unit tests for challenge list controller', function () {
             isPresentChallengeSuccess = true;
             isPastChallengeSuccess = null;
             successResponse = {
+                next: null,
                 results: [
                     {
                         id: 1,
@@ -197,6 +202,7 @@ describe('Unit tests for challenge list controller', function () {
             isPastChallengeSuccess = null;
             // success response for the ongoing challenge
             successResponse = {
+                next: null,
                 results: []
             };
             vm = createController();
@@ -209,6 +215,7 @@ describe('Unit tests for challenge list controller', function () {
             isPresentChallengeSuccess = true;
             isUpcomingChallengeSucess = true;
             successResponse = {
+                next: null,
                 results: []
             };
             vm = createController();
@@ -221,6 +228,7 @@ describe('Unit tests for challenge list controller', function () {
             isPresentChallengeSuccess = true;
             isUpcomingChallengeSucess = true;
             successResponse = {
+                next: null,
                 results: [
                     {
                         id: 1,
@@ -271,6 +279,7 @@ describe('Unit tests for challenge list controller', function () {
             isUpcomingChallengeSucess = true;
             // success response for the ongoing and upcoming challenge
             successResponse = {
+                next: null,
                 results: []
             };
             vm = createController();


### PR DESCRIPTION
This PR fixes the issue of pagination in challenge list on frontend. Basically, until now we were only reading the first page of get all challenges response and showing it on the frontend. The challenges from next pages were not showing up. This PR fixes that.

I have tested it locally and verified that the next page URLs are getting called and populated.

<img width="1437" alt="Screenshot 2023-05-06 at 12 41 54 AM" src="https://user-images.githubusercontent.com/29076344/236600287-d3b9eff1-3dd8-46a8-ae6b-4581113ed765.png">
