### PR TITLE
Fix #4848:  Enforce LF line endings for shell scripts to prevent Docker startup issues on Windows

### DIFF
--- a/evalai/.gitattributes
+++ b/evalai/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
This PR enforces LF line endings for shell scripts in the repository via .gitattributes to prevent Docker startup failures on Windows.

The original issue caused containers to exit with code 127:

    /usr/bin/env: ‘bash\r’: No such file or directory

By adding .gitattributes and normalizing shell scripts, this PR improves cross-platform Docker compatibility and avoids the CRLF-related errors during container startup.

Fixes #4848 

