### PR TITLE
Added test coverage for seed.py management command 

### DIFF
--- a/tests/unit/base/test_seed_command.py
+++ b/tests/unit/base/test_seed_command.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from apps.base.management.commands.seed import Command
+
+
+class TestSeedCommand(unittest.TestCase):
+
+    @patch("apps.base.management.commands.seed.call_command")
+    def test_handle_default_nc(self, mock_call_command):
+        """
+        Test that the handle() method uses the default value 20
+        when -nc is not provided.
+        """
+        command = Command()
+        command.stdout = MagicMock()
+        command.handle(**{"nc": 20})  
+        expected_msg = command.style.SUCCESS("Starting the database seeder. Hang on...")
+        command.stdout.write.assert_called_with(expected_msg)
+
+        mock_call_command.assert_called_with("runscript", "seed", "--script-args", 20)
+
+    @patch("apps.base.management.commands.seed.call_command")
+    def test_handle_custom_nc(self, mock_call_command):
+        """
+        Test that the handle() method uses the value of nc
+        provided as a command-line argument.
+        """
+        command = Command()
+        command.stdout = MagicMock()
+        command.handle(**{"nc": 5})  
+
+        expected_msg = command.style.SUCCESS("Starting the database seeder. Hang on...")
+        command.stdout.write.assert_called_with(expected_msg)
+
+        mock_call_command.assert_called_with("runscript", "seed", "--script-args", 5)
+
+    def test_add_arguments(self):
+        """
+        Test that the -nc argument is added to the parser correctly.
+        """
+        parser_mock = MagicMock()
+        command = Command()
+        command.add_arguments(parser_mock)
+
+        parser_mock.add_argument.assert_called_with(
+            "-nc",
+            nargs="?",
+            default=20,
+            type=int,
+            help="Number of challenges.",
+        )


### PR DESCRIPTION
**Fixes :** #4665

![Screenshot 2025-06-19 at 11 51 06 AM](https://github.com/user-attachments/assets/e69740af-30b2-445e-9b72-5feb7c340da6)

**This PR Covers:**

- Test that -nc argument is registered in add_arguments
- Test default behavior of handle when -nc is not provided
- Test custom behavior of handle when -nc is specified
- Achieve > 95% coverage for seed.py via coverage run and coverage report