### PR TITLE
[Frontend] Fix async update of challenge list params

### DIFF
--- a/frontend/src/js/controllers/challengeListCtrl.js
+++ b/frontend/src/js/controllers/challengeListCtrl.js
@@ -27,7 +27,6 @@
                 onSuccess: function(response) {
                     var data = response.data;
                     var results = data.results;
-                    var vm = this;
                     
                     var timezone = moment.tz.guess();
                     for (var i in results) {
@@ -66,7 +65,7 @@
                             vm[typ] = false;
                         }
                     }
-                }.bind(vm),
+                },
                 onError: function() {
                     utilities.hideLoader();
                 }

--- a/frontend/src/js/controllers/challengeListCtrl.js
+++ b/frontend/src/js/controllers/challengeListCtrl.js
@@ -19,14 +19,15 @@
         vm.upcomingList = [];
         vm.pastList = [];
 
-        vm.noneCurrentChallenge = true;
-        vm.noneUpcomingChallenge = true;
-        vm.nonePastChallenge = true;
-        vm.getAllResults = function(parameters, resultsArray){
+        vm.noneCurrentChallenge = false;
+        vm.noneUpcomingChallenge = false;
+        vm.nonePastChallenge = false;
+        vm.getAllResults = function(parameters, resultsArray, typ){
             parameters.callback = {
                 onSuccess: function(response) {
                     var data = response.data;
                     var results = data.results;
+                    var vm = this;
                     
                     var timezone = moment.tz.guess();
                     for (var i in results) {
@@ -58,8 +59,14 @@
                         vm.getAllResults(parameters, resultsArray);
                     } else {
                         utilities.hideLoader();
+                        if (resultsArray.length === 0) {
+                            vm[typ] = true;
+                        } else {
+                            console.log(resultsArray.length);
+                            vm[typ] = false;
+                        }
                     }
-                },
+                }.bind(vm),
                 onError: function() {
                     utilities.hideLoader();
                 }
@@ -81,38 +88,20 @@
         parameters.url = 'challenges/challenge/present/approved/public';
         parameters.method = 'GET';
         
-        vm.getAllResults(parameters, vm.currentList);
-
-        if (vm.currentList.length === 0) {
-            vm.noneCurrentChallenge = true;
-        } else {
-            vm.noneCurrentChallenge = false;
-        }
-
+        vm.getAllResults(parameters, vm.currentList, "noneCurrentChallenge");
         // calls for upcoming challenges
         parameters.url = 'challenges/challenge/future/approved/public';
         parameters.method = 'GET';
 
-        vm.getAllResults(parameters, vm.upcomingList);
-
-        if (vm.upcomingList.length === 0) {
-            vm.noneUpcomingChallenge = true;
-        } else {
-            vm.noneUpcomingChallenge = false;
-        }
+        vm.getAllResults(parameters, vm.upcomingList, "noneUpcomingChallenge");
 
         // calls for past challenges
         parameters.url = 'challenges/challenge/past/approved/public';
         parameters.method = 'GET';
 
-        vm.getAllResults(parameters, vm.pastList);
-
-        if (vm.pastList.length === 0) {
-            vm.nonePastChallenge = true;
-        } else {
-            vm.nonePastChallenge = false;
-        }
-
+        vm.getAllResults(parameters, vm.pastList, "nonePastChallenge");
+    
+        console.log(vm.nonePastChallenge);
         vm.scrollUp = function() {
             angular.element($window).bind('scroll', function() {
                 if (this.pageYOffset >= 100) {

--- a/frontend/tests/controllers-test/challengeListCtrl.test.js
+++ b/frontend/tests/controllers-test/challengeListCtrl.test.js
@@ -29,9 +29,9 @@ describe('Unit tests for challenge list controller', function () {
             expect(vm.currentList).toEqual([]);
             expect(vm.upcomingList).toEqual([]);
             expect(vm.pastList).toEqual([]);
-            expect(vm.noneCurrentChallenge).toBeTruthy();
-            expect(vm.noneUpcomingChallenge).toBeTruthy();
-            expect(vm.nonePastChallenge).toBeTruthy();
+            expect(vm.noneCurrentChallenge).toBeFalsy();
+            expect(vm.noneUpcomingChallenge).toBeFalsy();
+            expect(vm.nonePastChallenge).toBeFalsy();
             expect(vm.challengeCreator).toEqual({});
         });
     });


### PR DESCRIPTION
This PR fixes the asynchronous update of the parameters denoting whether we have challenges in list or not when fetching the challenges recursively.

I have tested it locally by disabling all past challenges.

Here is a screenshot:

![Screenshot 2023-05-14 at 4 30 32 PM](https://github.com/Cloud-CV/EvalAI/assets/29076344/2421159c-f36c-41a4-ab7a-473a035460b6)
