### PR TITLE
Fix build errors caused by boundary test conditions

### DIFF
--- a/frontend/src/js/controllers/hostedChallengeCtrl.js
+++ b/frontend/src/js/controllers/hostedChallengeCtrl.js
@@ -45,6 +45,7 @@
                     parameters.callback = {
                         onSuccess: function (response) {
                             var data = response.data;
+                            var current = new Date();
                             for (var j = 0; j < data.results.length; j++) {
                                 var challenge = data.results[j];
                                 vm.challengeList.push(challenge);
@@ -55,7 +56,6 @@
                                 challenge.time_zone = moment.tz.zone(timezone).abbr(offset);
                                 challenge.gmt_zone = gmtZone;
 
-                                var current = new Date();
                                 var startDate = new Date(challenge.start_date);
                                 var endDate = new Date(challenge.end_date);
 

--- a/frontend/tests/controllers-test/hostedChallengeCtrl.test.js
+++ b/frontend/tests/controllers-test/hostedChallengeCtrl.test.js
@@ -170,7 +170,8 @@ describe('Unit tests for hosted challenge controller', function () {
     describe('Challenge categorization with duplicate handling', function () {
         beforeEach(function () {
             jasmine.clock().install();
-            jasmine.clock().mockDate(new Date("2025-01-01T12:00:00Z"));
+            const now = new Date();
+            jasmine.clock().mockDate(now);
 
             vm = createController();
         });

--- a/frontend/tests/controllers-test/hostedChallengeCtrl.test.js
+++ b/frontend/tests/controllers-test/hostedChallengeCtrl.test.js
@@ -169,7 +169,14 @@ describe('Unit tests for hosted challenge controller', function () {
     
     describe('Challenge categorization with duplicate handling', function () {
         beforeEach(function () {
+            jasmine.clock().install();
+            jasmine.clock().mockDate(new Date("2025-01-01T12:00:00Z"));
+
             vm = createController();
+        });
+
+        afterEach(function () {
+            jasmine.clock().uninstall();
         });
         
         it('should handle duplicate challenges in upcoming category', function () {


### PR DESCRIPTION
## Description
This PR fixes the build error occurred from one of the boundary test condition in `hostedChallengesCtrl.test.js` by updating it to:
- Freeze the date and time with `jasmine.clock()` to ensure all test environments run with a fixed date and time to avoid corner condition failures.
- Then cleans up the mock clock and restores the real clock after the boundary tests are completed.