### PR TITLE
[Worker] Address missing job name in code upload worker

### DIFF
--- a/scripts/workers/code_upload_submission_worker.py
+++ b/scripts/workers/code_upload_submission_worker.py
@@ -749,8 +749,15 @@ def main():
                 ):
                     try:
                         # Fetch the last job name from the list as it is the latest running job
-                        job_name = submission.get("job_name")[-1]
-                        delete_job(api_instance, job_name)
+                        job_name = submission.get("job_name")
+                        if job_name:
+                            latest_job_name = job_name[-1]
+                            delete_job(api_instance, latest_job_name)
+                        else:
+                            logger.info(
+                                "No job name found corresponding to submission: {} with status: {}."
+                                "Deleting it from queue.".format(submission_pk, submission.get("status"))
+                            )
                         message_receipt_handle = message.get("receipt_handle")
                         evalai.delete_message_from_sqs_queue(
                             message_receipt_handle


### PR DESCRIPTION
This PR addresses missing job names in code upload worker when the submission is cancelled before it is submitted.

This is a brief description of the issue:

> When the submissions are cancelled before they go to running, there is no `job_name` but when it is picked up in the queue, it throws an error as `job_name` does not exist and the worker tries to delete that job.
> I will modify the worker script to delete the submission from the queue if the `job_name` is not found and it is already cancelled.