### PR TITLE
[Backend] Allow staff to access challenge phase splits

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -54,6 +54,7 @@ from base.utils import (
     send_email,
     send_slack_notification,
     is_user_a_staff,
+    is_user_a_staff_or_host
 )
 from challenges.utils import (
     complete_s3_multipart_file_upload,
@@ -1007,8 +1008,8 @@ def challenge_phase_split_list(request, challenge_pk):
         challenge_phase__challenge=challenge
     ).order_by("pk")
 
-    # Check if user is a challenge host or participant
-    challenge_host = is_user_a_host_of_challenge(request.user, challenge_pk)
+    # Check if user is a challenge host or staff
+    challenge_host = is_user_a_staff_or_host(request.user, challenge_pk)
 
     if not challenge_host:
         challenge_phase_split = challenge_phase_split.filter(

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -1009,7 +1009,7 @@ def challenge_phase_split_list(request, challenge_pk):
     ).order_by("pk")
 
     # Check if user is a challenge host or staff
-    challenge_host = is_user_a_staff_or_host(request.user, challenge_pk)
+    challenge_host = is_user_a_staff_or_host(request.user, challenge)
 
     if not challenge_host:
         challenge_phase_split = challenge_phase_split.filter(

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -3466,6 +3466,13 @@ class BaseChallengePhaseSplitClass(BaseAPITestClass):
         except OSError:
             pass
 
+        self.user2 = User.objects.create(
+            username="someuser2",
+            email="user2@test.com",
+            password="secret_password2",
+            is_staff=True,
+        )
+
         self.participant_user = User.objects.create(
             username="someuser1",
             email="participant@test.com",
@@ -3475,6 +3482,13 @@ class BaseChallengePhaseSplitClass(BaseAPITestClass):
         EmailAddress.objects.create(
             user=self.participant_user,
             email="participant@test.com",
+            primary=True,
+            verified=True,
+        )
+
+        EmailAddress.objects.create(
+            user=self.user2,
+            email="user2@test.com",
             primary=True,
             verified=True,
         )
@@ -3614,6 +3628,42 @@ class GetChallengePhaseSplitTest(BaseChallengePhaseSplitClass):
             },
         ]
         self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.url, {})
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_get_challenge_phase_split_when_user_is_staff(self):
+        self.url = reverse_lazy(
+            "challenges:challenge_phase_split_list",
+            kwargs={"challenge_pk": self.challenge.pk},
+        )
+        expected = [
+            {
+                "id": self.challenge_phase_split.id,
+                "challenge_phase": self.challenge_phase.id,
+                "challenge_phase_name": self.challenge_phase.name,
+                "dataset_split": self.dataset_split.id,
+                "dataset_split_name": self.dataset_split.name,
+                "visibility": self.challenge_phase_split.visibility,
+                "show_leaderboard_by_latest_submission": self.challenge_phase_split.show_leaderboard_by_latest_submission,
+                "show_execution_time": False,
+                "leaderboard_schema": self.challenge_phase_split.leaderboard.schema,
+                "is_multi_metric_leaderboard": self.challenge_phase_split.is_multi_metric_leaderboard,
+            },
+            {
+                "id": self.challenge_phase_split_host.id,
+                "challenge_phase": self.challenge_phase.id,
+                "challenge_phase_name": self.challenge_phase.name,
+                "dataset_split": self.dataset_split_host.id,
+                "dataset_split_name": self.dataset_split_host.name,
+                "visibility": self.challenge_phase_split_host.visibility,
+                "show_leaderboard_by_latest_submission": self.challenge_phase_split_host.show_leaderboard_by_latest_submission,
+                "show_execution_time": False,
+                "leaderboard_schema": self.challenge_phase_split_host.leaderboard.schema,
+                "is_multi_metric_leaderboard": self.challenge_phase_split_host.is_multi_metric_leaderboard,
+            },
+        ]
+        self.client.force_authenticate(user=self.user2)
         response = self.client.get(self.url, {})
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
Currently staff also gets leaderboard is private when they try to get the challenge phase split id. we changed the behavior to so both staff and host gets it