### PR TITLE
Remove white space to fix the trailing line issue and build failure

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -260,7 +260,7 @@ LOGGING = {
     },
     "loggers": {
         "django": {
-            "handlers": ["console"], 
+            "handlers": ["console"],
             "level": "DEBUG",
             "propagate": False
         },


### PR DESCRIPTION
Removes white space to fix the trailing line issue and build failure