### PR TITLE
Backend: Add ordering by id in challenge admin

### DIFF
--- a/apps/challenges/admin.py
+++ b/apps/challenges/admin.py
@@ -41,6 +41,7 @@ class UpdateNumOfWorkersForm(ActionForm):
 @admin.register(Challenge)
 class ChallengeAdmin(ImportExportTimeStampedAdmin):
     readonly_fields = ("created_at",)
+    ordering = ["-id"]
     list_display = (
         "id",
         "title",


### PR DESCRIPTION
This PR:

- Adds default ordering of challenges in the admin panel by id.