### PR TITLE
[Backend] Change termination grace period to 600 seconds

### DIFF
--- a/scripts/workers/code_upload_submission_worker.py
+++ b/scripts/workers/code_upload_submission_worker.py
@@ -382,7 +382,7 @@ def create_static_code_upload_submission_job_object(message, challenge):
             init_containers=[init_container],
             containers=[sidecar_container, submission_container],
             restart_policy="Never",
-            termination_grace_period_seconds=360,
+            termination_grace_period_seconds=600,
             volumes=volume_list,
         ),
     )


### PR DESCRIPTION
This PR changes termination grace period to 600 seconds (10 minutes) as the upload to submission files on EvalAI also takes time.
The hope is that the file will get uploaded within these. Once the file is uploaded, the container will stop running anyway and the pod gets killed. 
