### PR TITLE
Reduce page size to 3

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -161,7 +161,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": (
         "rest_framework.pagination.LimitOffsetPagination"
     ),
-    "PAGE_SIZE": 150,
+    "PAGE_SIZE": 3,
     "TEAM_PAGE_SIZE": 10,
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticatedOrReadOnly"


### PR DESCRIPTION
This PR temporarily reduces the page size to 3 to test pagination frontend changes just for staging. This will be reverted.