### PR TITLE
[Backend] Add gulp cli install to nodejs in production

### DIFF
--- a/docker/prod/nodejs/Dockerfile
+++ b/docker/prod/nodejs/Dockerfile
@@ -11,7 +11,7 @@ ADD ./.eslintrc /code
 ADD ./karma.conf.js /code
 
 # Install Prerequisites
-RUN npm install -g bower gulp
+RUN npm install -g bower gulp gulp-cli
 RUN npm install phantomjs-prebuilt
 RUN npm link gulp
 RUN npm cache clean -f


### PR DESCRIPTION
This PR adds installation of gulp-cli for production because of which builds are silently failing.