### PR TITLE
Remove github branch filter from create or update github challenge

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -3897,12 +3897,8 @@ def create_or_update_github_challenge(request, challenge_host_team_pk):
         response_data = {"error": "ChallengeHostTeam does not exist"}
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
-    # Get branch name with default fallback
-    github_branch = request.data.get("GITHUB_BRANCH_NAME", "")
-
     challenge_queryset = Challenge.objects.filter(
         github_repository=request.data["GITHUB_REPOSITORY"],
-        github_branch=github_branch,
     )
 
     if challenge_queryset:


### PR DESCRIPTION
This PR adds a temporary fix to remove GitHub branch based filtering in the `create_or_update_github_challenge` method. The purpose of this is to fix the issue of a new challenge being created every time someone pushes something on a branch.