### PR TITLE
Add submission count by status API for all challenges

### DIFF
--- a/apps/challenges/urls.py
+++ b/apps/challenges/urls.py
@@ -45,6 +45,11 @@ urlpatterns = [
         name="get_all_challenges",
     ),
     url(
+        r"^challenge/get_submission_metrics$",
+        views.get_all_challenges_submission_metrics,
+        name="get_all_challenges_submission_metrics",
+    ),
+    url(
         r"^challenges/participated/(?P<challenge_time>[A-Za-z]+)/$",
         views.get_all_participated_challenges,
         name="get_all_participated_challenges",

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -672,17 +672,7 @@ def get_all_challenges_submission_metrics(request):
     challenges = Challenge.objects.all()
     submission_metrics = {}
 
-    submission_statuses = [
-        "submitted",
-        "running",
-        "failed",
-        "cancelled",
-        "resuming",
-        "finished",
-        "submitting",
-        "archived",
-        "partially_evaluated",
-    ]
+    submission_statuses = [status[0] for status in Submission.STATUS_OPTIONS]
 
     for challenge in challenges:
         challenge_id = challenge.id

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -665,6 +665,43 @@ def get_all_challenges(request, challenge_time, challenge_approved, challenge_pu
 
 @api_view(["GET"])
 @throttle_classes([AnonRateThrottle])
+def get_all_challenges_submission_metrics(request):
+    """
+    Returns the submission metrics for all challenges and their phases
+    """
+    challenges = Challenge.objects.all()
+    submission_metrics = {}
+
+    submission_statuses = [
+        "submitted",
+        "running",
+        "failed",
+        "cancelled",
+        "resuming",
+        "finished",
+        "submitting",
+        "archived",
+        "partially_evaluated",
+    ]
+
+    for challenge in challenges:
+        challenge_id = challenge.id
+        challenge_metrics = {}
+
+        # Fetch challenge phases for the challenge
+        challenge_phases = ChallengePhase.objects.filter(challenge=challenge)
+
+        for submission_status in submission_statuses:
+            count = Submission.objects.filter(challenge_phase__in=challenge_phases, status=submission_status).count()
+            challenge_metrics[submission_status] = count
+
+        submission_metrics[challenge_id] = challenge_metrics
+
+    return Response(submission_metrics)
+
+
+@api_view(["GET"])
+@throttle_classes([AnonRateThrottle])
 def get_featured_challenges(request):
     """
     Returns the list of featured challenges

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -4014,6 +4014,41 @@ class GetAllSubmissionsTest(BaseAPITestClass):
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_get_all_challenges_submission_metrics(self):
+        self.maxDiff = None
+
+        url = reverse_lazy("challenges:get_all_challenges_submission_metrics")
+
+        expected_response = {
+            1: {
+                'archived': 0,
+                'cancelled': 0,
+                'failed': 0,
+                'finished': 0,
+                'partially_evaluated': 0,
+                'resuming': 0,
+                'running': 0,
+                'submitted': 0,
+                'submitting': 0
+            },
+            2: {
+                'archived': 0,
+                'cancelled': 0,
+                'failed': 0,
+                'finished': 0,
+                'partially_evaluated': 0,
+                'resuming': 0,
+                'running': 0,
+                'submitted': 3,
+                'submitting': 0
+            }
+        }
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, expected_response)
+
 
 class DownloadAllSubmissionsFileTest(BaseAPITestClass):
     def setUp(self):

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -4020,7 +4020,7 @@ class GetAllSubmissionsTest(BaseAPITestClass):
         url = reverse_lazy("challenges:get_all_challenges_submission_metrics")
 
         expected_response = {
-            1: {
+            292: {
                 'archived': 0,
                 'cancelled': 0,
                 'failed': 0,
@@ -4031,7 +4031,7 @@ class GetAllSubmissionsTest(BaseAPITestClass):
                 'submitted': 0,
                 'submitting': 0
             },
-            2: {
+            293: {
                 'archived': 0,
                 'cancelled': 0,
                 'failed': 0,


### PR DESCRIPTION
The response looks like this

```
{
    "13": {
        "submitted": 0,
        "running": 0,
        "failed": 10,
        "cancelled": 0,
        "resuming": 0,
        "finished": 10,
        "submitting": 0,
        "archived": 0,
        "partially_evaluated": 0
    },
    "12": {
        "submitted": 0,
        "running": 0,
        "failed": 10,
        "cancelled": 0,
        "resuming": 0,
        "finished": 10,
        "submitting": 0,
        "archived": 0,
        "partially_evaluated": 0
    },
    "6": {
        "submitted": 0,
        "running": 0,
        "failed": 10,
        "cancelled": 0,
        "resuming": 0,
        "finished": 10,
        "submitting": 0,
        "archived": 0,
        "partially_evaluated": 0
    },
}
```