### PR TITLE
Fix #4115: Use 'ubuntu' User for Crontab Configuration

### DIFF
--- a/scripts/deployment/deploy_ec2_worker.sh
+++ b/scripts/deployment/deploy_ec2_worker.sh
@@ -66,6 +66,6 @@ fi
 # Step 10: Setting up crontab
 echo "Step 10/10: Setting up crontab"
 echo "@reboot docker restart worker_${QUEUE}" >> workercron
-crontab workercron
+crontab -u ubuntu workercron
 rm workercron
 


### PR DESCRIPTION
This PR resolves issue #4115 by updating the crontab configuration command in the `scripts/deployment/deploy_ec2_worker.sh` to use the 'ubuntu' user instead of 'root'.
