### PR TITLE
[Debug] Add debug logging to Django loggers

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -259,20 +259,24 @@ LOGGING = {
         },
     },
     "loggers": {
-        "django": {"handlers": ["console"], "propagate": False},
+        "django": {
+            "handlers": ["console"], 
+            "level": "DEBUG",
+            "propagate": False
+        },
         "django.request": {
             "handlers": ["mail_admins", "console"],
-            "level": "ERROR",
+            "level": "DEBUG",
             "propagate": False,
         },
         "django.security": {
             "handlers": ["mail_admins", "console"],
-            "level": "ERROR",
+            "level": "DEBUG",
             "propagate": False,
         },
         "django.db.backends": {
             "handlers": ["mail_admins", "console"],
-            "level": "ERROR",
+            "level": "DEBUG",
             "propagate": False,
         },
     },


### PR DESCRIPTION
This PR adds debug level logging to Django loggers to understand why we are not able to see edit particualr challenges.

