### PR TITLE
Fix #2804: Update Baseline Submissions guide in baseline-submissions.md

### DIFF
--- a/docs/source/03-for-participants/visibility/baseline-submissions.md
+++ b/docs/source/03-for-participants/visibility/baseline-submissions.md
@@ -1,1 +1,56 @@
 # Baseline Submissions
+
+## What is a Baseline Submission?
+
+A **Baseline Submission** is a special submission created by a Challenge Host that acts as a reference point on the leaderboard.  
+Until a submission is marked as a baseline, it does not appear on the leaderboard for participants to compare their submissions.
+
+---
+
+## Why set a Baseline?
+
+- Helps participants understand the minimum standard they should surpass.
+- Provides an official benchmark to improve upon.
+- Makes the leaderboard informative and engaging.
+
+---
+
+## How to Make a Submission a Baseline Submission
+
+Follow these steps to mark a submission as a Baseline:
+
+### 1. Go to the Challenge
+
+- Navigate to your Challenge as a Host on the EvalAI platform.
+
+### 2. Open the Challenge Leaderboard
+
+- Go to the **Leaderboard** tab of your Challenge.
+
+### 3. Select the Submission
+
+- Identify the submission you want to mark as a Baseline.
+- It can be your own submission or one submitted by another user (if permissions allow).
+
+### 4. Mark as Baseline
+
+- Look for the option or button to **Mark as Baseline**.  
+  _(In the UI, it typically appears as a "B" badge or chip next to the submission on the leaderboard once marked.)_
+- Click on it to confirm.
+
+### 5. Verify
+
+- Once marked, the submission should appear on the leaderboard as a Baseline submission.
+- Participants will now see this Baseline score when viewing the leaderboard.
+
+---
+
+## Notes
+
+- You can have multiple baseline submissions if needed.
+- Only Challenge Hosts have permission to mark submissions as Baseline.
+- Unmarking a Baseline is also possible if the host wishes to update it later.
+
+---
+
+By following these steps, Challenge Hosts can ensure that participants always have a clear target to aim for during the challenge.


### PR DESCRIPTION
### Summary

- Added a new documentation page explaining how Challenge Hosts can mark submissions as baseline.
- Addressed Issue #2804

### Changes

- Created `baseline-submissions.md` under `docs/source/03-for-participants/visibility/`
- Added detailed step-by-step guide for hosts.

Thank you for reviewing this PR! 