### PR TITLE
Improve pylint score and code quality for accounts module

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -1,12 +1,12 @@
-from allauth.account.admin import EmailAddressAdmin
+from allauth.account.admin import EmailAddressAdmin as AllAuthEmailAdmin
 from allauth.account.models import EmailAddress
 from base.admin import ImportExportTimeStampedAdmin
 from django.contrib import admin
-from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 from django.contrib.auth.models import User
 from import_export import resources
 from import_export.admin import ExportMixin
-from rest_framework.authtoken.admin import TokenAdmin
+from rest_framework.authtoken.admin import TokenAdmin as RestTokenAdmin
 from rest_framework.authtoken.models import Token
 
 from .models import JwtToken, Profile
@@ -39,6 +39,7 @@ class ProfileAdmin(ImportExportTimeStampedAdmin):
     )
 
 
+# --------------------- User Admin ---------------------
 class UserResource(resources.ModelResource):
     class Meta:
         model = User
@@ -54,29 +55,31 @@ class UserResource(resources.ModelResource):
         )
 
 
-class UserAdmin(ExportMixin, UserAdmin):
+class CustomUserAdmin(ExportMixin, DjangoUserAdmin):
     resource_class = UserResource
 
 
 admin.site.unregister(User)
-admin.site.register(User, UserAdmin)
+admin.site.register(User, CustomUserAdmin)
 
 
+# --------------------- Token Admin ---------------------
 class TokenResource(resources.ModelResource):
     class Meta:
         model = Token
 
 
-class TokenAdmin(TokenAdmin):
+class CustomTokenAdmin(RestTokenAdmin):
     resource_class = TokenResource
     list_filter = ("created",)
     search_fields = ("user__username",)
 
 
 admin.site.unregister(Token)
-admin.site.register(Token, TokenAdmin)
+admin.site.register(Token, CustomTokenAdmin)
 
 
+# --------------------- JwtToken Admin ---------------------
 @admin.register(JwtToken)
 class JwtTokenAdmin(ImportExportTimeStampedAdmin):
     list_display = (
@@ -87,18 +90,15 @@ class JwtTokenAdmin(ImportExportTimeStampedAdmin):
     search_fields = ("user__username",)
 
 
-admin.site.unregister(JwtToken)
-admin.site.register(JwtToken, JwtTokenAdmin)
-
-
+# --------------------- EmailAddress Admin ---------------------
 class EmailAddressResource(resources.ModelResource):
     class Meta:
         model = EmailAddress
 
 
-class EmailAddressAdmin(ExportMixin, EmailAddressAdmin):
+class CustomEmailAddressAdmin(ExportMixin, AllAuthEmailAdmin):
     resource_class = EmailAddressResource
 
 
 admin.site.unregister(EmailAddress)
-admin.site.register(EmailAddress, EmailAddressAdmin)
+admin.site.register(EmailAddress, CustomEmailAddressAdmin)

--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -27,7 +27,7 @@ class UserStatus(TimeStampedModel):
     status = models.CharField(max_length=30, unique=True)
 
     def __str__(self):
-        return self.name
+        return str(self.name)  # Ensure string is returned
 
     class Meta:
         app_label = "accounts"
@@ -48,7 +48,7 @@ class Profile(TimeStampedModel):
     linkedin_url = models.URLField(max_length=200, null=True, blank=True)
 
     def __str__(self):
-        return "{}".format(self.user)
+        return str(self.user.username)  # Return a string, not a User object
 
     class Meta:
         app_label = "accounts"
@@ -65,7 +65,7 @@ class JwtToken(TimeStampedModel):
     refresh_token = models.CharField(max_length=512, blank=False, null=True)
 
     def __str__(self):
-        return "{}".format(self.user)
+        return str(self.user.username)  # Return string
 
     class Meta:
         app_label = "accounts"


### PR DESCRIPTION
## Description

This PR improves the pylint score for the `accounts` module by addressing common code-quality issues, as part of issue #4557.

## Changes Made

- Fixed `__str__` method in `UserStatus` model to return `str(self.name)` instead of `self.name`.
- Renamed conflicting admin classes to avoid redefinition errors:
  - `UserAdmin` → `CustomUserAdmin`
  - `TokenAdmin` → `CustomTokenAdmin`
  - `EmailAddressAdmin` → `CustomEmailAddressAdmin`
- Replaced old-style string formatting with f-strings in `views.py`.
- Fixed typo: `recieve_newsletter` → `receive_newsletter`.
- Improved search fields in `ProfileAdmin`.
- Minor pylint convention fixes (`else` after `return`, line length, simplifiable `if` statements).

## Pylint Score Improvements
<img width="758" height="70" alt="image" src="https://github.com/user-attachments/assets/1ab2a3d1-f7f9-423d-a1e1-71e633ff7069" />

- Accounts module: Improved from 0.04/10 to **9.55/10**.
- Overall pylint score: **8.31/10**, above the target of 7.5.

## Testing

- All models import successfully.
- No error-level pylint issues remaining.
- Local testing passed.

Fixes #4557
