### PR TITLE
Upgrade nodejs node version

### DIFF
--- a/docker/prod/nodejs/Dockerfile
+++ b/docker/prod/nodejs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11.2 as node
+FROM node:14.20.0 as node
 
 ARG NODE_ENV
 WORKDIR /code


### PR DESCRIPTION
This PR upgrades the nodejs version.
Currently, we get this error during build:
```
bower angular-messages#^1.5.8 CERT_HAS_EXPIRED Request to https://registry.bower.io/packages/angular-messages failed: certificate has expired
The command '/bin/sh -c bower install --allow-root' returned a non-zero code: 1
Service 'nodejs' failed to build : Build failed
```
This PR fixes that.