### PR TITLE
FIX#3935: Warn users that their tokens have expired

### DIFF
--- a/frontend/src/js/controllers/profileCtrl.js
+++ b/frontend/src/js/controllers/profileCtrl.js
@@ -88,6 +88,12 @@
                 vm.jsonResponse = response.data;
                 vm.token = response.data['token'];
                 vm.expiresAt = moment.utc(response.data['expires_at']).local().format("MMM D, YYYY h:mm:ss A");
+                var expirationDateStr = response.data['expires_at'];
+                var expirationDate = new Date(expirationDateStr);
+                var currentDate = new Date();
+                if (expirationDate < currentDate) {
+                    $rootScope.notify("Warning", "Your token has expired. Please refresh your token!");
+                    }
                 let expiresAtOffset = new Date(vm.expiresAt).getTimezoneOffset();
                 var timezone = moment.tz.guess();
                 vm.expiresAtTimezone = moment.tz.zone(timezone).abbr(expiresAtOffset);


### PR DESCRIPTION
Added Feature to Warn the users If their Tokens are expired and Give them a Warning that suggests to refresh the Token and try again.
closes #3935 