### PR TITLE
[BugFix] Make challenge PK string in EC2 setup

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -1500,7 +1500,7 @@ def setup_ec2(challenge):
         "AWS_ACCESS_KEY_ID": aws_keys["AWS_ACCESS_KEY_ID"],
         "AWS_SECRET_ACCESS_KEY": aws_keys["AWS_SECRET_ACCESS_KEY"],
         "AWS_REGION": aws_keys["AWS_REGION"],
-        "PK": challenge_obj.pk,
+        "PK": str(challenge_obj.pk),
         "QUEUE": challenge_obj.queue,
         "ENVIRONMENT": settings.ENVIRONMENT,
     }


### PR DESCRIPTION
This PR makes the challenge PK into a string in the EC2 setup.