### PR TITLE
Fix #4242: Updated Deploy and Pull scripts for TravisCI to report it as failed on issue

### DIFF
--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -8,10 +8,12 @@ aws_login() {
     eval $(aws ecr get-login --no-include-email)
 }
 
-if [ -z ${AWS_ACCOUNT_ID} ]; then
-    echo "AWS_ACCOUNT_ID not set."
-    exit 0
-fi
+aws_account_id_check() {
+    if [ -z ${AWS_ACCOUNT_ID} ]; then
+        echo "AWS_ACCOUNT_ID not set."
+        exit 1
+    fi
+}
 
 if [ -z ${COMMIT_ID} ]; then
     export COMMIT_ID="latest"
@@ -19,6 +21,7 @@ fi
 
 if [ -z ${TRAVIS_BRANCH} ]; then
     echo "Please set the TRAVIS_BRANCH first."
+    exit 1
 fi
 
 env=${TRAVIS_BRANCH}
@@ -37,6 +40,7 @@ fi
 
 case $opt in
         auto_deploy)
+            aws_account_id_check;
             chmod 400 scripts/deployment/evalai.pem
             ssh-add scripts/deployment/evalai.pem
 			ssh -A ubuntu@${JUMPBOX} -o StrictHostKeyChecking=no INSTANCE=${INSTANCE} AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID} COMMIT_ID=${COMMIT_ID} env=${env} 'bash -s' <<-'ENDSSH'
@@ -55,6 +59,7 @@ case $opt in
 			ENDSSH
             ;;
         deploy-monitoring)
+            aws_account_id_check;
             chmod 400 scripts/deployment/evalai.pem
             ssh-add scripts/deployment/evalai.pem
 			ssh -A ubuntu@${JUMPBOX} -o StrictHostKeyChecking=no MONITORING_INSTANCE=${MONITORING_INSTANCE} AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID} COMMIT_ID=${COMMIT_ID} env=${env} 'bash -s' <<-'ENDSSH'

--- a/scripts/deployment/push.sh
+++ b/scripts/deployment/push.sh
@@ -34,7 +34,7 @@ if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
     exit 0
 elif [ "${TRAVIS_BRANCH}" == "staging" -o "${TRAVIS_BRANCH}" == "production" ]; then
     build_and_push $TRAVIS_BRANCH
-    exit 0
+    exit 1
 else
     echo "Skipping deploy!"
     exit 0


### PR DESCRIPTION
## Expected Behaviour
Deploy and Pull Scripts should send exit code 1 when failure occurs

## Actual Behaviour
From the [example](https://github.com/Cloud-CV/EvalAI/pull/4239), deploy.sh script is sending exit code 0, which means success and Travis CI, in return make build successful.
![image](https://github.com/Cloud-CV/EvalAI/assets/63901956/5f6e6e39-7884-4b6c-9d0b-7ff06e77f5c3)

## Fix: 
1. Deploy.sh: Create a function to check for *AWS_ACCOUNT_ID*, and this function will only be called for the cases which uses this variable, for others cases, it will not check for this value.

2. Pull.sh: if env is production/staging, and error occurs in *build_and_push* function, it exits with error code 1.