### PR TITLE
Add placeholder content to empty Setup pages (Linux, Windows, macOS, Docker)

### DIFF
--- a/docs/source/01-getting-started/setup/docker-setup.md
+++ b/docs/source/01-getting-started/setup/docker-setup.md
@@ -1,3 +1,5 @@
 # Docker Setup
 
-Guide to setup EvalAI using Docker.
+This page will contain detailed instructions for setting up EvalAI using Docker.
+
+**Work in progress — contributions welcome!**

--- a/docs/source/01-getting-started/setup/linux-setup.md
+++ b/docs/source/01-getting-started/setup/linux-setup.md
@@ -1,3 +1,5 @@
 # Linux Setup
 
-Guide to setup EvalAI on Linux.
+This page will contain detailed instructions for setting up EvalAI on Linux systems.
+
+**Work in progress — contributions welcome!**

--- a/docs/source/01-getting-started/setup/macos-setup.md
+++ b/docs/source/01-getting-started/setup/macos-setup.md
@@ -1,3 +1,5 @@
-# MacOS Setup
+# macOS Setup
 
-Guide to setup EvalAI on MacOS.
+This page will contain detailed instructions for setting up EvalAI on macOS.
+
+**Work in progress — contributions welcome!**

--- a/docs/source/01-getting-started/setup/windows-setup.md
+++ b/docs/source/01-getting-started/setup/windows-setup.md
@@ -1,3 +1,5 @@
 # Windows Setup
 
-Guide to setup EvalAI on Windows.
+This page will contain detailed instructions for setting up EvalAI on Windows.
+
+**Work in progress — contributions welcome!**


### PR DESCRIPTION
This PR fixes issue #4826 by adding basic placeholder content to the empty Setup pages under docs/source/setup/.
This ensures the pages are not blank on ReadTheDocs and improves navigation for new contributors.
