### PR TITLE
Update nodejs base image to 16.20.2-bullseye

### DIFF
--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -1,5 +1,5 @@
 # Base stage with common dependencies
-FROM node:16.20.2-bullseye AS base
+FROM node:14.21.3-bullseye AS base
 WORKDIR /code
 
 # Add dependencies

--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -1,5 +1,5 @@
 # Base stage with common dependencies
-FROM node:14.20.0-bullseye AS base
+FROM node:16.20.2-bullseye AS base
 WORKDIR /code
 
 # Add dependencies


### PR DESCRIPTION
The current image is insufficient to resolve the issue with nodejs docker container creation.

We attempt to update the base image to a newer version in order to resolve this issue.