### PR TITLE
Fixes #4553 : Migrate CI/CD Pipeline from TravisCI to GitHub Actions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,137 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [ main, master, 'ci-cd' ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  lint:
+    name: Code Linting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+          
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8==3.8.2
+          
+      - name: Lint with flake8
+        run: flake8 ./
+
+  build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    needs: lint
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Install Docker Compose
+        run: |
+          sudo curl -L "https://github.com/docker/compose/releases/download/v2.23.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose --version
+      
+      - name: Docker login
+        if: github.event_name == 'push'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          
+      - name: Build Docker image
+        run: docker-compose build --build-arg PIP_NO_CACHE_DIR=1 --build-arg PIP_NO_BINARY=""
+
+  frontend-test:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Install Docker Compose
+        run: |
+          sudo curl -L "https://github.com/docker/compose/releases/download/v2.23.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose --version
+      
+      - name: Setup display for browser tests
+        run: |
+          export DISPLAY=:99
+          sudo apt-get install -y xvfb
+          Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+          
+      - name: Run frontend tests
+        run: docker-compose run nodejs bash -c "gulp dev && karma start --single-run && gulp staging"
+
+  backend-test:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Install Docker Compose
+        run: |
+          sudo curl -L "https://github.com/docker/compose/releases/download/v2.23.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose --version
+      
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+          
+      - name: Install dependencies
+        run: pip install awscli==1.18.66 coveralls
+        
+      - name: Run backend tests
+        run: |
+          docker-compose run -e DJANGO_SETTINGS_MODULE=settings.test django python manage.py flush --noinput
+          docker-compose run -e DJANGO_SETTINGS_MODULE=settings.test django pytest --cov . --cov-config .coveragerc
+          
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        
+      - name: Coveralls
+        continue-on-error: true
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: |
+          echo "Attempting to submit coverage to Coveralls..."
+          coveralls --rcfile=.coveragerc || echo "Coveralls submission failed, but continuing workflow"
+        
+      - name: Setup SSH key for deployment
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        continue-on-error: true
+        run: |
+          if [ -n "${{ secrets.SSH_PRIVATE_KEY }}" ]; then
+            mkdir -p ~/.ssh
+            echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
+            chmod 600 ~/.ssh/deploy_key
+            ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+          else
+            echo "SSH_PRIVATE_KEY is not set, skipping SSH setup"
+            exit 1
+          fi
+          
+      - name: Run deployment scripts
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && success()
+        run: |
+          if [ -f ~/.ssh/deploy_key ]; then
+            export SSH_AUTH_SOCK=/tmp/ssh_agent.sock
+            ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+            ssh-add ~/.ssh/deploy_key
+            ./scripts/deployment/push.sh
+            ./scripts/deployment/deploy.sh auto_deploy
+          else
+            echo "SSH key not set up, skipping deployment"
+          fi

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,7 +2,7 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main, master, 'ci-cd' ]
+    branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
 


### PR DESCRIPTION
This PR adds github ci/cd workflows to existing TravisCI configuration, maintaining all existing pipeline functionality.

The new GitHub Actions workflow includes:
- Code linting with flake8
- Docker build process
- Frontend testing with Karma
- Backend testing with pytest and coverage reporting
- Automatic deployment on master branch merges

Required secrets:
- `DOCKER_USERNAME` - Docker registry username
- `DOCKER_PASSWORD` - Docker registry password
- `COVERALLS_REPO_TOKEN` - Token for Coveralls coverage reporting
- `SSH_PRIVATE_KEY` - Deployment SSH key

