### PR TITLE
Add daily approval request limit and tracking

### DIFF
--- a/apps/challenges/models.py
+++ b/apps/challenges/models.py
@@ -177,6 +177,8 @@ class Challenge(TimeStampedModel):
         null=True, blank=True, max_length=2048, default=""
     )
     slack_webhook_url = models.URLField(max_length=200, blank=True, null=True)
+    daily_approval_request_limit = models.IntegerField(null=True, blank=True, default=5)
+    last_daily_approval_request = models.DateTimeField(null=True, blank=True)
     # Identifier for the github repository of a challenge in format: account_name/repository_name
     github_repository = models.CharField(
         max_length=1000, null=True, blank=True, default=""


### PR DESCRIPTION
This pull request adds a daily approval request limit and tracking feature to the codebase. The `Challenge` model now includes two new fields: `daily_approval_request_limit` and `last_daily_approval_request`. The `request_challenge_approval_by_pk` function has been updated to check the daily limit and track the last approval request time. This feature ensures that the number of approval requests per day is limited and provides better tracking of approval requests.