### PR TITLE
Fix #4822: Add dismissible close button to announcement banner

### DIFF
--- a/frontend/src/css/modules/main-header.scss
+++ b/frontend/src/css/modules/main-header.scss
@@ -55,6 +55,33 @@
     /* horizontally center */
     align-items: center;
     /* vertically center */
+
+    .close-banner-btn {
+        position: absolute;
+        top: 10px;
+        right: 15px;
+        background: transparent;
+        border: none;
+        color: $light-gray;
+        font-size: 32px;
+        font-weight: bold;
+        cursor: pointer;
+        padding: 0;
+        width: 30px;
+        height: 30px;
+        line-height: 30px;
+        transition: all 0.2s ease-in-out;
+        opacity: 0.8;
+
+        &:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        &:focus {
+            outline: none;
+        }
+    }
 }
 
 @media only screen and (max-width: $med-screen) {

--- a/frontend/src/views/web/partials/main-header.html
+++ b/frontend/src/views/web/partials/main-header.html
@@ -1,4 +1,7 @@
-<div class="announcement-banner">
+<div class="announcement-banner" id="announcement-banner">
+    <button class="close-banner-btn" onclick="document.getElementById('announcement-banner').style.display='none'; document.querySelector('.main-header nav').style.top='0';" aria-label="Close announcement">
+        ×
+    </button>
     <div style="max-width: 960px; margin: 0 auto;">
         🚨 <strong>Update:</strong> EvalAI is transitioning to a paid plan for hosting challenges and is sunsetting
         support for code-upload and static code-upload challenges. If you are planning to host a new challenge, please get in touch at


### PR DESCRIPTION
## Description
This PR adds a close button to the announcement banner, allowing users to dismiss it when desired.

## Changes Made
- Added a close button (×) in the top-right corner of the announcement banner
- Implemented dismiss functionality that hides the banner on click
- Added CSS styling for the close button with hover effects
- Adjusted main header position when banner is dismissed

## Files Modified
- `frontend/src/views/web/partials/main-header.html` - Added close button element with onclick handler
- `frontend/src/css/modules/main-header.scss` - Added styling for the close button

## Related Issue
Fixes #4822 
<img width="1593" height="742" alt="Screenshot 2025-11-30 135341" src="https://github.com/user-attachments/assets/13ba7df5-bebc-4a77-8af5-6befb3f93c47" />
<img width="1594" height="745" alt="Screenshot 2025-11-30 135321" src="https://github.com/user-attachments/assets/4885eda1-2dd2-4b77-8c17-6d1944940a3d" />

