### PR TITLE
Add documentation for creating baseline submissions by challenge hosts

### DIFF
--- a/docs/source/02-for-challenge-hosts/README.md
+++ b/docs/source/02-for-challenge-hosts/README.md
@@ -7,3 +7,4 @@ hosting-guide/index
 configuration/index
 evaluation/index
 templates/index
+baseline-submissions

--- a/docs/source/02-for-challenge-hosts/baseline-submissions.md
+++ b/docs/source/02-for-challenge-hosts/baseline-submissions.md
@@ -1,0 +1,66 @@
+Baseline Submissions (For Challenge Hosts)
+
+Overview:-
+
+When a challenge host submits a solution to their own challenge on EvalAI, the submission does not appear on the leaderboard by default. This behavior is intentional and helps prevent confusion during challenge setup and testing.
+
+To make a host submission visible on the leaderboard, it must be explicitly marked as a baseline submission.
+
+This document explains:-
+
+1.Why host submissions are hidden by default
+2.What baseline submissions are
+3.How to create a baseline submission step by step
+4.Why Host Submissions Don’t Appear on the Leaderboard
+5.Challenge hosts often submit solutions for purposes such as:
+-> Testing evaluation scripts
+-> Validating submission formats
+-> Debugging challenge configurations
+
+Since these submissions are not meant to compete with participants, EvalAI hides them from the leaderboard unless the host explicitly marks them as a baseline submission.
+
+This Ensures:
+-> Fair competition
+-> Clear separation between testing and reference submissions
+
+What Is a Baseline Submission?
+
+A baseline submission is a reference submission provided by the challenge host that:
+
+-> Appears on the leaderboard
+-> Serves as a benchmark for participants
+-> emonstrates expected input/output formats
+-> Helps participants validate their submission pipeline
+-> Baseline submissions are clearly labeled and do not affect participant rankings.
+
+How to Make a Submission a Baseline (Step-by-Step)
+
+Follow these steps to convert a host submission into a baseline submission:-
+
+-> Log in to EvalAI using your challenge host account.
+-> Navigate to your Challenge Dashboard.
+-> Select the challenge for which you want to add a baseline.
+-> Go to the Submissions section.
+-> Submit your solution as you normally would.
+-> Once the submission is successfully processed, locate it in the submissions list.
+-> Click the “Make Baseline” option associated with the submission.
+-> Confirm the action when prompted.
+-> The submission will now appear on the leaderboard as a baseline submission.
+
+Notes and Best Practices:-
+
+-> Only challenge hosts can create baseline submissions.
+-> Baseline submissions are intended for reference purposes and should not be used to compete with participants.
+-> You can add multiple baseline submissions if needed (e.g., different reference models).
+-> If a host submission does not appear on the leaderboard, ensure it has been explicitly marked as a baseline.
+
+Troubleshooting:-
+
+-> ubmission not visible on leaderboard?
+Verify that the submission has been marked as a baseline.
+-> Ensure the submission completed successfully.
+-> Check that you are viewing the correct leaderboard phase.
+
+Summary:-
+
+Baseline submissions help improve the participant experience by providing clear reference points and ensuring transparency. By explicitly marking host submissions as baselines, challenge hosts can make their submissions visible while maintaining fair competition

--- a/docs/source/02-for-challenge-hosts/hosting-guide/index.md
+++ b/docs/source/02-for-challenge-hosts/hosting-guide/index.md
@@ -7,4 +7,4 @@ getting-started
 challenge-types
 host-challenge
 approval-process
-
+baseline-submissions

--- a/docs/source/02-for-challenge-hosts/templates/index.md
+++ b/docs/source/02-for-challenge-hosts/templates/index.md
@@ -6,4 +6,4 @@
 example-challenges
 html-templates
 submission-guidelines
-
+baseline-submissions


### PR DESCRIPTION
### Summary
This PR adds clear, host-focused documentation explaining why challenge host submissions do not appear on the leaderboard by default and provides a step-by-step guide on how to mark a submission as a baseline.

### Changes
- Added a new documentation page for baseline submissions under challenge host docs
- Explained expected behavior for host submissions
- Provided step-by-step instructions for creating baseline submissions
- Linked the new page in the host documentation toctree

### Related Issue
Fixes #2804