### PR TITLE
Docs: Adds explainer on making a baseline submission

### DIFF
--- a/docs/source/03-for-participants/visibility/baseline-submissions.md
+++ b/docs/source/03-for-participants/visibility/baseline-submissions.md
@@ -1,1 +1,66 @@
 # Baseline Submissions
+
+A **Baseline Submission** is a special submission created by a Challenge Host that acts as a reference point on the leaderboard.  
+Until a submission is marked as a baseline, it does not appear on the leaderboard for participants to compare their submissions.
+
+---
+
+## Why Set a Baseline?
+
+- Helps participants understand the minimum standard they should surpass.
+- Provides an official benchmark for participants to improve upon.
+- Makes the leaderboard informative and engaging by showing a reference performance.
+
+---
+
+## How to Make a Submission Baseline
+
+Follow these steps to create, upload and mark a submission Baseline in EvalAI:
+
+### Step 1: Prepare Your Baseline Submission
+
+- Develop a solution or model that represents a reasonable starting point or minimal benchmark for the challenge.
+- Ensure your submission complies with the challenge’s submission format and requirements (e.g., correct output files, file format, metadata).
+
+### Step 2: Submit the Baseline
+
+- Log in to EvalAI as the Challenge Host.
+- Navigate to the **Challenge Dashboard** and select your challenge.
+- Go to the **Submit** tab.
+- Upload your baseline submission just like a regular participant submission.
+
+### Step 3: Open the My Submissions Tab
+
+- After the submission is uploaded, go to the **My Submissions** tab of your challenge.
+
+### Step 4: Locate the Submission
+
+- Find the submission you just uploaded and want to mark as baseline.
+
+### Step 5: Mark the Submission as Baseline
+
+- Once the submission has passed the evaluation successfully, click the checkbox in the **Baseline** column next to the submission entry, .  
+
+### Step 6: Confirm Baseline Display
+
+- The baseline submission will now appear on the leaderboard with a "B" badge indicating a Basline submission.
+- Participants will see this baseline as a reference when viewing the leaderboard.
+
+---
+
+## Managing Baseline Submissions
+
+- You can have multiple baseline submissions if your challenge requires benchmarks for different metrics or tasks.
+- Only Challenge Hosts have permission to mark or unmark submissions as baselines.
+- If needed, you can unmark or replace a baseline submission at any time by following the same steps and unchecking previous submission's **Baseline** checkbox and marking a new submission as baseline to update it.
+
+---
+
+### Note:
+
+- Choose a baseline that is meaningful and encourages participants to improve.
+- Update baseline submissions periodically if better baseline models become available.
+- Communicate clearly to participants what the baseline represents in the challenge overview or description.
+
+
+---


### PR DESCRIPTION
This PR adds a content in the previously empty doc `baseline_submission.md` breaking down the process of making a submission baseline.

fixes #4755 