### PR TITLE
Fix #2676 Redundant worker dependencies

### DIFF
--- a/docker/dev/worker/Dockerfile
+++ b/docker/dev/worker/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /code
 
 ADD requirements/* /code/
 
-RUN pip install -U cffi service_identity cython==0.29 numpy==1.14.5
+RUN pip install -U cffi service_identity cython==0.29 numpy==1.21.0
 RUN pip install -r dev.txt
 RUN pip install -r worker.txt
 

--- a/docker/dev/worker_py3.8/Dockerfile
+++ b/docker/dev/worker_py3.8/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
     libgmp-dev libcgal-qt5-dev swig && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install -U cffi service_identity cython==0.29 numpy==1.14.5
+RUN pip install -U cffi service_identity cython==0.29 numpy==1.21.0
 RUN pip install -r worker.txt
 
 ADD . /code

--- a/docker/prod/worker/Dockerfile
+++ b/docker/prod/worker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
   libgmp-dev libcgal-qt5-dev swig && \
   rm -rf /var/lib/apt/lists/*
 
-RUN pip install -U cffi service_identity cython==0.29 numpy==1.18.1
+RUN pip install -U cffi service_identity cython==0.29 numpy==1.21.0
 RUN pip install -r worker.txt
 
 CMD ["python", "-m", "scripts.workers.submission_worker"]

--- a/docker/prod/worker_py3.8/Dockerfile
+++ b/docker/prod/worker_py3.8/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     libgmp-dev libcgal-qt5-dev swig && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install -U cffi service_identity cython==0.29 numpy==1.18.1
+RUN pip install -U cffi service_identity cython==0.29 numpy==1.21.0
 RUN pip install -r worker.txt
 
 CMD ["python", "-m", "scripts.workers.submission_worker"]


### PR DESCRIPTION
The bug of Redundant worker dependencies #2676 has solved  and collected rebuild  log for your reference 

[Here is the Text file  with log](https://github.com/user-attachments/files/19474564/log.txt)

Now the worker have NumPy version 1.21.0 dependency everywhere  and there are no error in the building or any other place 

I also collected the deprecation of function between NumPy 1.14.1 and the 1.21.0  the there are no major changes only the bug fixes and some function removed which is not used in our project 

also here is the  screenshot of the terminal for justify there is no error or numpy issue
![image](https://github.com/user-attachments/assets/91b3e6aa-e2fc-4e27-b367-3a9e97988f1b)
![Screenshot from 2025-03-27 01-14-57](https://github.com/user-attachments/assets/2772fc7d-1b54-4b9c-b974-570d300b8524)


looking forward to merge the PR