### PR TITLE
[Backend] Add custom EC2 storage to challenges

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -1513,7 +1513,7 @@ def setup_ec2(challenge):
             'DeviceName': '/dev/sda1',
             'Ebs': {
                 'DeleteOnTermination': True,
-                'VolumeSize': 8,  # TODO: Make this customizable
+                'VolumeSize': challenge_obj.ec2_storage,  # TODO: Make this customizable
                 'VolumeType': 'gp2'
             }
         },

--- a/apps/challenges/models.py
+++ b/apps/challenges/models.py
@@ -91,6 +91,9 @@ class Challenge(TimeStampedModel):
     ec2_instance_id = models.CharField(
         max_length=200, default="", null=True, blank=True
     )
+    ec2_storage = models.PositiveIntegerField(
+        default=8, verbose_name="EC2 storage (GB)"
+    )
     featured = models.BooleanField(
         default=False, verbose_name="Featured", db_index=True
     )

--- a/apps/challenges/serializers.py
+++ b/apps/challenges/serializers.py
@@ -84,6 +84,7 @@ class ChallengeSerializer(serializers.ModelSerializer):
             "cpu_only_jobs",
             "job_cpu_cores",
             "job_memory",
+            "ec2_storage",
         )
 
 
@@ -295,6 +296,7 @@ class ZipChallengeSerializer(ChallengeSerializer):
             "cpu_only_jobs",
             "job_cpu_cores",
             "job_memory",
+            "ec2_storage",
         )
 
 


### PR DESCRIPTION
This PR adds custom EC2 storage to challenges. Currently, we only restrict to `gp2` volumes. We can add an attribute to modify that later on.