### PR TITLE
Update Celery Dockerfile to use 'latest' tag for backend image

### DIFF
--- a/docker/prod/celery/Dockerfile
+++ b/docker/prod/celery/Dockerfile
@@ -2,6 +2,6 @@ ARG AWS_ACCOUNT_ID
 ARG COMMIT_ID
 ARG TRAVIS_BRANCH
 
-FROM ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/evalai-${TRAVIS_BRANCH}-backend:${COMMIT_ID}
+FROM ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/evalai-${TRAVIS_BRANCH}-backend:latest
 
 CMD ["sh", "/code/docker/prod/celery/container-start.sh"]


### PR DESCRIPTION
- Update Celery Dockerfile to use 'latest' tag for backend image