### PR TITLE
Update dev nodejs Dockerfile to include gcc-10 and libgcc-s1

### DIFF
--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:14.20.0
 
+RUN wget https://mirrors.edge.kernel.org/ubuntu/pool/main/g/gcc-10/gcc-10-base_10-20200411-0ubuntu1_amd64.deb && dpkg -i gcc-10-base_10-20200411-0ubuntu1_amd64.deb
+RUN wget https://mirrors.edge.kernel.org/ubuntu/pool/main/g/gcc-10/libgcc-s1_10-20200411-0ubuntu1_amd64.deb && dpkg -i libgcc-s1_10-20200411-0ubuntu1_amd64.deb
+
 # install chrome for protractor tests
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'


### PR DESCRIPTION
This pull request updates the dev nodejs Dockerfile to include gcc-10 and libgcc-s1. This is necessary for certain dependencies that require these packages.