### PR TITLE
Fix #4830: Prevent multiple public submissions using atomic DB locking

### DIFF
--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -3,6 +3,8 @@ import json
 import logging
 import os
 import uuid
+from django.db import transaction
+
 
 import botocore
 from accounts.permissions import HasVerifiedEmail


### PR DESCRIPTION
Fixes #4830

### Summary
When `is_restricted_to_select_one_submission=True`, concurrent requests that toggle submission visibility can result in multiple submissions being marked as public. This is caused by a non-atomic `count()` check that allows two parallel requests to observe stale state and both proceed, leading to more than one public submission.

### Root Cause
The existing logic performs:
```python
submissions_already_public.count() == 1
