### PR TITLE
Fix #4280: Improve challenge title validation

### DIFF
--- a/apps/challenges/challenge_config_utils.py
+++ b/apps/challenges/challenge_config_utils.py
@@ -227,6 +227,7 @@ error_message_dict = {
     "multiple_yaml_files": "There are {} challenge config YAML files instead of 1 in the zip file!",
     "yaml_file_read_error": "\n{} in line {}, column {}\n",
     "missing_challenge_title": "Please add the challenge title",
+    "invalid_challenge_title": "Challenge title contains invalid characters.",
     "missing_challenge_description": "Please add the challenge description",
     "missing_evaluation_details": "Please add the evaluation details",
     "missing_terms_and_conditions": "Please add the terms and conditions.",
@@ -377,6 +378,9 @@ class ValidateChallengeConfigUtil:
         challenge_title = self.yaml_file_data.get("title")
         if not challenge_title or len(challenge_title) == 0:
             message = self.error_messages_dict.get("missing_challenge_title")
+            self.error_messages.append(message)
+        elif not re.match(r"^[a-zA-Z0-9 \-_.',!&]+$", challenge_title):
+            message = self.error_messages_dict.get("invalid_challenge_title")
             self.error_messages.append(message)
 
     def validate_challenge_logo(self):


### PR DESCRIPTION
Allow only alphanumerics and symbols (space, hyphen, underscore, period, comma, apostrophe, exclamation point, ampersand) in challenge titles. It resolves issue #4280. 