### PR TITLE
[BugFix] Add domain and tag to seed file

### DIFF
--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -248,6 +248,8 @@ def create_challenge(
         approved_by_admin=True,
         leaderboard_description=fake.paragraph(),
         creator=host_team,
+        domain="CV",
+        list_tags=["Paper", "Dataset"],
         published=True,
         enable_forum=True,
         anonymous_leaderboard=anon_leaderboard,


### PR DESCRIPTION
We currently don't show domain in our dev bench made challenges, but since it is a mandatory field for challenge upload moving forward, we should have domain and tags in the seed file
![image](https://github.com/Cloud-CV/EvalAI/assets/34577232/191898e8-12ef-4266-aa26-8403abe386d4)
