### PR TITLE
Add Interactive Buttons for Slack message to approve and disapprove message from Slack

### DIFF
--- a/apps/base/utils.py
+++ b/apps/base/utils.py
@@ -251,12 +251,19 @@ def send_slack_notification(webhook=settings.SLACK_WEB_HOOK_URL, message=""):
         message {str} -- JSON/Text message to be sent to slack (default: {""})
     """
     try:
-        data = {
-            "attachments": [{"color": "ffaf4b", "fields": message["fields"]}],
-            "icon_url": "https://eval.ai/dist/images/evalai-logo-single.png",
-            "text": message["text"],
-            "username": "EvalAI",
-        }
+        # check if the message is a string or a dictionary
+        if isinstance(message, str):
+            data = {
+                "attachments": [
+                    {"color": "ffaf4b", "fields": message["fields"]}
+                ],
+                "icon_url": "https://eval.ai/dist/images/evalai-logo-single.png",
+                "text": message["text"],
+                "username": "EvalAI",
+            }
+        else:
+            data = message
+
         return requests.post(
             webhook,
             data=json.dumps(data),

--- a/apps/challenges/models.py
+++ b/apps/challenges/models.py
@@ -260,6 +260,39 @@ class Challenge(TimeStampedModel):
         return False
 
 
+def slack_challenge_approval_callback(challenge_id):
+    field_name = "approved_by_admin"
+    from challenges.models import Challenge
+    import challenges.aws_utils as aws
+
+    instance = Challenge.objects.get(id=challenge_id)
+
+    if challenge_id:
+        challenge = Challenge.objects.filter(id=challenge_id).first()
+        if challenge:
+            created = False
+        else:
+            created = True
+
+    if not created and is_model_field_changed(instance, field_name):
+        if (
+            instance.approved_by_admin is True
+            and instance.is_docker_based is True
+            and instance.remote_evaluation is False
+        ):
+            serialized_obj = serializers.serialize("json", [instance])
+            aws.setup_eks_cluster.delay(serialized_obj)
+        elif (
+            instance.approved_by_admin is True
+            and instance.uses_ec2_worker is True
+        ):
+            serialized_obj = serializers.serialize("json", [instance])
+            aws.setup_ec2.delay(serialized_obj)
+    aws.challenge_approval_callback(
+        instance=instance, field_name=field_name, sender="challenges.Challenge"
+    )
+
+
 @receiver(signals.post_save, sender="challenges.Challenge")
 def create_eks_cluster_or_ec2_for_challenge(sender, instance, created, **kwargs):
     field_name = "approved_by_admin"

--- a/apps/challenges/urls.py
+++ b/apps/challenges/urls.py
@@ -131,6 +131,11 @@ urlpatterns = [
         name="get_or_update_challenge_phase_split",
     ),
     url(
+        r"^challenge/slack_actions/$",
+        views.slack_actions,
+        name="challenge_slack_actions",
+    ),
+    url(
         r"^(?P<challenge_pk>[0-9]+)/$",
         views.star_challenge,
         name="star_challenge",


### PR DESCRIPTION
This pull request adds interactive buttons to the Slack message for approving and disapproving a challenge. When the buttons are clicked, the corresponding action is performed and a response message is sent back to the backend.