### PR TITLE
refactor: docker compose file (postgres 10 to 16.8)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
 services:
   db:
-    image: postgres:10.4
+    image: postgres:16.8
     ports:
       - "5432:5432"
+    env_file:
+      - docker/dev/docker.env
 
   sqs:
     image: softwaremill/elasticmq

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -5397,11 +5397,6 @@ class GetChallengePhasesByChallengePkTest(BaseChallengePhaseClass):
         response = self.client.get(self.url, {})
         actual_sorted = sorted(response.data, key=lambda x: x["id"])
         expected_sorted = sorted(expected, key=lambda x: x["id"])
-
-        print("\n\nACTUAL RESPONSE (sorted):")
-        print(actual_sorted)
-        print("\n\nEXPECTED (sorted):")
-        print(expected_sorted)
         self.assertEqual(actual_sorted, expected_sorted)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -5395,6 +5395,10 @@ class GetChallengePhasesByChallengePkTest(BaseChallengePhaseClass):
             },
         ]
         response = self.client.get(self.url, {})
+        print("\n\nACTUAL RESPONSE:")
+        print(response.data)
+        print("\n\nEXPECTED:")
+        print(expected)
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -5395,11 +5395,14 @@ class GetChallengePhasesByChallengePkTest(BaseChallengePhaseClass):
             },
         ]
         response = self.client.get(self.url, {})
-        print("\n\nACTUAL RESPONSE:")
-        print(response.data)
-        print("\n\nEXPECTED:")
-        print(expected)
-        self.assertEqual(response.data, expected)
+        actual_sorted = sorted(response.data, key=lambda x: x["id"])
+        expected_sorted = sorted(expected, key=lambda x: x["id"])
+
+        print("\n\nACTUAL RESPONSE (sorted):")
+        print(actual_sorted)
+        print("\n\nEXPECTED (sorted):")
+        print(expected_sorted)
+        self.assertEqual(actual_sorted, expected_sorted)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_get_challenge_phases_by_challenge_pk_when_challenge_does_not_exist(


### PR DESCRIPTION
This PR:



### 🔄 Updates

- Postgres version updated to 16.8 in `docker-compose.yml`.
- The `.env` file is now explicitly passed to the DB container to provide necessary environment variables like `POSTGRES_PASSWORD`.



🤔 Why it worked in Postgres 10.4 but not in 16.8:

 🔹 Postgres 10.4 (older behavior):
- Earlier Docker images of Postgres were more lenient with password enforcement.
- If `POSTGRES_PASSWORD` wasn’t set, the container would still run, often allowing passwordless access depending on context (e.g., local connections or isolated environments).
- The default authentication method could be `trust` or `peer`, allowing easier access in development.

🔹 Postgres 16.8 (stricter behavior):
- Newer Postgres Docker images enforce stricter security defaults.
- A password is now mandatory unless you explicitly set `POSTGRES_HOST_AUTH_METHOD=trust`.
- This change (introduced around Postgres 12–13) prevents insecure setups by:
  - Requiring `POSTGRES_PASSWORD` to be defined.
  - Failing fast with clear error messages if it's missing.

These changes enhance container security and reduce the risk of accidental exposure, but also require developers to be more explicit with DB credentials during setup.


✅ Test Case Fix:
         🔸One of the test cases was failing because the expected and actual responses were in a different order, even though 
              their contents were exactly the same.
        🔸Since the order of challenge phases isn't guaranteed in the response, the fix was to sort both the expected and actual 
              lists before asserting equality.
        🔸This makes the test more robust and prevents false negatives due to unordered data.

