### PR TITLE
Motion organization logo size changed

### DIFF
--- a/frontend/src/css/modules/landing.scss
+++ b/frontend/src/css/modules/landing.scss
@@ -565,7 +565,7 @@ a.view-more {
 }
   
 #motional {
-    height: 5%;
+    height: 45%;
 }
 
 #uau {


### PR DESCRIPTION
Fix #4341 

1. Updated the logo size for motion organization in landing.scss.
2. Ensures better alignment and consistency across different screen sizes.
3. Improves visual appearance and responsiveness.

Before: 
![Screenshot 2025-03-07 165825](https://github.com/user-attachments/assets/1097ae60-5727-4224-830b-1959d221f492)

After: 
![Screenshot 2025-03-07 170627](https://github.com/user-attachments/assets/6d79511d-bf85-490b-adc9-7b6a37b935e5)
