### PR TITLE
Update Postgres Version to 16.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     image: postgres:16.8
     ports:
       - "5432:5432"
+    env_file:
+      - docker/dev/docker.env
 
   sqs:
     image: softwaremill/elasticmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:10.4
+    image: postgres:17.4
     ports:
       - "5432:5432"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:17.4
+    image: postgres:16.8
     ports:
       - "5432:5432"
 


### PR DESCRIPTION
This PR:

- Updates the Postgres Version to 16.8 in the `docker-compose.yml`

Why env file is passed in the db docker image?

**🤔 Why it works in Postgres 10.4 but not in 16.8:**

**🔸 Postgres 10.4 (older image behavior):**

- The Docker image for Postgres didn't strictly enforce password setup.
- If you didn't specify POSTGRES_PASSWORD, it would silently allow passwordless access under certain conditions.
- This was especially true if the container was isolated, or you were connecting as postgres from localhost.
- The default authentication method in the container might've been trust or peer, depending on how the image was built.

**🔸 Postgres 16.8 (modern behavior):**

- The official Postgres Docker image now requires a password unless you explicitly override it with POSTGRES_HOST_AUTH_METHOD=trust.
- It enforces stricter defaults to improve security and avoid accidental exposures.
- This change started somewhere around Postgres 12–13 in the official images. Here’s what changed:
- Stricter enforcement of required environment variables (POSTGRES_PASSWORD).
- Clear exit messages to avoid insecure defaults.