### PR TITLE
[Backend] Update EKS cluster version to 1.29

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -1665,7 +1665,7 @@ def create_eks_cluster(challenge):
         try:
             response = client.create_cluster(
                 name=cluster_name,
-                version="1.23",
+                version="1.29",
                 roleArn=cluster_meta["EKS_CLUSTER_ROLE_ARN"],
                 resourcesVpcConfig={
                     "subnetIds": [


### PR DESCRIPTION
Modify the challenges/aws_utils.py to change the new EKS cluster created with Kubernete version 1.29, upgrade from the previous 1.23