### PR TITLE
[BugFix] Fix removal of leaderboard id from challenge phase split

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -4030,6 +4030,7 @@ def create_or_update_github_challenge(request, challenge_host_team_pk):
                     challenge_phase_split_qs = ChallengePhaseSplit.objects.filter(
                         challenge_phase__pk=challenge_phase,
                         dataset_split__pk=dataset_split,
+                        leaderboard__pk=leaderboard,
                     )
                     if challenge_phase_split_qs:
                         challenge_phase_split = challenge_phase_split_qs.first()


### PR DESCRIPTION
Fixes #4048 
**Current Scenario**
When a host tries to update the challenge and he has more than one leaderboard than the update process removes the other leaderboard id from the challenge phase split

**New Scenario**
leaderboard id isn't removed anymore and stays the same