### PR TITLE
[BugFix] Update EKS EFS and EBS driver versions

### DIFF
--- a/scripts/workers/code_upload_worker_utils/install_dependencies.sh
+++ b/scripts/workers/code_upload_worker_utils/install_dependencies.sh
@@ -32,7 +32,8 @@ curl https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-i
 echo "### Container Insights Installed"
 
 # Setup EFS as persistent volume
-kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/ecr/?ref=release-1.1"
+kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/ecr/?ref=release-1.5"
+kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.23"
 cat /code/scripts/workers/code_upload_worker_utils/persistent_volume.yaml | sed "s/{{EFS_ID}}/$EFS_ID/" | kubectl apply -f -
 kubectl apply -f /code/scripts/workers/code_upload_worker_utils/persistent_volume_claim.yaml
 kubectl apply -f /code/scripts/workers/code_upload_worker_utils/persistent_volume_storage_class.yaml


### PR DESCRIPTION
This PR updates the EFS and EBS driver versions due to an issue we have been facing:
```
error: resource mapping not found for name: "efs.csi.aws.com" namespace: "" from "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/ecr/?ref=release-1.1": no matches for kind "CSIDriver" in version "storage.k8s.io/v1beta1"
```
In addition, we have to use EBS driver due to K8s version update:
- See point 4: https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html
