### PR TITLE
Added github icon on hosted challenge page

### DIFF
--- a/apps/challenges/serializers.py
+++ b/apps/challenges/serializers.py
@@ -94,6 +94,7 @@ class ChallengeSerializer(serializers.ModelSerializer):
             "worker_image_url",
             "worker_instance_type",
             "sqs_retention_period",
+            "github_repository",
         )
 
 

--- a/frontend/src/css/modules/challenge.scss
+++ b/frontend/src/css/modules/challenge.scss
@@ -381,12 +381,12 @@ md-select .md-select-value span:first-child:after {
     li {
         margin-bottom: -0.5%;
     }
-    
+
     .nav-item {
       flex: 1;
       text-align: center;
       color: #4d4d4d;
-  
+
       .nav-link {
         display: block;
         padding: 10px 0;
@@ -397,7 +397,7 @@ md-select .md-select-value span:first-child:after {
         font-weight: 500;
         transition: border-bottom 0.3s ease;
         cursor: pointer;
-  
+
         &.active {
           border-bottom: 2px solid #000;
           color: #4d4d4d;
@@ -413,7 +413,7 @@ md-select .md-select-value span:first-child:after {
       a {
         color: #4d4d4d;
         font-weight: 400;
-  
+
         &.active {
           color: #3f51b5;
           font-weight: 600;
@@ -425,7 +425,7 @@ md-select .md-select-value span:first-child:after {
 .challenges-container {
     margin-top: 20px;
     min-height: 200px;
-  
+
   .card-content {
     padding: 20px;
     text-align: center;
@@ -436,4 +436,6 @@ md-select .md-select-value span:first-child:after {
     margin-right: 10px;
     display: inline-block;
     vertical-align: middle;
+    color: #000; // Ensure the icon is visible
+    font-size: 15px; // Adjust size if needed
 }

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -396,6 +396,7 @@
                 vm.has_sponsors = details.has_sponsors;
                 vm.queueName = details.queue;
                 vm.evaluation_module_error = details.evaluation_module_error;
+                vm.githubRepository = details.github_repository;
                 vm.getTeamName(vm.challengeId);
                 if (vm.page.image === null) {
                     vm.page.image = "dist/images/logo.png";

--- a/frontend/src/views/web/challenge/challenge-page.html
+++ b/frontend/src/views/web/challenge/challenge-page.html
@@ -93,12 +93,12 @@
                 </div>
             </div>
             <div class="col m2 l2 fs-16 w-300 center">
-                <a ng-if="(challenge.isChallengeHost ) && challenge.page.github_repository"
-                ng-href="{{ 'https://github.com/' + challenge.page.github_repository }}"
+                <a ng-if="(challenge.isChallengeHost) && challenge.githubRepository"
+                ng-href="{{ 'https://github.com/' + challenge.githubRepository }}"
                 target="_blank"
                 class="github-icon-link">
                 <i class="fa fa-github fa-2x black-text" aria-hidden="true"></i>
-             </a>   
+   </a>   
                 <button class="waves-effect waves-dark btn ev-btn-dark w-300 fs-14" type="submit"
                     ng-click="challenge.starChallenge()" ng-init="challenge.isStarred()"><i class="fa fa-star star"></i>
                     {{challenge.data}}&nbsp;&nbsp;{{challenge.count}}</button>


### PR DESCRIPTION
#FIX 4591
This PR is about adding github icon on hosted challenge page which will link to challenge repository.
<img width="1845" alt="Github Icon" src="https://github.com/user-attachments/assets/196787f9-3095-47db-b82a-f23584f14dbb" />

Changes Implemented:
Introduced a GitHub icon on each challenge page that links to the challenge's GitHub repository.
The icon is only visible to the challenge host and host team members.
The icon is conditionally rendered only if there is a valid GitHub repository for the challenge