### PR TITLE
Fix #4820: Add retry logic to apt-get install commands to handle transient network failures

### DIFF
--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -48,12 +48,16 @@ RUN npm install --only=production --no-audit --no-fund --prefer-offline --progre
 FROM base AS amd64
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
-    apt-get update && apt-get install -yq google-chrome-stable libxss1 && \
+    apt-get update && \
+    (apt-get install -yq google-chrome-stable libxss1 || \
+     (apt-get update && apt-get install -yq --fix-missing google-chrome-stable libxss1)) && \
     rm -rf /var/lib/apt/lists/*
 
 # ARM64-specific stage
 FROM base AS arm64
-RUN apt-get update && apt-get install -yq chromium libxss1 && \
+RUN apt-get update && \
+    (apt-get install -yq chromium libxss1 || \
+     (apt-get update && apt-get install -yq --fix-missing chromium libxss1)) && \
     ln -sf /usr/bin/chromium /usr/bin/google-chrome && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/prod/nodejs/Dockerfile
+++ b/docker/prod/nodejs/Dockerfile
@@ -46,7 +46,9 @@ RUN bower install --allow-root
 # Install Chrome for testing (if needed)
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
-    apt-get update && apt-get install -yq google-chrome-stable libxss1 && \
+    apt-get update && \
+    (apt-get install -yq google-chrome-stable libxss1 || \
+     (apt-get update && apt-get install -yq --fix-missing google-chrome-stable libxss1)) && \
     rm -rf /var/lib/apt/lists/*
 
 # Set Chrome environment variables for production


### PR DESCRIPTION
## Description
This PR adds retry logic to `apt-get install` commands in both development and production Dockerfiles to handle transient network connection failures during package downloads.

## Changes Made
- ✅ Added retry logic with `--fix-missing` flag to AMD64 stage (Chrome installation)
- ✅ Added retry logic with `--fix-missing` flag to ARM64 stage (Chromium installation)
- ✅ Applied changes to both `Dockerfile.dev` and `Dockerfile` for consistency
- ✅ Maintained existing build optimizations and configurations

## Technical Details
The fix implements a two-attempt strategy using the `||` (OR) operator:
1. **First attempt**: Normal `apt-get install` execution
2. **Fallback**: If first attempt fails, updates package lists and retries with `--fix-missing` flag

### Before:
```dockerfile
RUN apt-get update && apt-get install -yq google-chrome-stable libxss1 && \
    rm -rf /var/lib/apt/lists/*
    
    
this fixes #4820 