### PR TITLE
[Monitoring] Update auto scaling to use submissions

### DIFF
--- a/scripts/monitoring/auto_scale_eks_nodes.py
+++ b/scripts/monitoring/auto_scale_eks_nodes.py
@@ -191,7 +191,7 @@ def scale_up_or_down_workers(challenge, metrics, evalai_interface, aws_keys, sca
 
 # Cron Job
 def start_job():
-    
+
     # Get metrics
     evalai_interface = create_evalai_interface(AUTH_TOKEN)
     metrics = evalai_interface.get_challenges_submission_metrics()

--- a/scripts/monitoring/auto_scale_eks_nodes.py
+++ b/scripts/monitoring/auto_scale_eks_nodes.py
@@ -8,7 +8,6 @@ import boto3
 import pytz
 from dateutil.parser import parse
 from evalai_interface import EvalAI_Interface
-from prometheus_api_client import PrometheusConnect
 
 warnings.filterwarnings("ignore")
 
@@ -28,9 +27,6 @@ SCALE_UP_DESIRED_SIZE = 1
 ENV = os.environ.get("ENV", "production")
 # AUTH_TOKEN = os.environ.get("AUTH_TOKEN")
 EVALAI_ENDPOINT = os.environ.get("API_HOST_URL", "https://eval.ai")
-PROMETHEUS_URL = os.environ.get(
-    "MONITORING_API_URL", "https://monitoring.eval.ai/prometheus/"
-)
 
 json_path = os.environ.get("JSON_PATH", "~/prod_eks_auth_tokens.json")
 # QUEUES
@@ -38,16 +34,10 @@ with open(json_path, "r") as f:
     # Load the JSON data into a Python dictionary
     INCLUDED_CHALLENGE_PKS = json.load(f)
 
-NUM_PROCESSED_SUBMISSIONS = "num_processed_submissions"
-NUM_SUBMISSIONS_IN_QUEUE = "num_submissions_in_queue"
-
 
 def create_evalai_interface(auth_token):
     evalai_interface = EvalAI_Interface(auth_token, EVALAI_ENDPOINT)
     return evalai_interface
-
-
-prom = PrometheusConnect(url=PROMETHEUS_URL, disable_ssl=True)
 
 
 def get_boto3_client(resource, aws_keys):

--- a/scripts/monitoring/auto_scale_eks_nodes.py
+++ b/scripts/monitoring/auto_scale_eks_nodes.py
@@ -151,7 +151,7 @@ def scale_up_workers(challenge, desired_size, pending_submissions, evalai_interf
         )
     else:
         print(
-            "Existing workers and pending pending submissions found for Challenge ID: {}, Title: {}. Skipping.".format(
+            "Existing workers and pending submissions found for Challenge ID: {}, Title: {}. Skipping.".format(
                 challenge["id"], challenge["title"]
             )
         )
@@ -162,7 +162,7 @@ def scale_up_or_down_workers(challenge, metrics, evalai_interface, aws_keys, sca
         pending_submissions = get_pending_submission_count_by_pk(metrics, challenge["id"])
     except Exception:  # noqa: F841
         print(
-            "Unable to get the queue length for challenge ID: {}, Title: {}. Skipping.".format(
+            "Unable to get the pending submissions for challenge ID: {}, Title: {}. Skipping.".format(
                 challenge["id"], challenge["title"]
             )
         )

--- a/scripts/monitoring/auto_scale_eks_nodes.py
+++ b/scripts/monitoring/auto_scale_eks_nodes.py
@@ -83,7 +83,7 @@ def get_scaling_config(eks_client, cluster_name, nodegroup_name):
     return scaling_config
 
 
-def start_eks_worker(challenge, queue_length, evalai_interface, aws_keys, desired_size=None):
+def start_eks_worker(challenge, pending_submissions, evalai_interface, aws_keys, desired_size=None):
     eks_client, cluster_name, nodegroup_name = get_eks_meta(
         challenge, evalai_interface, aws_keys
     )

--- a/scripts/monitoring/auto_scale_eks_nodes.py
+++ b/scripts/monitoring/auto_scale_eks_nodes.py
@@ -108,8 +108,10 @@ def stop_eks_worker(challenge, evalai_interface, aws_keys):
 
 
 def get_pending_submission_count_by_pk(metrics, challenge_pk):
-    metrics = metrics[challenge_pk]
-    pending_submissions = metrics["submitted"] + metrics["running"]
+    challenge_metrics = metrics[str(challenge_pk)]
+    pending_submissions = 0
+    for status in ["running", "submitted", "queued", "resuming"]:
+        pending_submissions += challenge_metrics.get(status, 0)
     return pending_submissions
 
 

--- a/scripts/monitoring/auto_scale_workers.py
+++ b/scripts/monitoring/auto_scale_workers.py
@@ -1,5 +1,4 @@
 import os
-import time
 import pytz
 import warnings
 

--- a/scripts/monitoring/auto_scale_workers.py
+++ b/scripts/monitoring/auto_scale_workers.py
@@ -1,13 +1,11 @@
 import os
 import time
 import pytz
-import requests
 import warnings
 
 from datetime import datetime
 from dateutil.parser import parse
 from auto_stop_workers import start_worker, stop_worker
-from prometheus_api_client import PrometheusConnect
 from evalai_interface import EvalAI_Interface
 
 warnings.filterwarnings("ignore")
@@ -130,9 +128,11 @@ def scale_up_or_down_workers_for_challenges(response, metrics):
                 )
             )
 
+
 def create_evalai_interface(auth_token, evalai_endpoint):
     evalai_interface = EvalAI_Interface(auth_token, evalai_endpoint)
     return evalai_interface
+
 
 # Cron Job
 def start_job():

--- a/scripts/monitoring/auto_scale_workers.py
+++ b/scripts/monitoring/auto_scale_workers.py
@@ -8,15 +8,11 @@ from datetime import datetime
 from dateutil.parser import parse
 from auto_stop_workers import start_worker, stop_worker
 from prometheus_api_client import PrometheusConnect
+from evalai_interface import EvalAI_Interface
 
 warnings.filterwarnings("ignore")
 
 utc = pytz.UTC
-NUM_PROCESSED_SUBMISSIONS = "num_processed_submissions"
-NUM_SUBMISSIONS_IN_QUEUE = "num_submissions_in_queue"
-PROMETHEUS_URL = os.environ.get(
-    "MONITORING_API_URL", "https://monitoring-staging.eval.ai/prometheus/"
-)
 PROD_EXCLUDED_CHALLENGE_QUEUES = [
     "textvqa-challenge-2021-874-production-41966973-4d99-4326-a402-b749b1d89aad",
     "vqa-challenge-2021-830-production-6343db53-af82-4618-8c51-0e294611315a",
@@ -42,52 +38,12 @@ PROD_EXCLUDED_CHALLENGE_QUEUES = [
 ENV = os.environ.get("ENV", "dev")
 
 evalai_endpoint = os.environ.get("API_HOST_URL")
-authorization_header = {
-    "Authorization": "Bearer {}".format(os.environ.get("AUTH_TOKEN"))
-}
-
-prom = PrometheusConnect(url=PROMETHEUS_URL, disable_ssl=True)
+auth_token = os.environ.get("AUTH_TOKEN")
 
 
-def execute_get_request(url):
-    response = requests.get(url, headers=authorization_header)
-    return response.json()
-
-
-def get_challenges():
-    all_challenge_endpoint = "{}/api/challenges/challenge/all/all/all".format(
-        evalai_endpoint
-    )
-    response = execute_get_request(all_challenge_endpoint)
-
-    return response
-
-
-def get_queue_length(queue_name):
-    try:
-        num_processed_submissions = int(
-            prom.custom_query(
-                f"num_processed_submissions{{queue_name='{queue_name}'}}"
-            )[0]["value"][1]
-        )
-    except Exception:  # noqa: F841
-        num_processed_submissions = 0
-
-    try:
-        num_submissions_in_queue = int(
-            prom.custom_query(
-                f"num_submissions_in_queue{{queue_name='{queue_name}'}}"
-            )[0]["value"][1]
-        )
-    except Exception:  # noqa: F841
-        num_submissions_in_queue = 0
-
-    return num_submissions_in_queue - num_processed_submissions
-
-
-def get_queue_length_by_challenge(challenge):
-    queue_name = challenge["queue"]
-    return get_queue_length(queue_name)
+def get_pending_submission_count_by_pk(metrics, challenge_pk):
+    pending_submissions = metrics["submitted"] + metrics["running"]
+    return pending_submissions
 
 
 def scale_down_workers(challenge, num_workers):
@@ -101,7 +57,7 @@ def scale_down_workers(challenge, num_workers):
         )
     else:
         print(
-            "No workers and queue messages found for Challenge ID: {}, Title: {}. Skipping.".format(
+            "No workers and pending messages found for Challenge ID: {}, Title: {}. Skipping.".format(
                 challenge["id"], challenge["title"]
             )
         )
@@ -118,18 +74,18 @@ def scale_up_workers(challenge, num_workers):
         )
     else:
         print(
-            "Existing workers and pending queue messages found for Challenge ID: {}, Title: {}. Skipping.".format(
+            "Existing workers and pending messages found for Challenge ID: {}, Title: {}. Skipping.".format(
                 challenge["id"], challenge["title"]
             )
         )
 
 
-def scale_up_or_down_workers(challenge):
+def scale_up_or_down_workers(challenge, metrics):
     try:
-        queue_length = get_queue_length_by_challenge(challenge)
+        pending_submissions = get_pending_submission_count_by_pk(metrics, challenge["id"])
     except Exception:  # noqa: F841
         print(
-            "Unable to get the queue length for challenge ID: {}, Title: {}. Skipping.".format(
+            "Unable to get the pending submissions for challenge ID: {}, Title: {}. Skipping.".format(
                 challenge["id"], challenge["title"]
             )
         )
@@ -140,11 +96,11 @@ def scale_up_or_down_workers(challenge):
     )
 
     print(
-        "Num Workers: {}, Queue Length: {}".format(num_workers, queue_length)
+        "Num Workers: {}, Pending Submissions: {}".format(num_workers, pending_submissions)
     )
 
     if (
-        queue_length == 0
+        pending_submissions == 0
         or parse(challenge["end_date"])
         < pytz.UTC.localize(datetime.utcnow())
     ):
@@ -154,7 +110,7 @@ def scale_up_or_down_workers(challenge):
 
 
 # TODO: Factor in limits for the APIs
-def scale_up_or_down_workers_for_challenges(response):
+def scale_up_or_down_workers_for_challenges(response, metrics):
     for challenge in response["results"]:
         if (
             not challenge["is_docker_based"]
@@ -162,9 +118,9 @@ def scale_up_or_down_workers_for_challenges(response):
         ):
             if ENV == "prod":
                 if challenge["queue"] not in PROD_EXCLUDED_CHALLENGE_QUEUES:
-                    scale_up_or_down_workers(challenge)
+                    scale_up_or_down_workers(challenge, metrics[str(challenge["id"])])
             else:
-                scale_up_or_down_workers(challenge)
+                scale_up_or_down_workers(challenge, metrics[str(challenge["id"])])
             time.sleep(1)
 
         else:
@@ -174,15 +130,20 @@ def scale_up_or_down_workers_for_challenges(response):
                 )
             )
 
+def create_evalai_interface(auth_token, evalai_endpoint):
+    evalai_interface = EvalAI_Interface(auth_token, evalai_endpoint)
+    return evalai_interface
 
 # Cron Job
 def start_job():
-    response = get_challenges()
-    scale_up_or_down_workers_for_challenges(response)
+    evalai_interface = create_evalai_interface(auth_token, evalai_endpoint)
+    response = evalai_interface.get_challenges()
+    metrics = evalai_interface.get_challenges_submission_metrics()
+    scale_up_or_down_workers_for_challenges(response, metrics)
     next_page = response["next"]
     while next_page is not None:
-        response = execute_get_request(next_page)
-        scale_up_or_down_workers_for_challenges(response)
+        response = evalai_interface.make_request(next_page, "GET")
+        scale_up_or_down_workers_for_challenges(response, metrics)
         next_page = response["next"]
 
 

--- a/scripts/monitoring/auto_scale_workers.py
+++ b/scripts/monitoring/auto_scale_workers.py
@@ -41,7 +41,7 @@ auth_token = os.environ.get("AUTH_TOKEN")
 def get_pending_submission_count(challenge_metrics):
     pending_submissions = 0
     for status in ["running", "submitted", "queued", "resuming"]:
-        pending_submissions += challenge_metrics.get(status, None)
+        pending_submissions += challenge_metrics.get(status, 0)
     return pending_submissions
 
 

--- a/scripts/monitoring/evalai_interface.py
+++ b/scripts/monitoring/evalai_interface.py
@@ -18,6 +18,7 @@ URLS = {
     "get_challenge_by_pk": "/api/challenges/challenge/{}/",
     "get_challenges": "/api/challenges/challenge/all/all/all",
     "get_submissions_for_challenge": "/api/jobs/challenge/{}/submission/",
+    "get_challenges_submission_metrics": "/api/challenges/challenge/get_submission_metrics",
 }
 
 
@@ -132,5 +133,11 @@ class EvalAI_Interface:
         url = self.return_url_per_environment(url)
         if status:
             url += f"?status={status}"
+        response = self.make_request(url, "GET")
+        return response
+    
+    def get_challenges_submission_metrics(self):
+        url = URLS.get("get_challenges_submission_metrics")
+        url = self.return_url_per_environment(url)
         response = self.make_request(url, "GET")
         return response

--- a/scripts/monitoring/evalai_interface.py
+++ b/scripts/monitoring/evalai_interface.py
@@ -135,7 +135,7 @@ class EvalAI_Interface:
             url += f"?status={status}"
         response = self.make_request(url, "GET")
         return response
-    
+
     def get_challenges_submission_metrics(self):
         url = URLS.get("get_challenges_submission_metrics")
         url = self.return_url_per_environment(url)

--- a/scripts/monitoring/run_auto_scale_eks_nodes.sh
+++ b/scripts/monitoring/run_auto_scale_eks_nodes.sh
@@ -17,37 +17,32 @@ if [ ! -z "$3" ]; then
 fi
 
 if [ ! -z "$4" ]; then
-  monitoring_api_url=$4
+  env=$4
 fi
 
 if [ ! -z "$5" ]; then
-  env=$5
+  eks_aws_account_id=$5
 fi
 
 if [ ! -z "$6" ]; then
-  eks_aws_account_id=$6
+  eks_aws_access_key_id=$6
 fi
 
 if [ ! -z "$7" ]; then
-  eks_aws_access_key_id=$7
+  eks_aws_secret_access_key=$7
 fi
 
 if [ ! -z "$8" ]; then
-  eks_aws_secret_access_key=$8
+  eks_aws_region=$8
 fi
 
-if [ ! -z "$9" ]; then
-  eks_aws_region=$9
-fi
-
-if [ ! -z "${10}" ]; then
-  eks_aws_storage_bucket_name=${10}
+if [ ! -z "${9}" ]; then
+  eks_aws_storage_bucket_name=${9}
 fi
 
 # crontab doesn't have access to env variable, define explicitly
 export JSON_PATH=${json_path}
 export API_HOST_URL=${api_host_url}
-export MONITORING_API_URL=${monitoring_api_url}
 export ENV=${env}
 export EKS_AWS_ACCOUNT_ID=${eks_aws_account_id}
 export EKS_AWS_ACCESS_KEY_ID=${eks_aws_access_key_id}

--- a/scripts/monitoring/run_auto_scale_eks_nodes.sh
+++ b/scripts/monitoring/run_auto_scale_eks_nodes.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 path=$PWD
+auth_token=''
 json_path=''
 api_host_url=''
 eks_aws_storage_bucket_name=''
@@ -9,38 +10,43 @@ if [ ! -z "$1" ]; then
 fi
 
 if [ ! -z "$2" ]; then
-  json_path=$2
+    auth_token=$2
 fi
 
 if [ ! -z "$3" ]; then
-  api_host_url=$3
+  json_path=$3
 fi
 
 if [ ! -z "$4" ]; then
-  env=$4
+  api_host_url=$4
 fi
 
 if [ ! -z "$5" ]; then
-  eks_aws_account_id=$5
+  env=$5
 fi
 
 if [ ! -z "$6" ]; then
-  eks_aws_access_key_id=$6
+  eks_aws_account_id=$6
 fi
 
 if [ ! -z "$7" ]; then
-  eks_aws_secret_access_key=$7
+  eks_aws_access_key_id=$7
 fi
 
 if [ ! -z "$8" ]; then
-  eks_aws_region=$8
+  eks_aws_secret_access_key=$8
 fi
 
-if [ ! -z "${9}" ]; then
-  eks_aws_storage_bucket_name=${9}
+if [ ! -z "$9" ]; then
+  eks_aws_region=$89
+fi
+
+if [ ! -z "${10}" ]; then
+  eks_aws_storage_bucket_name=${10}
 fi
 
 # crontab doesn't have access to env variable, define explicitly
+export AUTH_TOKEN=${auth_token};
 export JSON_PATH=${json_path}
 export API_HOST_URL=${api_host_url}
 export ENV=${env}

--- a/scripts/monitoring/run_auto_scale_eks_nodes.sh
+++ b/scripts/monitoring/run_auto_scale_eks_nodes.sh
@@ -38,7 +38,7 @@ if [ ! -z "$8" ]; then
 fi
 
 if [ ! -z "$9" ]; then
-  eks_aws_region=$89
+  eks_aws_region=$9
 fi
 
 if [ ! -z "${10}" ]; then

--- a/scripts/monitoring/run_auto_scale_workers.sh
+++ b/scripts/monitoring/run_auto_scale_workers.sh
@@ -19,18 +19,12 @@ fi
 
 if [ ! -z "$4" ]
   then
-    monitoring_api_url=$4
-fi
-
-if [ ! -z "$5" ]
-  then
-    env=$5
+    env=$4
 fi
 
 # crontab doesn't have access to env variable, define explicitly
 export AUTH_TOKEN=${auth_token};
 export API_HOST_URL=${api_host_url};
-export MONITORING_API_URL=${monitoring_api_url};
 export ENV=${env}
 
 /home/ubuntu/venv/bin/python ${path}/scripts/monitoring/auto_scale_workers.py


### PR DESCRIPTION
This PR updates the auto scaling scripts to use submission counts by status for auto scaling instead of prometheus metrics. The prometheus metrics are sometimes incorrect due to several reasons, this one removes dependency on prometheus.

This PR specifically:
- Uses submission metrics from Django Admin for challenges to scale workers up or down.
- Allows auto scaling for code-upload as well as remote evaluation workers.
- Updates auto scaling EKS to have minimum of pending submissions or a maximum scale up desired size.