### PR TITLE
[Backend] Restrict access to submission metrics to admin

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -713,25 +713,27 @@ def get_all_challenges_submission_metrics(request):
     Returns the submission metrics for all challenges and their phases
     """
     if not is_user_a_staff(request.user):
-        challenges = Challenge.objects.all()
-        submission_metrics = {}
+        response_data = {"error": "Sorry, you are not authorized to make this request"}
+        return Response(response_data, status=status.HTTP_403_FORBIDDEN)
+    challenges = Challenge.objects.all()
+    submission_metrics = {}
 
-        submission_statuses = [status[0] for status in Submission.STATUS_OPTIONS]
+    submission_statuses = [status[0] for status in Submission.STATUS_OPTIONS]
 
-        for challenge in challenges:
-            challenge_id = challenge.id
-            challenge_metrics = {}
+    for challenge in challenges:
+        challenge_id = challenge.id
+        challenge_metrics = {}
 
-            # Fetch challenge phases for the challenge
-            challenge_phases = ChallengePhase.objects.filter(challenge=challenge)
+        # Fetch challenge phases for the challenge
+        challenge_phases = ChallengePhase.objects.filter(challenge=challenge)
 
-            for submission_status in submission_statuses:
-                count = Submission.objects.filter(challenge_phase__in=challenge_phases, status=submission_status).count()
-                challenge_metrics[submission_status] = count
+        for submission_status in submission_statuses:
+            count = Submission.objects.filter(challenge_phase__in=challenge_phases, status=submission_status).count()
+            challenge_metrics[submission_status] = count
 
-            submission_metrics[challenge_id] = challenge_metrics
+        submission_metrics[challenge_id] = challenge_metrics
 
-        return Response(submission_metrics)
+    return Response(submission_metrics, status=status.HTTP_200_OK)
 
 
 @api_view(["GET"])

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -712,7 +712,7 @@ def get_all_challenges_submission_metrics(request):
     """
     Returns the submission metrics for all challenges and their phases
     """
-    if not is_user_a_host_of_challenge(request.user):
+    if not is_user_a_staff(request.user):
         challenges = Challenge.objects.all()
         submission_metrics = {}
 

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -713,9 +713,6 @@ def get_all_challenges_submission_metrics(request):
     Returns the submission metrics for all challenges and their phases
     """
     if not is_user_a_host_of_challenge(request.user):
-        response_data = {"error": "You are not authorized to make this request"}
-        return Response(response_data, status=status.HTTP_403_FORBIDDEN)
-    else:
         challenges = Challenge.objects.all()
         submission_metrics = {}
 

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -53,6 +53,7 @@ from base.utils import (
     paginated_queryset,
     send_email,
     send_slack_notification,
+    is_user_a_staff,
 )
 from challenges.utils import (
     complete_s3_multipart_file_upload,
@@ -711,25 +712,29 @@ def get_all_challenges_submission_metrics(request):
     """
     Returns the submission metrics for all challenges and their phases
     """
-    challenges = Challenge.objects.all()
-    submission_metrics = {}
+    if(is_user_a_staff(request.user)):
+        challenges = Challenge.objects.all()
+        submission_metrics = {}
 
-    submission_statuses = [status[0] for status in Submission.STATUS_OPTIONS]
+        submission_statuses = [status[0] for status in Submission.STATUS_OPTIONS]
 
-    for challenge in challenges:
-        challenge_id = challenge.id
-        challenge_metrics = {}
+        for challenge in challenges:
+            challenge_id = challenge.id
+            challenge_metrics = {}
 
-        # Fetch challenge phases for the challenge
-        challenge_phases = ChallengePhase.objects.filter(challenge=challenge)
+            # Fetch challenge phases for the challenge
+            challenge_phases = ChallengePhase.objects.filter(challenge=challenge)
 
-        for submission_status in submission_statuses:
-            count = Submission.objects.filter(challenge_phase__in=challenge_phases, status=submission_status).count()
-            challenge_metrics[submission_status] = count
+            for submission_status in submission_statuses:
+                count = Submission.objects.filter(challenge_phase__in=challenge_phases, status=submission_status).count()
+                challenge_metrics[submission_status] = count
 
-        submission_metrics[challenge_id] = challenge_metrics
+            submission_metrics[challenge_id] = challenge_metrics
 
-    return Response(submission_metrics)
+        return Response(submission_metrics)
+    else:
+        response_data = {"error": "You are not authorized to make this request"}
+        return Response(response_data, status=status.HTTP_403_FORBIDDEN)
 
 
 @api_view(["GET"])

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -712,7 +712,10 @@ def get_all_challenges_submission_metrics(request):
     """
     Returns the submission metrics for all challenges and their phases
     """
-    if(is_user_a_staff(request.user)):
+    if not is_user_a_host_of_challenge(request.user):
+        response_data = {"error": "You are not authorized to make this request"}
+        return Response(response_data, status=status.HTTP_403_FORBIDDEN)
+    else:
         challenges = Challenge.objects.all()
         submission_metrics = {}
 
@@ -732,9 +735,6 @@ def get_all_challenges_submission_metrics(request):
             submission_metrics[challenge_id] = challenge_metrics
 
         return Response(submission_metrics)
-    else:
-        response_data = {"error": "You are not authorized to make this request"}
-        return Response(response_data, status=status.HTTP_403_FORBIDDEN)
 
 
 @api_view(["GET"])

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -4198,6 +4198,20 @@ class GetAllSubmissionsTest(BaseAPITestClass):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_get_all_challenges_submission_metrics(self):
+
+        self.user8 = User.objects.create(
+            username="admin_test",
+            password="admin@123",
+            is_staff=True,
+        )
+
+        EmailAddress.objects.create(
+            user=self.user8,
+            email="user8@test.com",
+            primary=True,
+            verified=True,
+        )
+
         self.maxDiff = None
 
         url = reverse_lazy("challenges:get_all_challenges_submission_metrics")
@@ -4227,6 +4241,7 @@ class GetAllSubmissionsTest(BaseAPITestClass):
             }
         }
 
+        self.client.force_authenticate(user=self.user8)
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
Fixes #4054 
**Current Scenario**
get_all_challenges_submission_metrics can be accessed by anyone without any authentication.

**New Scenario**
Since we got the is_user_a_staff function, we can check if the person accessing the class is a staff or not. so now get_all_challenges_submission_metrics requires the authenticated or the user is given a 403 Forbidden