### PR TITLE
Fix #4826 : Documentation pages for Docker Setup

### DIFF
--- a/apps/base/utils.py
+++ b/apps/base/utils.py
@@ -317,9 +317,7 @@ def is_model_field_changed(model_obj, field_name):
     """
     prev = getattr(model_obj, "_original_{}".format(field_name))
     curr = getattr(model_obj, "{}".format(field_name))
-    if prev != curr:
-        return True
-    return False
+    return prev != curr
 
 
 def is_user_a_staff(user):

--- a/docs/source/01-getting-started/setup/docker-setup.md
+++ b/docs/source/01-getting-started/setup/docker-setup.md
@@ -338,11 +338,12 @@ To stop and remove volumes (this deletes all data):
 docker compose down -v
 ```
 
-# Important Notes
+## Important Notes
 - Non-Docker installation is not officially supported
 - Docker setup works consistently across Windows, Linux, and macOS
 - This is the recommended setup for contributors and challenge hosts
+- When running tests locally outside Docker, ensure your global `pytest` configuration files (such as any `setup.cfg` in parent directories) are compatible with the `pytest` version you are using.
 
-# Contribution
+## Contribution
 
 If you are interested in contributing to EvalAI, please follow the [Contribution guidelines](https://github.com/Cloud-CV/EvalAI/blob/master/.github/CONTRIBUTING.md)


### PR DESCRIPTION


Documentation pages for Setup (Linux, Windows, macOS , manual , docker ) are empty on ReadTheDocs #4826

path :  Cloud-CV/EvalAI/tree/master/docs/source/01-getting-started/setup

issue : there is no Docker setup guide  ( issue #4826 )

## What this PR Does 

This PR adds **complete Docker-based setup documentation** for EvalAI to address missing and empty setup pages and improve the onboarding experience.

### Added Documentation Includes

- **Clear prerequisites**
  - Docker
  - Docker Compose
  - Git

- **Step-by-step setup instructions**
  - Forking the EvalAI repository
  - Cloning the fork locally
  - Building and running EvalAI using Docker Compose

- **Default login credentials**
  - Admin, Host, and Participant accounts for local development

- **Optional service profiles**
  - Worker services for local evaluation testing
  - StatsD exporter for monitoring

- **Container verification steps**
  - Validating running services using `docker ps`

- **Common issues & troubleshooting**
  - Port conflicts (e.g., port 8888 already in use)
  - Database and volume reset instructions
  - Viewing service logs for debugging

Next step : i will make more Setup documentation for (Linux , MacOs , Manual Installation , Windows )

@RishabhJain2018 @gchhablani  sir , Please review my Pr 

Thanks 
Shubham Kumar sharma


