### PR TITLE
Update .readthedocs.yml to fix the latest build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,14 +1,17 @@
 version: 2
 
-sphinx:
-  builder: html
-
-formats:
-  - epub
-  - pdf
+build:
+  os: ubuntu-22.04 # required since Oct 2023
+  tools:
+    python: "3.11"
 
 python:
-   version: 3.6
-   install:
-   - requirements: requirements/readthedocs.txt
-   system_packages: true
+  install:
+    - requirements: requirements/readthedocs.txt
+
+sphinx:
+  configuration: docs/source/conf.py
+  builder: html
+  formats:
+    - epub
+    - pdf


### PR DESCRIPTION
#### What does this PR do?

1. **Introduces a modern RTD config (`.readthedocs.yaml`)**

   * Targets the current build image `ubuntu-22.04`
   * Pins **Python 3.11** (supported range is 3.8 – 3.12)
   * Installs all docs dependencies from `requirements/readthedocs.txt`
   * Enables HTML, PDF, and ePub outputs

2. **Removes the legacy `.readthedocs.yml`**

   * The old file still referenced Python 3.6 and the now-deprecated `system_packages` key, causing every build since early 2024 to fail.

---

#### Why is this needed?

* **Broken builds → stale docs**
  RTD has been rejecting our configuration before Sphinx runs, so [https://evalai.readthedocs.io/en/latest/](https://evalai.readthedocs.io/en/latest/) is stuck at a July 2022 snapshot.
* Updating the config to spec `version: 2` unblocks the pipeline and ensures each commit to `master` automatically updates the “latest” docs.

