### PR TITLE
[BugFix] Add termination period for static code upload

### DIFF
--- a/scripts/workers/code_upload_submission_worker.py
+++ b/scripts/workers/code_upload_submission_worker.py
@@ -382,6 +382,7 @@ def create_static_code_upload_submission_job_object(message, challenge):
             init_containers=[init_container],
             containers=[sidecar_container, submission_container],
             restart_policy="Never",
+            termination_grace_period_seconds=360,
             volumes=volume_list,
         ),
     )


### PR DESCRIPTION
This PR adds a graceful termination period time for static code upload jobs. 

The issue is that while the sidecar container polls for the submission file, the submission container exists and initiates a TERM signal to all the other containers (sidecar). What this does is that after 30 seconds kills the running sidecar container and the submission never reaches EvalAI backend.
This is fixed by adding a graceful termination period for the sidecar container which is slightly higher than the sleep interval.

**Scenarios**
- Sidecar container terminates first - only happens when the submission time limit is reached. In this case, no file will be uploaded to EvalAI, although the submission container will get 360 secons of grace period.
- Submission container terminates first - more likely to happen, the sidecar container may be in sleep mode - a maximum of 300 seconds - after 360 seconds of submission container terminates it should have found the submission file and can exit without any issues.

There might be a better way to fix this to need as little time as possible while exiting (maybe a `preStop` hook or something else). This may be investigated later on. 