### PR TITLE
Upgrade to Python 3.7 for Code Upload Worker

### DIFF
--- a/docker/dev/code-upload-worker/Dockerfile
+++ b/docker/dev/code-upload-worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.7.5
 
 ENV PYTHONUNBUFFERED 1
 

--- a/docker/prod/code-upload-worker/Dockerfile
+++ b/docker/prod/code-upload-worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.7.5
 
 ENV PYTHONUNBUFFERED 1
 


### PR DESCRIPTION
This PR fixes the failing build of code upload worker by upgrading the docker base image to python 3.7.

Currently, it is failing because of this issue:

```
Ign:9 http://deb.debian.org/debian stretch/main all Packages
Ign:10 http://deb.debian.org/debian stretch/main amd64 Packages
Ign:11 http://deb.debian.org/debian stretch-updates/main amd64 Packages
Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
Ign:9 http://deb.debian.org/debian stretch/main all Packages
Err:10 http://deb.debian.org/debian stretch/main amd64 Packages
  404  Not Found
Err:11 http://deb.debian.org/debian stretch-updates/main amd64 Packages
  404  Not Found
Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
Reading package lists...
W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages  404  Not Found
E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages  404  Not Found
E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found
E: Some index files failed to download. They have been ignored, or old ones used instead.
The command '/bin/sh -c apt-get update &&   apt-get install --no-install-recommends -y unzip &&   rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
Service 'code-upload-worker' failed to build : Build failed
```