### PR TITLE
Fix #2804 make submission baseline documentation update

### DIFF
--- a/docs/source/make_submission_public_private_baseline.md
+++ b/docs/source/make_submission_public_private_baseline.md
@@ -19,5 +19,22 @@ Let's assume that you want to make your latest submission <span style="color:blu
 2. Now, to make the first submission private, click on the green checkmark under the column `Show on Leaderboard`. It will turn into a black checkbox.
    <img src="_static/img/my_submission_private.png">
    <img src="_static/img/my_submission_public.png">
+   
+## Make Submission Baseline
+
+Let's assume that you want to make your latest submission <span style="color:blue;">baseline</span> in `William Challenge`.
+1. Go to `My Submissions` Tab of the challenge page, select the phase and scroll horizontally.
+   <img src="_static/img/my_submission.png">
+2. Select the submission you want to make as the baseline one (The submission should be Public).
+3. Add this piece of documentation in the announcement feature
+   "Dear Participants,
+   We’re excited to share the baseline submission for this challenge. This submission demonstrates the expected minimum performance level. It has been made public and is visible on the leaderboard under Submission ID [ID or Name].
+
+   Aim to surpass this baseline for higher rankings. Visit the leaderboard to view the metrics.
+
+   Happy coding,
+   Challenge Host Team "
+  
+
 
 If you face any issues, please feel free to create an issue on our [GitHub Issues Page](https://github.com/Cloud-CV/EvalAI/issues/new).


### PR DESCRIPTION
This PR updates the documentation in the make_submission_public_private_baseline.md file to include a section on how the challenge host can make a submission as the baseline submission.

  1.  Added new section explaining the process for making a submission as the baseline.
  2. Clarified steps and responsibilities for the challenge host.
Testing Steps:
Since this is a documentation update, no testing is required for functionality. Please verify the accuracy and clarity of the new instructions provided.
Hi team,
Thank you for reviewing this PR! Please let me know if anything needs further clarification or modification.