### PR TITLE
[BugFix] Remove manage worker option

### DIFF
--- a/frontend/src/views/web/challenge/manage.html
+++ b/frontend/src/views/web/challenge/manage.html
@@ -12,11 +12,11 @@
     
     <div class="ev-md-container ev-card-panel ev-z-depth-5 ev-challenge-view" ng-if="!challenge.isRemoteChallenge">
         
-        <div class="row margin-bottom-cancel">
+        <!-- <div class="row margin-bottom-cancel">
             <div class="col s12">
                 <h5 class="w-300">Manage worker</h5>
             </div>
-        </div>
+        </div> -->
         <!-- <div class="row">
             <div class="col xs12 s6">
                 <span>
@@ -41,13 +41,13 @@
             </div>
         </div> -->
 
-        <div class="row worker-actions-row">
+        <!-- <div class="row worker-actions-row">
             <div class="col s12">
                 <button class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-14" ng-click="challenge.manageWorker('start');"><i class="fa fa-play"></i> Start worker</button>
                 <button class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-14" ng-click="challenge.manageWorker('stop');"><i class="fa fa-stop"></i> Stop worker</button>
                 <button class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-14" ng-click="challenge.manageWorker('restart');"><i class="fa fa-refresh"></i> Restart worker</button>
             </div>
-        </div>
+        </div> -->
         <div class="row margin-bottom-cancel">
             <div class="col s12">
                 <h5 class="w-300">Worker logs</h5>

--- a/frontend/src/views/web/challenge/manage.html
+++ b/frontend/src/views/web/challenge/manage.html
@@ -17,7 +17,7 @@
                 <h5 class="w-300">Manage worker</h5>
             </div>
         </div>
-        <div class="row">
+        <!-- <div class="row">
             <div class="col xs12 s6">
                 <span>
                     <form ng-submit="challenge.setWorkerResources()" class="multiple-columns">
@@ -39,7 +39,7 @@
                     </form>
                 </span>
             </div>
-        </div>
+        </div> -->
 
         <div class="row worker-actions-row">
             <div class="col s12">


### PR DESCRIPTION
Scale worker is incorrect, and does not handle the resources/backend attributes gracefully. Removing it from frontend in this PR.

This feature can be re-added once the issues are fixed.

Similarly, start/stop worker is also problematic.

People start workers initially, and then switch to remote eval without stopping the workers.
These workers have to be manually shut down which consumes credits, and is impractical.

We have auto-scaling, and these users should never need to start/stop/restart things as long as that script works fine.
Also, we are working on auto-deciding the amount of resources to be allocated. Should be added soon, this will handle the scale workers issue.