### PR TITLE
[BugFix] Fix is_user_a_staff_or_host

### DIFF
--- a/apps/base/utils.py
+++ b/apps/base/utils.py
@@ -342,4 +342,4 @@ def is_user_a_staff_or_host(user, challenge):
     Return:
         {bool} : True/False if the user is staff or host
     """
-    return user.is_staff or user == challenge.creator
+    return user.is_staff or user == challenge.creator.created_by

--- a/tests/unit/base/test_utils.py
+++ b/tests/unit/base/test_utils.py
@@ -207,6 +207,8 @@ class TestUserisStafforHost(BaseAPITestClass):
         self.assertFalse(is_user_a_staff_or_host(self.user2, self.challenge))
 
     def test_if_user_is_host(self):
+        self.user.is_staff = False
+        self.user.save()
         self.assertTrue(is_user_a_staff_or_host(self.user, self.challenge))
 
     def test_if_user_is_not_host(self):


### PR DESCRIPTION
is_user_a_staff_or_host is also suppose to return true for host when given a correct one, but it was checking it against the team name instead of the created_by name of the team user.