### PR TITLE
Filter out disabled challenges for create/update challenge

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -3899,7 +3899,7 @@ def create_or_update_github_challenge(request, challenge_host_team_pk):
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     challenge_queryset = Challenge.objects.filter(
-        github_repository=request.data["GITHUB_REPOSITORY"],
+        github_repository=request.data["GITHUB_REPOSITORY"], is_disabled=False
     )
 
     if challenge_queryset:


### PR DESCRIPTION
This PR adds a check to the method that creates or updates a GitHub challenge to filter out the disabled challenges so that the hosts are unable to update them. 

This is needed because of a recent issue with duplicate challenges being created on multiple updates of the same challenge.
