### PR TITLE
Start django services before docker in worker container

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,7 +7,8 @@
 # W0223: Method %r is abstract in class %r but is not overridden.
 # W0613: Unused argument.
 # W0702: No exception type(s) specified.
-disable=C0103,C0111,E1101,R0903,W0223,W0613,W0702
+# C0413: wrong-import-position (since it conflicts with isort-ordering)
+disable=C0103,C0111,E1101,R0903,W0223,W0613,W0702,C0413
 
 [FORMAT]
 max-line-length=79

--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -25,19 +25,28 @@ import botocore
 import django
 import requests
 import yaml
+
+# fmt: off
+django.setup()  # isort:skip noqa:E402
+# fmt: on
+
 from challenges.models import ChallengePhase  # noqa:E402
-from challenges.models import Challenge, ChallengePhaseSplit, LeaderboardData
+from challenges.models import (  # noqa:E402
+    Challenge,
+    ChallengePhaseSplit,
+    LeaderboardData,
+)
 
 # Load django app settings
-from django.conf import settings  # noqa
-from django.core.files.base import ContentFile
-from django.utils import timezone
+from django.conf import settings  # noqa:E402
+from django.core.files.base import ContentFile  # noqa:E402
+from django.utils import timezone  # noqa:E402
 from jobs.models import Submission  # noqa:E402
 from jobs.serializers import SubmissionSerializer  # noqa:E402
 
-from settings.common import SQS_RETENTION_PERIOD
+from settings.common import SQS_RETENTION_PERIOD  # noqa:E402
 
-from .statsd_utils import increment_and_push_metrics_to_statsd
+from .statsd_utils import increment_and_push_metrics_to_statsd  # noqa:E402
 
 # all challenge and submission will be stored in temp directory
 BASE_TEMP_DIR = tempfile.mkdtemp(prefix="tmp")
@@ -54,7 +63,6 @@ logger = logging.getLogger(__name__)
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
 
-django.setup()
 
 LIMIT_CONCURRENT_SUBMISSION_PROCESSING = os.environ.get(
     "LIMIT_CONCURRENT_SUBMISSION_PROCESSING"


### PR DESCRIPTION
This PR:

- [x] Disables the wrong-import position in pylint since it conflicts with isort.
- [x] Set up Django before calling the worker container.