### PR TITLE
Fixes #4303: Resolved uneven width of organization logos across different responsive layouts

### DIFF
--- a/apps/accounts/static/accounts/css/main.css
+++ b/apps/accounts/static/accounts/css/main.css
@@ -1171,13 +1171,14 @@ a.view-more:hover {
     width: 100%;
   }
 }
-@media only screen and (max-width: 600px) {
+@media only screen and (max-width: 992px) {
   .org-logo {
     height: auto;
     width: 100%;
   }
   .org-logo img {
-    width: 100%;
+    width: 40%;
+    padding: 10px;
     height: auto;
   }
 }


### PR DESCRIPTION
The PR fixes #4303.
The PR does the following : reduces width to 40% and adds padding to the organizations logos below 993 px.
![image](https://github.com/Cloud-CV/EvalAI/assets/67970947/5ccb6918-9ad2-402e-802f-97e180bec206)

## Proof that Issue is resolved

https://github.com/Cloud-CV/EvalAI/assets/67970947/61240a75-214e-4b8e-b6cf-1a8e4ce6e45e

