### PR TITLE
Fix #4706: Replace deprecated cloudcv.org domain with eval.ai across codebase

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
-contacting a project maintainer at [admin@cloudcv.org](mailto:admin@cloudcv.org). All complaints will
+contacting a project maintainer at [admin@eval.ai](mailto:admin@eval.ai). All complaints will
 be reviewed and investigated and will result in a response that is deemed necessary and
 appropriate to the circumstances. Maintainers are obligated to maintain confidentiality
 with regard to the reporter of an incident.

--- a/apps/accounts/templates/account/email_confirm.html
+++ b/apps/accounts/templates/account/email_confirm.html
@@ -63,7 +63,7 @@
                 <a href="https://github.com/Cloud-CV/EvalAI" class="light-link" target="_blank"><i
                         class="fa fa-github"></i></a> &nbsp;&nbsp;&nbsp;<a href="https://twitter.com/eval_ai"
                     class="light-link" target="_blank"><i class="fa fa-twitter"></i></a> &nbsp;&nbsp;&nbsp; <a
-                    href="https://cloudcv.org/" class="light-link fg-pass" target="_blank">www.cloudcv.org</a>
+                    href="https://eval.ai" class="light-link fg-pass" target="_blank">www.eval.ai</a>
                 &nbsp;&nbsp;&nbsp; <a ui-sref="home" class="light-link fg-pass">Back to home</a>
             </div>
         </div>

--- a/docs/source/02-for-challenge-hosts/hosting-guide/host-challenge.md
+++ b/docs/source/02-for-challenge-hosts/hosting-guide/host-challenge.md
@@ -101,7 +101,7 @@ Finally run the `./run.sh` script in the bundle. It will generate a `challenge_c
 
 **Congratulations!** you have submitted your challenge configuration for review and [EvalAI team](https://eval.ai/team) has notified about this. [EvalAI team](https://eval.ai/team) will review and will approve the challenge.
 
-If you have issues in creating a challenge on EvalAI, please feel free to contact us at [team@cloudcv.org](mailto:team@cloudcv.org) create an issue on our [GitHub issues page](https://github.com/Cloud-CV/EvalAI/issues/new).
+If you have issues in creating a challenge on EvalAI, please feel free to contact us at [team@eval.ai](mailto:team@eval.ai) create an issue on our [GitHub issues page](https://github.com/Cloud-CV/EvalAI/issues/new).
 
 ## Host a remote evaluation challenge
 
@@ -144,7 +144,7 @@ Please refer to <a href="../evaluation/remote-evaluation.html#writing-an-remote-
    python main.py
    ```
 
-If you have issues in creating a challenge on EvalAI, please feel free to contact us at [team@cloudcv.org](mailto:team@cloudcv.org) create an issue on our [GitHub issues page](https://github.com/Cloud-CV/EvalAI/issues/new).
+If you have issues in creating a challenge on EvalAI, please feel free to contact us at [team@eval.ai](mailto:team@eval.ai) create an issue on our [GitHub issues page](https://github.com/Cloud-CV/EvalAI/issues/new).
 
 [evalai-starters]: https://github.com/Cloud-CV/EvalAI-Starters
 [evalai-cli]: https://cli.eval.ai/

--- a/frontend/src/views/web/about-us.html
+++ b/frontend/src/views/web/about-us.html
@@ -6,7 +6,7 @@
             <div class="col s12 m8 ev-about-us">
                 <h4 class="text-dark-black"><strong>About Us</strong></h4>
                 <p class="text-med-black">EvalAI is built by a team of open source enthusiasts working at
-                    <a href="https://cloudcv.org" class="blue-text" target="_blank">CloudCV</a>. CloudCV aims to make AI research
+                    <a href="https://eval.ai" class="blue-text" target="_blank">EvalAI</a>. EvalAI aims to make AI research
                     reproducible and easily accessible. We want to reduce the barrier to entry for doing research
                     and make it easier for researchers, students and developers to develop and use state-of-the-art
                     algorithms as a service.</p>

--- a/frontend/src/views/web/auth/auth.html
+++ b/frontend/src/views/web/auth/auth.html
@@ -35,7 +35,7 @@
         </div>
         <div class="row">
             <div class="reg-alert col s12 m6 offset-m3 align-left text-highlight w-300 social-auth-group">
-              <a href="https://github.com/Cloud-CV/EvalAI" class="light-link" target="_blank"><i class="fa fa-github"></i></a> &nbsp;&nbsp;&nbsp;<a href="https://twitter.com/eval_ai" class="light-link" target="_blank"><i class="fa fa-twitter"></i></a> &nbsp;&nbsp;&nbsp; <a href="https://www.cloudcv.org/" class="light-link fg-pass" target="_blank">www.cloudcv.org</a> &nbsp;&nbsp;&nbsp; <a ui-sref="home" class="light-link fg-pass">Back to home</a>
+              <a href="https://github.com/Cloud-CV/EvalAI" class="light-link" target="_blank"><i class="fa fa-github"></i></a> &nbsp;&nbsp;&nbsp;<a href="https://twitter.com/eval_ai" class="light-link" target="_blank"><i class="fa fa-twitter"></i></a> &nbsp;&nbsp;&nbsp; <a href="https://eval.ai" class="light-link fg-pass" target="_blank">www.eval.ai</a> &nbsp;&nbsp;&nbsp; <a ui-sref="home" class="light-link fg-pass">Back to home</a>
             </div>
         </div>
     </div>

--- a/frontend/src/views/web/challenge/evaluation.html
+++ b/frontend/src/views/web/challenge/evaluation.html
@@ -5,7 +5,7 @@
             <div class="col s12 m12 l12">To access evaluation logs and manage the evalaution worker please go to the <b>Manage</b> tab.
                 To update the evaluation script use the <b>Upload</b> option on Evalaution tab.
                 If you have any questions, please feel free to reach out to us at 
-                <a href="mailto:team@cloudcv.org" class="blue-text">team@cloudcv.org</a>
+                <a href="mailto:team@eval.ai" class="blue-text">team@eval.ai</a>
             </div>
         </div>
     </div>

--- a/frontend/src/views/web/challenge/manage.html
+++ b/frontend/src/views/web/challenge/manage.html
@@ -3,7 +3,7 @@
         <div class="row margin-bottom-cancel">
             <div class="col s12 m12 l12">
                 <div class="w-300 fs-16"><strong>Note: </strong>We have auto-scaling and auto-allocation features in place which assess the resource requirement for your challenge based on previous submissions.
-                    Ideally, you should not need any manual intervention for scaling the worker. However, in case your evaluation requires additional resources or you face any issues, please email us at <a href="mailto:admin@cloudcv.org" class="blue-text">admin@cloudcv.org</a>.
+                    Ideally, you should not need any manual intervention for scaling the worker. However, in case your evaluation requires additional resources or you face any issues, please email us at <a href="mailto:admin@eval.ai" class="blue-text">admin@eval.ai</a>.
                 </div>
             </div>
         </div>

--- a/frontend/src/views/web/get-involved.html
+++ b/frontend/src/views/web/get-involved.html
@@ -14,19 +14,19 @@
                     <p> If you identify a bug or run into issues while using the website, or you'd like to suggest some new features 
                         or want to get in touch with us, feel free to reach out via our 
                         <a href="https://groups.google.com/forum/#!forum/evalai" class="blue-text" target="_blank">EvalAI Google Group</a>, 
-                        or contact us at <a href="mailto:team@cloudcv.org" class="blue-text">team@cloudcv.org</a>.</p>
+                        or contact us at <a href="mailto:team@eval.ai" class="blue-text">team@eval.ai</a>.</p>
                     <h5 align="left" class="text-dark-black"><strong>Improving and maintaining the site</strong></h5>
                     <p>The EvalAI project is fully open source, and is maintained by a large community of volunteers on <a href="https://github.com/Cloud-CV/EvalAI" class="blue-text" target="_blank">GitHub</a>. 
                         We are in need of coders and designers so if you would like to help out, please drop us a line! 
-                        The best way to get started is to write us at <a href="mailto:team@cloudcv.org" class="blue-text">team@cloudcv.org</a> 
+                        The best way to get started is to write us at <a href="mailto:team@eval.ai" class="blue-text">team@eval.ai</a> 
                         or ping us on our <a href="https://gitter.im/Cloud-CV/EvalAI" class="blue-text" target="_blank">Gitter Channel</a>.</p>
                     <h5 align="left" class="text-dark-black"><strong>Press</strong></h5>
                     <p> If you're a journalist who would like to help spread the word about EvalAI or CloudCV, 
-                        please email <a href="mailto:admin@cloudcv.org" class="blue-text">admin@cloudcv.org</a>.</p>
+                        please email <a href="mailto:admin@eval.ai" class="blue-text">admin@eval.ai</a>.</p>
                     <h5 align="left" class="text-dark-black"><strong>Partnership</strong></h5>
                     <p> If you are interested in partnering with us to make a bigger impact on the research community, 
                         or want to host a challenge of your own, please email 
-                        <a href="mailto:admin@cloudcv.org" class="blue-text">admin@cloudcv.org</a>. </p>
+                        <a href="mailto:admin@eval.ai" class="blue-text">admin@eval.ai</a>. </p>
                 </div>
                 <div ng-include="'dist/views/web/partials/rocket-container.html'"></div>
             </div>

--- a/frontend/src/views/web/partials/dashboard-footer.html
+++ b/frontend/src/views/web/partials/dashboard-footer.html
@@ -18,7 +18,7 @@
                     <li><a class="text-light-gray" ui-sref="our-team">Our Team</a></li>
                     <li><a class="text-light-gray" ui-sref="get-involved">Get Involved</a></li>
                     <li><a class="text-light-gray" ui-sref="privacy_policy">Privacy Policy</a></li>
-                    <li><a class="text-light-gray" href="https://cloudcv.org">CloudCV Website</a></li>
+                    <li><a class="text-light-gray" href="https://eval.ai">EvalAI Website</a></li>
                 </ul>
             </div>
             <div class="col l2 s12">

--- a/frontend/src/views/web/partials/footer.html
+++ b/frontend/src/views/web/partials/footer.html
@@ -19,7 +19,7 @@
                     <li><a class="text-light-gray" ui-sref="our-team">Our Team</a></li>
                     <li><a class="text-light-gray" ui-sref="get-involved">Get Involved</a></li>
                     <li><a class="text-light-gray" ui-sref="privacy_policy">Privacy Policy</a></li>
-                    <li><a class="text-light-gray" href="https://cloudcv.org">CloudCV Website</a></li>
+                    <li><a class="text-light-gray" href="https://eval.ai">EvalAI Website</a></li>
                 </ul>
             </div>
             <div class="col l2 s12">

--- a/frontend/src/views/web/privacy-policy.html
+++ b/frontend/src/views/web/privacy-policy.html
@@ -78,15 +78,15 @@
                     <li style="list-style-type: circle;">Send information, respond to inquiries, and/or other requests or questions</li>
                 </ul>
                 <p><b>To be in accordance with CANSPAM, we agree to the following:</b></p>
-                <p>If at any time you would like to unsubscribe from receiving future emails, you can email us at <a style="color: #0000EE" href="mailto:admin@cloudcv.org">admin@cloudcv.org</a> and we will promptly remove you from <b>ALL</b> correspondence.</p>
+                <p>If at any time you would like to unsubscribe from receiving future emails, you can email us at <a style="color: #0000EE" href="mailto:admin@eval.ai">admin@eval.ai</a> and we will promptly remove you from <b>ALL</b> correspondence.</p>
                 <p><b>How can users get their data deleted from EvalAI?</b></p>
-                <p>In order to get user data deleted from EvalAI you can email us at <a style="color: #0000EE" href="mailto:admin@cloudcv.org">admin@cloudcv.org</a> with your EvalAI account email id and we will promptly delete all of your data from <b>EvalAI</b>.</p>
+                <p>In order to get user data deleted from EvalAI you can email us at <a style="color: #0000EE" href="mailto:admin@eval.ai">admin@eval.ai</a> with your EvalAI account email id and we will promptly delete all of your data from <b>EvalAI</b>.</p>
                 <p><b>Contacting Us</b></p>
                 <p>If there are any questions regarding this privacy policy, you may contact us using the information below.
                 </p>
                 <p>EvalAI
                     <br>
-                    <a style="color: #0000EE" href="mailto:admin@cloudcv.org">admin@cloudcv.org</a>
+                    <a style="color: #0000EE" href="mailto:admin@eval.ai">admin@eval.ai</a>
                     <br> Last Edited on 2017-05-29</p>
             </div>
             <div ng-include="'dist/views/web/partials/rocket-container.html'"></div>

--- a/frontend_v2/src/app/components/about/about.component.html
+++ b/frontend_v2/src/app/components/about/about.component.html
@@ -6,7 +6,7 @@
       <h4 class="about-title">About Us</h4>
       <p class="about-content text-med-black fw-light">
         EvalAI is built by a team of open source enthusiasts working at
-        <a href="http://cloudcv.org" target="_blank" class="blue-text">CloudCV</a>. CloudCV aims to make AI research
+        <a href="https://eval.ai" target="_blank" class="blue-text">EvalAI</a>. EvalAI aims to make AI research
         reproducible and easily accessible. We want to reduce the barrier to entry for doing research and make it easier
         for researchers, students and developers to develop and use state-of-the-art algorithms as a service.
       </p>

--- a/frontend_v2/src/app/components/auth/auth.component.html
+++ b/frontend_v2/src/app/components/auth/auth.component.html
@@ -41,7 +41,7 @@
           ><i class="fa fa-twitter"></i
         ></a>
         &nbsp;&nbsp;&nbsp;
-        <a href="http://www.cloudcv.org/" class="light-link fg-pass" target="_blank">www.cloudcv.org</a>
+        <a href="https://eval.ai" class="light-link fg-pass" target="_blank">www.eval.ai</a>
         &nbsp;&nbsp;&nbsp; <a routerLink="/" class="light-link fg-pass">Back to home</a>
       </div>
     </div>

--- a/frontend_v2/src/app/components/challenge/challenge.component.html
+++ b/frontend_v2/src/app/components/challenge/challenge.component.html
@@ -11,8 +11,8 @@
                 <div class="row margin-bottom-cancel">
                     <div class="col s12 m12 l12">Thank you for successfully creating a challenge on EvalAI.
                         The challenge is ready to accept submissions from host the team. Please note that the submissions from the host team won't be visible on leaderboard until you mark them as baseline submission.
-                        In order for the challenge to accept submissions from the public, it requires approval from the EvalAI Team. Please reach out to us at 
-                        <a href="mailto:team@cloudcv.org" class="blue-text">team@cloudcv.org</a> for challenge approval.
+                        In order for the challenge to accept submissions from the public, it requires approval from the EvalAI Team. Please reach out to us at
+                        <a href="mailto:team@eval.ai" class="blue-text">team@eval.ai</a> for challenge approval.
                     </div>
                 </div>
             </div>

--- a/frontend_v2/src/app/components/challenge/challengesettings/challengesettings.component.html
+++ b/frontend_v2/src/app/components/challenge/challengesettings/challengesettings.component.html
@@ -5,7 +5,7 @@
         <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12 content">
           <div class="fs-16 fw-light"><strong>Note:</strong> By default, we allocate 0.25 vCPU and 0.5 GB memory
           to each challenge evaluation worker. In case your evaluation requires additional resources,
-          please email us at <a href="mailto:admin@cloudcv.org" class="blue-text">admin@cloudcv.org</a>.</div>
+          please email us at <a href="mailto:admin@eval.ai" class="blue-text">admin@eval.ai</a>.</div>
         </div>
       </div>
     </div>
@@ -179,7 +179,7 @@
                   <strong class="text-light-black">Phase Details </strong>
                 </span>
                 <a class="pointer fs-16" (click)="editPhaseDetails()">
-                  <i class="fa fa-pencil" aria-hidden="true"> </i> 
+                  <i class="fa fa-pencil" aria-hidden="true"> </i>
                 </a>&nbsp;&nbsp;&nbsp;
                 <a class="pointer fs-16" (click) = "editPhaseDetailsUpload()">
                   <i class="fa fa-upload" aria-hidden="true"> </i></a
@@ -299,7 +299,7 @@
                   <strong class="text-light-black">Evaluation Criteria </strong>
                 </span>
                 <a class="pointer fs-16" (click)="editEvaluationCriteria()">
-                  <i class="fa fa-pencil" aria-hidden="true"> </i> 
+                  <i class="fa fa-pencil" aria-hidden="true"> </i>
                 </a>&nbsp;&nbsp;&nbsp;
                 <a class="pointer fs-16" (click) = "editEvaluationCriteriaUpload()">
                   <i class="fa fa-upload" aria-hidden="true"> </i>

--- a/frontend_v2/src/app/components/get-involved/get-involved.component.html
+++ b/frontend_v2/src/app/components/get-involved/get-involved.component.html
@@ -19,26 +19,26 @@
             or want to get in touch with us, feel free to reach out via our
             <a href="https://groups.google.com/forum/#!forum/evalai" class="blue-text" target="_blank"
               >EvalAI Google Group</a
-            >, or contact us at <a href="mailto:team@cloudcv.org" class="blue-text">team@cloudcv.org</a>.
+            >, or contact us at <a href="mailto:team@eval.ai" class="blue-text">team@eval.ai</a>.
           </p>
           <h5 class="align-left" class="text-dark-black"><strong>Improving and maintaining the site</strong></h5>
           <p class="text-med-black fw-light">
             The EvalAI project is fully open source, and is maintained by a large community of volunteers on
             <a href="https://github.com/Cloud-CV/EvalAI" class="blue-text" target="_blank">GitHub</a>. We are in need of
             coders and designers so if you would like to help out, please drop us a line! The best way to get started is
-            to write us at <a href="mailto:team@cloudcv.org" class="blue-text">team@cloudcv.org</a> or ping us on our
+            to write us at <a href="mailto:team@eval.ai" class="blue-text">team@eval.ai</a> or ping us on our
             <a href="https://gitter.im/Cloud-CV/EvalAI" class="blue-text" target="_blank">Gitter Channel</a>.
           </p>
           <h5 class="align-left" class="text-dark-black"><strong>Press</strong></h5>
           <p class="text-med-black fw-light">
             If you're a journalist who would like to help spread the word about EvalAI or CloudCV, please email
-            <a href="mailto:admin@cloudcv.org" class="blue-text">admin@cloudcv.org</a>.
+            <a href="mailto:admin@eval.ai" class="blue-text">admin@eval.ai</a>.
           </p>
           <h5 class="align-left" class="text-dark-black"><strong>Partnership</strong></h5>
           <p class="text-med-black fw-light">
             If you are interested in partnering with us to make a bigger impact on the research community, or want to
             host a challenge of your own, please email
-            <a href="mailto:admin@cloudcv.org" class="blue-text">admin@cloudcv.org</a>.
+            <a href="mailto:admin@eval.ai" class="blue-text">admin@eval.ai</a>.
           </p>
         </div>
         <div class="col s12 m4 l4">

--- a/frontend_v2/src/app/components/nav/footer/footer.component.html
+++ b/frontend_v2/src/app/components/nav/footer/footer.component.html
@@ -28,7 +28,7 @@
           <li><a class="text-light-gray" routerLink="/our-team">Our Team</a></li>
           <li><a class="text-light-gray" routerLink="/get-involved">Get Involved</a></li>
           <li><a class="text-light-gray" routerLink="/privacy-policy">Privacy Policy</a></li>
-          <li><a class="text-light-gray" href="http://cloudcv.org">CloudCV Website</a></li>
+          <li><a class="text-light-gray" href="https://eval.ai">EvalAI Website</a></li>
         </ul>
       </div>
       <div class="col l2 s12">

--- a/frontend_v2/src/app/components/privacy-policy/privacy-policy.component.html
+++ b/frontend_v2/src/app/components/privacy-policy/privacy-policy.component.html
@@ -306,14 +306,14 @@
       </div>
       <p class="privacy-section-content">
         If at any time you would like to unsubscribe from receiving future emails, you can email us at
-        <a class="blue-text" href="mailto:admin@cloudcv.org">admin@cloudcv.org</a> and we will promptly remove you from
+        <a class="blue-text" href="mailto:admin@eval.ai">admin@eval.ai</a> and we will promptly remove you from
         <b>ALL</b> correspondence.
       </p>
       <div class="privacy-section-title">
         How can users get their data deleted from EvalAI?
       </div>
       <p class="privacy-section-content">
-        In order to get user data deleted from EvalAI you can email us at <a style="color: #0000EE" href="mailto:admin@cloudcv.org">admin@cloudcv.org</a> with your EvalAI account email id and we will promptly delete all of your data from <b>EvalAI</b>.
+        In order to get user data deleted from EvalAI you can email us at <a style="color: #0000EE" href="mailto:admin@eval.ai">admin@eval.ai</a> with your EvalAI account email id and we will promptly delete all of your data from <b>EvalAI</b>.
       </p>
       <div class="privacy-section-title">
         Contacting Us
@@ -324,7 +324,7 @@
       <p class="privacy-section-content">
         EvalAI
         <br />
-        <a href="mailto:admin@cloudcv.org">admin@cloudcv.org</a>
+        <a href="mailto:admin@eval.ai">admin@eval.ai</a>
         <br />
         Last Edited on 2017-05-29
       </p>

--- a/settings/common.py
+++ b/settings/common.py
@@ -296,7 +296,7 @@ REST_AUTH_SERIALIZERS = {
 }
 
 # For inviting users to participant and host teams.
-ADMIN_EMAIL = "admin@cloudcv.org"
+ADMIN_EMAIL = "admin@eval.ai"
 CLOUDCV_TEAM_EMAIL = "team@eval.ai"
 
 # Expiry time of a presigned url for uploading files to AWS, in seconds.

--- a/settings/prod.py
+++ b/settings/prod.py
@@ -62,7 +62,7 @@ MEDIA_URL = "http://%s.s3.amazonaws.com/%s/" % (
 DEFAULT_FILE_STORAGE = "settings.custom_storages.MediaStorage"
 
 # Setup Email Backend related settings
-DEFAULT_FROM_EMAIL = "noreply@cloudcv.org"
+DEFAULT_FROM_EMAIL = "noreply@eval.ai"
 EMAIL_BACKEND = "django_ses.SESBackend"
 EMAIL_HOST = os.environ.get("EMAIL_HOST")
 EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")


### PR DESCRIPTION
## Description
This PR fixes #4706 by replacing all references to the deprecated `cloudcv.org` domain with the active `eval.ai` domain throughout the codebase. The `cloudcv.org` website is no longer functional, causing broken links on the LinkedIn page, GitHub profile, and throughout the application.

## Motivation and Context
Fixes #4706 

The `cloudcv.org` domain is no longer active, which creates a poor user experience and makes it difficult for new users and contributors to find official resources or contact the team. This issue affects:
- User-facing website links in footers and headers
- Contact email addresses in multiple components
- Documentation and contribution guidelines
- Email sender configuration in production settings

## Changes Made

### Frontend (v2 & Legacy)
- **Navigation & Footers**: Updated website links in [`footer.component.html`](frontend_v2/src/app/components/nav/footer/footer.component.html), [`dashboard-footer.html`](frontend/src/views/web/partials/dashboard-footer.html), and [`footer.html`](frontend/src/views/web/partials/footer.html)
- **Auth Pages**: Fixed links in [`auth.component.html`](frontend_v2/src/app/components/auth/auth.component.html) and [`auth.html`](frontend/src/views/web/auth/auth.html)
- **About Pages**: Updated branding and links in [`about.component.html`](frontend_v2/src/app/components/about/about.component.html) and [`about-us.html`](frontend/src/views/web/about-us.html)
- **Community Pages**: 
  - [`get-involved.component.html`](frontend_v2/src/app/components/get-involved/get-involved.component.html) - Updated 4 email addresses
  - [`get-involved.html`](frontend/src/views/web/get-involved.html) - Updated 4 email addresses
- **Privacy Policy**: Updated 3 admin email references in both frontend versions
- **Challenge Pages**: Fixed contact emails in challenge management and settings components

### Backend Configuration
- **Production Settings** ([`settings/prod.py`](settings/prod.py)): Updated `DEFAULT_FROM_EMAIL` from `noreply@cloudcv.org` to `noreply@eval.ai`
- **Common Settings** ([`settings/common.py`](settings/common.py)): Updated `ADMIN_EMAIL` configuration

### Documentation
- **Hosting Guide** ([`docs/source/02-for-challenge-hosts/hosting-guide/host-challenge.md`](docs/source/02-for-challenge-hosts/hosting-guide/host-challenge.md)): Updated 2 team email references
- **Code of Conduct** ([`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)): Updated admin contact email

### Email Templates
- **Account Verification** ([`apps/accounts/templates/account/email_confirm.html`](apps/accounts/templates/account/email_confirm.html)): Updated website link

## What was NOT changed (intentionally)
- Test files with mock email data (in `tests/` directory)
- Nginx configuration files (maintains backward compatibility)
- SSL-related comments in deployment scripts
- Copyright notices in [`LICENSE`](LICENSE) that reference CloudCV organization

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] Verified all updated links point to accessible pages
- [x] Confirmed email addresses follow the @eval.ai domain pattern
- [x] Checked that no functionality is broken by these URL changes
- [x] Validated that all user-facing text reads naturally with the new domain

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

## Related Issues
Fixes #4706 - Broken cloudcv.org URLs reported on LinkedIn and GitHub profile pages

## Additional Notes
This PR updates 19 files across the codebase to ensure all user-facing URLs and contact information use the active `eval.ai` domain. The changes maintain backward compatibility where necessary (nginx configs) while improving the user experience for documentation, community engagement, and support channels.