### PR TITLE
Fix4307:Showing irrelavant warning whenever wrong details are shared.

### DIFF
--- a/frontend/src/js/controllers/profileCtrl.js
+++ b/frontend/src/js/controllers/profileCtrl.js
@@ -272,8 +272,7 @@
                                     vm.FormError = response.data.affiliation[0]; 
                                 } else {
                                     $rootScope.notify("error", "Some error have occured . Please try again !");
-                                }
-                                $rootScope.notify("error", vm.FormError);
+                                } $rootScope.notify("error", vm.FormError);
 
                             } catch (error) {
                                 $rootScope.notify("error", error);


### PR DESCRIPTION
fixed it don't shows the warning triggered unnecessarily

![Screenshot from 2024-03-20 14-26-52](https://github.com/Cloud-CV/EvalAI/assets/118094105/a92f0d83-322c-48d6-b2cc-f92c04846a02)
