### PR TITLE
Fix CSS to center the text in transition banner

### DIFF
--- a/frontend/src/css/modules/main-header.scss
+++ b/frontend/src/css/modules/main-header.scss
@@ -39,7 +39,6 @@
         box-shadow: 0 0 10px $light-black;
     }
 }
-
 .announcement-banner {
     position: fixed;
     top: 0;
@@ -49,8 +48,13 @@
     z-index: 1000;
     background-color: $dark-gray;
     color: $light-gray;
-    padding: 10px 0;
     text-align: center;
+
+    display: flex;
+    justify-content: center;
+    /* horizontally center */
+    align-items: center;
+    /* vertically center */
 }
 
 @media only screen and (max-width: $med-screen) {


### PR DESCRIPTION
This PR centers the text in the transition to paid plan banner.
