### PR TITLE
Add script to delete services with evaluation errors

### DIFF
--- a/scripts/monitoring/delete_services_with_evaluation_errors.py
+++ b/scripts/monitoring/delete_services_with_evaluation_errors.py
@@ -1,0 +1,69 @@
+import os
+import pytz
+import warnings
+
+from datetime import datetime
+from dateutil.parser import parse
+from auto_stop_workers import start_worker, stop_worker
+from evalai_interface import EvalAI_Interface
+
+warnings.filterwarnings("ignore")
+
+utc = pytz.UTC
+
+ENV = os.environ.get("ENV", "dev")
+
+evalai_endpoint = os.environ.get("API_HOST_URL")
+auth_token = os.environ.get("AUTH_TOKEN")
+
+
+def scale_down_workers(challenge, num_workers):
+    if num_workers > 0:
+        response = stop_worker(challenge_id=challenge["id"])
+        print("AWS API Response: {}".format(response))
+        print(
+            "Stopped worker for Challenge ID: {}, Title: {}".format(
+                challenge["id"], challenge["title"]
+            )
+        )
+
+    else:
+        print(
+            "No workers and pending messages found for Challenge ID: {}, Title: {}. Skipping.".format(
+                challenge["id"], challenge["title"]
+            )
+        )
+
+
+def scale_down_workers_for_challenges(evalai_interface, response):
+    for challenge in response["results"]:
+        try:
+            # this is the most important line
+            if challenge["evaluation_module_error"] != '':
+                num_workers = (
+                    0
+                    if challenge["workers"] is None
+                    else int(challenge["workers"])
+                )
+                print("number of workers", num_workers)
+
+                scale_down_workers(challenge, num_workers)
+        except Exception as e:
+            print(e)
+
+
+def create_evalai_interface(auth_token, evalai_endpoint):
+    evalai_interface = EvalAI_Interface(auth_token, evalai_endpoint)
+    return evalai_interface
+
+
+def start():
+    evalai_interface = create_evalai_interface(auth_token, evalai_endpoint)
+    response = evalai_interface.get_challenges()
+
+    scale_down_workers_for_challenges(evalai_interface, response)
+
+
+if __name__ == "__main__":
+    pass
+    # start

--- a/scripts/monitoring/delete_services_with_evaluation_errors.py
+++ b/scripts/monitoring/delete_services_with_evaluation_errors.py
@@ -2,9 +2,7 @@ import os
 import pytz
 import warnings
 
-from datetime import datetime
-from dateutil.parser import parse
-from auto_stop_workers import start_worker, stop_worker
+from auto_stop_workers import stop_worker
 from evalai_interface import EvalAI_Interface
 
 warnings.filterwarnings("ignore")
@@ -39,7 +37,7 @@ def scale_down_workers_for_challenges(evalai_interface, response):
     for challenge in response["results"]:
         try:
             # this is the most important line
-            if challenge["evaluation_module_error"] != '':
+            if challenge["evaluation_module_error"] != "":
                 num_workers = (
                     0
                     if challenge["workers"] is None


### PR DESCRIPTION
This pull request adds a script that can be used to delete services with evaluation errors. 

The script will filter out challenges with non empty `evaluation_module_error` and scale its ECS workers to 0