### PR TITLE
FIX#4115 : 'Crontab' is now created for 'ubuntu' user

### DIFF
--- a/scripts/deployment/deploy_ec2_worker.sh
+++ b/scripts/deployment/deploy_ec2_worker.sh
@@ -65,7 +65,9 @@ fi
 
 # Step 10: Setting up crontab
 echo "Step 10/10: Setting up crontab"
+sudo -u ubuntu bash <<EOF
 echo "@reboot docker restart worker_${QUEUE}" >> workercron
 crontab workercron
 rm workercron
+EOF
 


### PR DESCRIPTION
Earlier it crontab was created for root user , now it is configured to create crontab for ubuntu user.
closes #4115 
closes #4113 