### PR TITLE
Fixes #4289: Updates new Twitter (X) logo

### DIFF
--- a/frontend_v2/src/styles/font.scss
+++ b/frontend_v2/src/styles/font.scss
@@ -780,7 +780,7 @@
   content: '\f098';
 }
 .fa-twitter:before {
-  content: '\f099';
+  content: "𝕏";
 }
 .fa-facebook-f:before,
 .fa-facebook:before {


### PR DESCRIPTION
The PR fixes #4289  and updates the twitter logo to the new one.
![image](https://github.com/Cloud-CV/EvalAI/assets/67970947/77e90d35-ebfe-48c5-a408-3d3d38bdad68)

![image](https://github.com/Cloud-CV/EvalAI/assets/67970947/d7d7719b-615a-41aa-b5e7-8c981658160f)
