### PR TITLE
Add functions to retrieve CPU, memory, and storage utilization metrics for a challenge

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -1634,6 +1634,97 @@ def create_eks_cluster_subnets(challenge):
         return
 
 
+def get_cpu_utilization(challenge, range_days, period_seconds, cluster_name):
+    """
+    Get the CPU utilization of the worker in the challenge.
+    """
+    from datetime import datetime, timedelta
+
+    cloudwatch_client = get_boto3_client("cloudwatch", aws_keys)
+
+    start_time = datetime.utcnow() - timedelta(days=range_days)
+    end_time = datetime.utcnow()
+    queue_name = challenge.queue
+    service_name = "{}_service".format(queue_name)
+
+    response = cloudwatch_client.get_metric_statistics(
+        Namespace="AWS/ECS",
+        MetricName="CPUUtilization",
+        Dimensions=[
+            {"Name": "ClusterName", "Value": cluster_name},
+            {"Name": "ServiceName", "Value": service_name},
+        ],
+        StartTime=start_time,
+        EndTime=end_time,
+        Period=period_seconds,
+        Statistics=["Average", "Maximum", "Minimum"],
+    )
+
+    return response["Datapoints"]
+
+
+def get_memory_utilization(
+    challenge, range_days, period_seconds, cluster_name
+):
+    """
+    Get the Memory utilization of the worker in the challenge.
+    """
+    from datetime import datetime, timedelta
+
+    cloudwatch_client = get_boto3_client("cloudwatch", aws_keys)
+
+    start_time = datetime.utcnow() - timedelta(days=range_days)
+    end_time = datetime.utcnow()
+    queue_name = challenge.queue
+    service_name = "{}_service".format(queue_name)
+
+    response = cloudwatch_client.get_metric_statistics(
+        Namespace="AWS/ECS",
+        MetricName="MemoryUtilization",
+        Dimensions=[
+            {"Name": "ClusterName", "Value": cluster_name},
+            {"Name": "ServiceName", "Value": service_name},
+        ],
+        StartTime=start_time,
+        EndTime=end_time,
+        Period=period_seconds,
+        Statistics=["Average", "Maximum", "Minimum"],
+    )
+
+    return response["Datapoints"]
+
+
+def get_storage_utilization(
+    challenge, range_days, period_seconds, cluster_name
+):
+    """
+    Get the Storage utilization of the worker in the challenge.
+    """
+    from datetime import datetime, timedelta
+
+    cloudwatch_client = get_boto3_client("cloudwatch", aws_keys)
+
+    start_time = datetime.utcnow() - timedelta(days=range_days)
+    end_time = datetime.utcnow()
+    queue_name = challenge.queue
+    service_name = "{}_service".format(queue_name)
+
+    response = cloudwatch_client.get_metric_statistics(
+        Namespace="ECS/ContainerInsights",
+        MetricName="EphemeralStorageUtilized",
+        Dimensions=[
+            {"Name": "ClusterName", "Value": cluster_name},
+            {"Name": "ServiceName", "Value": service_name},
+        ],
+        StartTime=start_time,
+        EndTime=end_time,
+        Period=period_seconds,
+        Statistics=["Average"],
+    )
+
+    return response["Datapoints"]
+
+
 @app.task
 def create_eks_cluster(challenge):
     """

--- a/apps/challenges/urls.py
+++ b/apps/challenges/urls.py
@@ -202,6 +202,11 @@ urlpatterns = [
         name="manage_worker",
     ),
     url(
+        r"^(?P<challenge_pk>[0-9]+)/get_ecs_workers_metrics/(?P<metric>[\w-]+)/$",
+        views.get_ecs_workers_metrics,
+        name="get_ecs_workers_metrics",
+    ),
+    url(
         r"^(?P<challenge_pk>[0-9]+)/manage_ec2_instance/(?P<action>[\w-]+)/$",
         views.manage_ec2_instance,
         name="manage_ec2_instance",

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -151,6 +151,9 @@ from .aws_utils import (
     get_logs_from_cloudwatch,
     get_log_group_name,
     scale_resources,
+    get_cpu_utilization,
+    get_memory_utilization,
+    get_storage_utilization,
 )
 from .utils import (
     get_aws_credentials_for_submission,

--- a/scripts/monitoring/monitor_metrics_workers.py
+++ b/scripts/monitoring/monitor_metrics_workers.py
@@ -1,7 +1,6 @@
 import os
 import pytz
 import requests
-from datetime import datetime
 from evalai_interface import EvalAI_Interface
 
 utc = pytz.UTC
@@ -74,6 +73,11 @@ def monitor_workers_for_challenge(response, evalai_interface):
                 challenge)
             storage_utilization_datapoints = get_storage_metrics_for_challenge(
                 challenge)
+
+            # log the metrics with print
+            print(cpu_utilization_datapoints)
+            print(memory_utilization_datapoints)
+            print(storage_utilization_datapoints)
 
         except Exception as e:
             print("Error while fetching metrics for challenge: {}".format(e))

--- a/scripts/monitoring/monitor_metrics_workers.py
+++ b/scripts/monitoring/monitor_metrics_workers.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import pytz
 import requests
@@ -15,64 +16,100 @@ authorization_header = {
 ENV = os.environ.get("ENV", "dev")
 
 
-def get_cpu_metrics_for_challenge(challenge, range_days=1, period_seconds=300):
-    get_cpu_metrics_endpoint = "{}/api/challenges/{}/get_ecs_workers_metrics/cpu/?range={}&period={}".format(
-        evalai_endpoint, challenge.id, range_days, period_seconds
+def fetch_metrics_in_chunks(endpoint, range_days=1, period_seconds=300):
+    max_days_per_request = 1  # Define maximum days per request to 1 day
+    metrics_data = []
+
+    start_date = datetime.datetime.now(pytz.UTC) - datetime.timedelta(
+        days=range_days
     )
-    response = requests.get(
-        get_cpu_metrics_endpoint, headers=authorization_header
+    end_date = datetime.datetime.now(pytz.UTC)
+
+    while start_date < end_date:
+        chunk_end_date = min(
+            start_date + datetime.timedelta(days=max_days_per_request),
+            end_date,
+        )
+        chunk_range_days = (chunk_end_date - start_date).days
+        chunk_endpoint = (
+            f"{endpoint}&range={chunk_range_days}&period={period_seconds}"
+        )
+        response = requests.get(chunk_endpoint, headers=authorization_header)
+
+        if response.status_code == 200:
+            metrics_data.append(response.json())
+        else:
+            print(
+                f"Failed to fetch metrics for chunk: {
+                    start_date} to {chunk_end_date}"
+            )
+
+        start_date = chunk_end_date
+
+    return metrics_data
+
+
+def get_cpu_metrics_for_challenge(challenge, range_days=1, period_seconds=300):
+    get_cpu_metrics_endpoint = f"{evalai_endpoint}/api/challenges/{
+        challenge.id}/get_ecs_workers_metrics/cpu/?period={period_seconds}"
+    metrics_data = fetch_metrics_in_chunks(
+        get_cpu_metrics_endpoint, range_days, period_seconds
     )
     print(
         "CPU Metrics for Challenge ID: {}, Title: {}".format(
             challenge.id, challenge.title
         )
     )
-    print(response)
+    print(metrics_data)
+    return metrics_data
 
 
 def get_memory_metrics_for_challenge(
     challenge, range_days=1, period_seconds=300
 ):
-    get_memory_metrics_endpoint = "{}/api/challenges/{}/get_ecs_workers_metrics/memory/?range={}&period={}".format(
-        evalai_endpoint, challenge.id, range_days, period_seconds
-    )
-    response = requests.get(
-        get_memory_metrics_endpoint, headers=authorization_header
+    get_memory_metrics_endpoint = f"{evalai_endpoint}/api/challenges/{
+        challenge.id}/get_ecs_workers_metrics/memory/?period={period_seconds}"
+    metrics_data = fetch_metrics_in_chunks(
+        get_memory_metrics_endpoint, range_days, period_seconds
     )
     print(
         "Memory Metrics for Challenge ID: {}, Title: {}".format(
             challenge.id, challenge.title
         )
     )
-    print(response)
+    print(metrics_data)
+    return metrics_data
 
 
 def get_storage_metrics_for_challenge(
     challenge, range_days=1, period_seconds=300
 ):
-    get_storage_metrics_endpoint = "{}/api/challenges/{}/get_ecs_workers_metrics/storage/?range={}&period={}".format(
-        evalai_endpoint, challenge.id, range_days, period_seconds
-    )
-    response = requests.get(
-        get_storage_metrics_endpoint, headers=authorization_header
+    get_storage_metrics_endpoint = f"{evalai_endpoint}/api/challenges/{
+        challenge.id}/get_ecs_workers_metrics/storage/?period={period_seconds}"
+    metrics_data = fetch_metrics_in_chunks(
+        get_storage_metrics_endpoint, range_days, period_seconds
     )
     print(
         "Storage Metrics for Challenge ID: {}, Title: {}".format(
             challenge.id, challenge.title
         )
     )
-    print(response)
+    print(metrics_data)
+    return metrics_data
 
 
 def monitor_workers_for_challenge(response, evalai_interface):
     for challenge in response["results"]:
         try:
             cpu_utilization_datapoints = get_cpu_metrics_for_challenge(
-                challenge)
+                challenge
+            )
             memory_utilization_datapoints = get_memory_metrics_for_challenge(
-                challenge)
+                challenge
+            )
             storage_utilization_datapoints = get_storage_metrics_for_challenge(
-                challenge)
+                challenge
+            )
 
             # log the metrics with print
             print(cpu_utilization_datapoints)

--- a/scripts/monitoring/monitor_metrics_workers.py
+++ b/scripts/monitoring/monitor_metrics_workers.py
@@ -5,6 +5,9 @@ from datetime import datetime
 from evalai_interface import EvalAI_Interface
 
 utc = pytz.UTC
+auth_token = os.environ.get(
+    "AUTH_TOKEN",
+)
 evalai_endpoint = os.environ.get("API_HOST_URL")
 authorization_header = {
     "Authorization": "Bearer {}".format(os.environ.get("AUTH_TOKEN"))
@@ -13,51 +16,68 @@ authorization_header = {
 ENV = os.environ.get("ENV", "dev")
 
 
-def get_cpu_metrics_for_challenge(challenge):
-    get_cpu_metrics_endpoint = "{}/api/challenges/{}/get_ecs_workers_metrics/cpu/".format(
-        evalai_endpoint, challenge.id
+def get_cpu_metrics_for_challenge(challenge, range_days=1, period_seconds=300):
+    get_cpu_metrics_endpoint = "{}/api/challenges/{}/get_ecs_workers_metrics/cpu/?range={}&period={}".format(
+        evalai_endpoint, challenge.id, range_days, period_seconds
     )
-    response = requests.get(get_cpu_metrics_endpoint, headers=authorization_header)
-    print("CPU Metrics for Challenge ID: {}, Title: {}".format(challenge.id, challenge.title))
-    print(response.json())
-
-
-def get_memory_metrics_for_challenge(challenge):
-    queue_name = challenge.queue
-    service_name = "{}_service".format(queue_name)
-    get_memory_metrics_endpoint = "{}/api/challenges/{}/get_ecs_workers_metrics/memory/".format(
-        evalai_endpoint, challenge.id
+    response = requests.get(
+        get_cpu_metrics_endpoint, headers=authorization_header
     )
-    response = requests.get(get_memory_metrics_endpoint, headers=authorization_header)
-    print("Memory Metrics for Challenge ID: {}, Title: {}".format(challenge.id, challenge.title))
-    print(response.json())
-
-
-def get_storage_metrics_for_challenge(challenge):
-    queue_name = challenge.queue
-    service_name = "{}_service".format(queue_name)
-    get_storage_metrics_endpoint = "{}/api/challenges/{}/get_ecs_workers_metrics/storage/".format(
-        evalai_endpoint, challenge.id
+    print(
+        "CPU Metrics for Challenge ID: {}, Title: {}".format(
+            challenge.id, challenge.title
+        )
     )
-    response = requests.get(get_storage_metrics_endpoint, headers=authorization_header)
-    print("Storage Metrics for Challenge ID: {}, Title: {}".format(challenge.id, challenge.title))
-    print(response.json())
+    print(response)
+
+
+def get_memory_metrics_for_challenge(
+    challenge, range_days=1, period_seconds=300
+):
+    get_memory_metrics_endpoint = "{}/api/challenges/{}/get_ecs_workers_metrics/memory/?range={}&period={}".format(
+        evalai_endpoint, challenge.id, range_days, period_seconds
+    )
+    response = requests.get(
+        get_memory_metrics_endpoint, headers=authorization_header
+    )
+    print(
+        "Memory Metrics for Challenge ID: {}, Title: {}".format(
+            challenge.id, challenge.title
+        )
+    )
+    print(response)
+
+
+def get_storage_metrics_for_challenge(
+    challenge, range_days=1, period_seconds=300
+):
+    get_storage_metrics_endpoint = "{}/api/challenges/{}/get_ecs_workers_metrics/storage/?range={}&period={}".format(
+        evalai_endpoint, challenge.id, range_days, period_seconds
+    )
+    response = requests.get(
+        get_storage_metrics_endpoint, headers=authorization_header
+    )
+    print(
+        "Storage Metrics for Challenge ID: {}, Title: {}".format(
+            challenge.id, challenge.title
+        )
+    )
+    print(response)
 
 
 def monitor_workers_for_challenge(response, evalai_interface):
-    for challenge in response['results']:
+    for challenge in response["results"]:
         try:
-            # Get the CPU metrics for 1 days
-            get_cpu_metrics_for_challenge(challenge)
-            # Get the memory metrics for 1 days
-            get_memory_metrics_for_challenge(challenge)
-            # Get the utilization storage metrics for 1 days
-            get_storage_metrics_for_challenge(challenge)
-        
+            cpu_utilization_datapoints = get_cpu_metrics_for_challenge(
+                challenge)
+            memory_utilization_datapoints = get_memory_metrics_for_challenge(
+                challenge)
+            storage_utilization_datapoints = get_storage_metrics_for_challenge(
+                challenge)
+
         except Exception as e:
             print("Error while fetching metrics for challenge: {}".format(e))
             continue
-        
 
 
 def create_evalai_interface(auth_token, evalai_endpoint):
@@ -69,11 +89,11 @@ def create_evalai_interface(auth_token, evalai_endpoint):
 def start_job():
     evalai_interface = create_evalai_interface(auth_token, evalai_endpoint)
     response = evalai_interface.get_challenges()
-    scale_up_or_down_workers_for_challenges(response, evalai_interface)
+    monitor_workers_for_challenge(response, evalai_interface)
     next_page = response["next"]
     while next_page is not None:
         response = evalai_interface.make_request(next_page, "GET")
-        scale_up_or_down_workers_for_challenges(response, evalai_interface)
+        monitor_workers_for_challenge(response, evalai_interface)
         next_page = response["next"]
 
 

--- a/scripts/monitoring/monitor_metrics_workers.py
+++ b/scripts/monitoring/monitor_metrics_workers.py
@@ -1,0 +1,83 @@
+import os
+import pytz
+import requests
+from datetime import datetime
+from evalai_interface import EvalAI_Interface
+
+utc = pytz.UTC
+evalai_endpoint = os.environ.get("API_HOST_URL")
+authorization_header = {
+    "Authorization": "Bearer {}".format(os.environ.get("AUTH_TOKEN"))
+}
+
+ENV = os.environ.get("ENV", "dev")
+
+
+def get_cpu_metrics_for_challenge(challenge):
+    get_cpu_metrics_endpoint = "{}/api/challenges/{}/get_ecs_workers_metrics/cpu/".format(
+        evalai_endpoint, challenge.id
+    )
+    response = requests.get(get_cpu_metrics_endpoint, headers=authorization_header)
+    print("CPU Metrics for Challenge ID: {}, Title: {}".format(challenge.id, challenge.title))
+    print(response.json())
+
+
+def get_memory_metrics_for_challenge(challenge):
+    queue_name = challenge.queue
+    service_name = "{}_service".format(queue_name)
+    get_memory_metrics_endpoint = "{}/api/challenges/{}/get_ecs_workers_metrics/memory/".format(
+        evalai_endpoint, challenge.id
+    )
+    response = requests.get(get_memory_metrics_endpoint, headers=authorization_header)
+    print("Memory Metrics for Challenge ID: {}, Title: {}".format(challenge.id, challenge.title))
+    print(response.json())
+
+
+def get_storage_metrics_for_challenge(challenge):
+    queue_name = challenge.queue
+    service_name = "{}_service".format(queue_name)
+    get_storage_metrics_endpoint = "{}/api/challenges/{}/get_ecs_workers_metrics/storage/".format(
+        evalai_endpoint, challenge.id
+    )
+    response = requests.get(get_storage_metrics_endpoint, headers=authorization_header)
+    print("Storage Metrics for Challenge ID: {}, Title: {}".format(challenge.id, challenge.title))
+    print(response.json())
+
+
+def monitor_workers_for_challenge(response, evalai_interface):
+    for challenge in response['results']:
+        try:
+            # Get the CPU metrics for 1 days
+            get_cpu_metrics_for_challenge(challenge)
+            # Get the memory metrics for 1 days
+            get_memory_metrics_for_challenge(challenge)
+            # Get the utilization storage metrics for 1 days
+            get_storage_metrics_for_challenge(challenge)
+        
+        except Exception as e:
+            print("Error while fetching metrics for challenge: {}".format(e))
+            continue
+        
+
+
+def create_evalai_interface(auth_token, evalai_endpoint):
+    evalai_interface = EvalAI_Interface(auth_token, evalai_endpoint)
+    return evalai_interface
+
+
+# Cron Job
+def start_job():
+    evalai_interface = create_evalai_interface(auth_token, evalai_endpoint)
+    response = evalai_interface.get_challenges()
+    scale_up_or_down_workers_for_challenges(response, evalai_interface)
+    next_page = response["next"]
+    while next_page is not None:
+        response = evalai_interface.make_request(next_page, "GET")
+        scale_up_or_down_workers_for_challenges(response, evalai_interface)
+        next_page = response["next"]
+
+
+if __name__ == "__main__":
+    print("Starting worker metric monitoring script")
+    start_job()
+    print("Quitting worker metric monitoring script!")

--- a/scripts/monitoring/monitor_metrics_workers.py
+++ b/scripts/monitoring/monitor_metrics_workers.py
@@ -35,11 +35,11 @@ def fetch_metrics_in_chunks(endpoint, range_days=1, period_seconds=300):
             metrics_data.append(response.json())
         else:
             print(
-                f"Failed to fetch metrics for chunk: {
-                    start_date} to {chunk_end_date}"
+                f"Failed to fetch metrics for chunk: {start_date} to {chunk_end_date}"
             )
 
         start_date = chunk_end_date
+
     return metrics_data
 
 
@@ -47,8 +47,7 @@ def get_metrics_for_challenge(
     challenge, metric_type, range_days=1, period_seconds=300
 ):
     # Construct the API endpoint with the required query parameters
-    endpoint = f"{EVALAI_ENDPOINT}/api/challenges/{challenge.id}/get_ecs_workers_metrics/{
-        metric_type}/?range={range_days}&period={period_seconds}"
+    endpoint = f"{EVALAI_ENDPOINT}/api/challenges/{challenge.id}/get_ecs_workers_metrics/{metric_type}/?range={range_days}&period={period_seconds}"
 
     # Fetch metrics in chunks from the endpoint
     metrics_data = fetch_metrics_in_chunks(
@@ -57,8 +56,7 @@ def get_metrics_for_challenge(
 
     # Log the fetched metrics
     print(
-        f"{metric_type.capitalize()} Metrics for Challenge ID: {
-            challenge.id}, Title: {challenge.title}"
+        f"{metric_type.capitalize()} Metrics for Challenge ID: {challenge.id}, Title: {challenge.title}"
     )
     print(metrics_data)
 

--- a/scripts/monitoring/monitor_metrics_workers.py
+++ b/scripts/monitoring/monitor_metrics_workers.py
@@ -4,139 +4,69 @@ import pytz
 import requests
 from evalai_interface import EvalAI_Interface
 
+# Constants
 utc = pytz.UTC
-auth_token = os.environ.get(
-    "AUTH_TOKEN",
-)
-evalai_endpoint = os.environ.get("API_HOST_URL")
-authorization_header = {
-    "Authorization": "Bearer {}".format(os.environ.get("AUTH_TOKEN"))
-}
-
-ENV = os.environ.get("ENV", "dev")
-
+AUTH_TOKEN = os.getenv("AUTH_TOKEN")
+EVALAI_ENDPOINT = os.getenv("API_HOST_URL")
+AUTH_HEADER = {"Authorization": f"Bearer {AUTH_TOKEN}"}
+ENV = os.getenv("ENV", "dev")
 
 def fetch_metrics_in_chunks(endpoint, range_days=1, period_seconds=300):
-    max_days_per_request = 1  # Define maximum days per request to 1 day
+    max_days_per_request = 1  # Max days per request
     metrics_data = []
-
-    start_date = datetime.datetime.now(pytz.UTC) - datetime.timedelta(
-        days=range_days
-    )
+    start_date = datetime.datetime.now(pytz.UTC) - datetime.timedelta(days=range_days)
     end_date = datetime.datetime.now(pytz.UTC)
 
     while start_date < end_date:
-        chunk_end_date = min(
-            start_date + datetime.timedelta(days=max_days_per_request),
-            end_date,
-        )
+        chunk_end_date = min(start_date + datetime.timedelta(days=max_days_per_request), end_date)
         chunk_range_days = (chunk_end_date - start_date).days
-        chunk_endpoint = (
-            f"{endpoint}&range={chunk_range_days}&period={period_seconds}"
-        )
-        response = requests.get(chunk_endpoint, headers=authorization_header)
+        chunk_endpoint = f"{endpoint}&range={chunk_range_days}&period={period_seconds}"
+        response = requests.get(chunk_endpoint, headers=AUTH_HEADER)
 
         if response.status_code == 200:
             metrics_data.append(response.json())
         else:
-            print(
-                f"Failed to fetch metrics for chunk: {
-                    start_date} to {chunk_end_date}"
-            )
+            print(f"Failed to fetch metrics for chunk: {start_date} to {chunk_end_date}")
 
         start_date = chunk_end_date
-
     return metrics_data
 
-
-def get_cpu_metrics_for_challenge(challenge, range_days=1, period_seconds=300):
-    get_cpu_metrics_endpoint = f"{evalai_endpoint}/api/challenges/{
-        challenge.id}/get_ecs_workers_metrics/cpu/?period={period_seconds}"
-    metrics_data = fetch_metrics_in_chunks(
-        get_cpu_metrics_endpoint, range_days, period_seconds
-    )
-    print(
-        "CPU Metrics for Challenge ID: {}, Title: {}".format(
-            challenge.id, challenge.title
-        )
-    )
+def get_metrics_for_challenge(challenge, metric_type, range_days=1, period_seconds=300):
+    endpoint = f"{EVALAI_ENDPOINT}/api/challenges/{challenge.id}/get_ecs_workers_metrics/{metric_type}/?period={period_seconds}"
+    metrics_data = fetch_metrics_in_chunks(endpoint, range_days, period_seconds)
+    print(f"{metric_type.capitalize()} Metrics for Challenge ID: {challenge.id}, Title: {challenge.title}")
     print(metrics_data)
     return metrics_data
-
-
-def get_memory_metrics_for_challenge(
-    challenge, range_days=1, period_seconds=300
-):
-    get_memory_metrics_endpoint = f"{evalai_endpoint}/api/challenges/{
-        challenge.id}/get_ecs_workers_metrics/memory/?period={period_seconds}"
-    metrics_data = fetch_metrics_in_chunks(
-        get_memory_metrics_endpoint, range_days, period_seconds
-    )
-    print(
-        "Memory Metrics for Challenge ID: {}, Title: {}".format(
-            challenge.id, challenge.title
-        )
-    )
-    print(metrics_data)
-    return metrics_data
-
-
-def get_storage_metrics_for_challenge(
-    challenge, range_days=1, period_seconds=300
-):
-    get_storage_metrics_endpoint = f"{evalai_endpoint}/api/challenges/{
-        challenge.id}/get_ecs_workers_metrics/storage/?period={period_seconds}"
-    metrics_data = fetch_metrics_in_chunks(
-        get_storage_metrics_endpoint, range_days, period_seconds
-    )
-    print(
-        "Storage Metrics for Challenge ID: {}, Title: {}".format(
-            challenge.id, challenge.title
-        )
-    )
-    print(metrics_data)
-    return metrics_data
-
 
 def monitor_workers_for_challenge(response, evalai_interface):
     for challenge in response["results"]:
         try:
-            cpu_utilization_datapoints = get_cpu_metrics_for_challenge(
-                challenge
-            )
-            memory_utilization_datapoints = get_memory_metrics_for_challenge(
-                challenge
-            )
-            storage_utilization_datapoints = get_storage_metrics_for_challenge(
-                challenge
-            )
+            cpu_utilization_datapoints = get_metrics_for_challenge(challenge, 'cpu')
+            memory_utilization_datapoints = get_metrics_for_challenge(challenge, 'memory')
+            storage_utilization_datapoints = get_metrics_for_challenge(challenge, 'storage')
 
-            # log the metrics with print
+            # Log the metrics
             print(cpu_utilization_datapoints)
             print(memory_utilization_datapoints)
             print(storage_utilization_datapoints)
 
         except Exception as e:
-            print("Error while fetching metrics for challenge: {}".format(e))
+            print(f"Error while fetching metrics for challenge: {e}")
             continue
 
-
-def create_evalai_interface(auth_token, evalai_endpoint):
-    evalai_interface = EvalAI_Interface(auth_token, evalai_endpoint)
+def create_evalai_interface():
+    evalai_interface = EvalAI_Interface(AUTH_TOKEN, EVALAI_ENDPOINT)
     return evalai_interface
 
-
-# Cron Job
 def start_job():
-    evalai_interface = create_evalai_interface(auth_token, evalai_endpoint)
+    evalai_interface = create_evalai_interface()
     response = evalai_interface.get_challenges()
     monitor_workers_for_challenge(response, evalai_interface)
     next_page = response["next"]
-    while next_page is not None:
+    while next_page:
         response = evalai_interface.make_request(next_page, "GET")
         monitor_workers_for_challenge(response, evalai_interface)
         next_page = response["next"]
-
 
 if __name__ == "__main__":
     print("Starting worker metric monitoring script")


### PR DESCRIPTION
This pull request adds new functions to retrieve CPU, memory, and storage utilization metrics for a challenge. These functions use the AWS CloudWatch API to fetch the metrics for the worker in the challenge. The metrics include CPU utilization, memory utilization, and storage utilization. These metrics will be used for monitoring and analyzing the performance of the worker.