### PR TITLE
feat: make dashboard stats loading-aware

### DIFF
--- a/frontend/src/js/controllers/dashCtrl.js
+++ b/frontend/src/js/controllers/dashCtrl.js
@@ -19,6 +19,7 @@
         vm.hostTeamCount = 0;
         vm.hostTeamExist = false;
         vm.participatedTeamCount = 0;
+        vm.isLoading = true;
         // get token
         var userKey = utilities.getData('userKey');
 
@@ -146,6 +147,7 @@
                 if (status == 200) {
                     vm.participatedTeamCount = details.results.length;
                 }
+                vm.isLoading = false;
                 utilities.hideLoader();
             },
             onError: function(response) {

--- a/frontend/src/views/web/dashboard.html
+++ b/frontend/src/views/web/dashboard.html
@@ -7,7 +7,8 @@
                         <img src="dist/images/email.png" height="80" width="80">
                     </div>
                     <div class="card-content">
-                        <p><strong> You have limited privileges. <br> Please verify your email Id for getting all privileges!</strong>
+                        <p><strong> You have limited privileges. <br> Please verify your email Id for getting all
+                                privileges!</strong>
                     </div>
                 </div>
             </div>
@@ -16,7 +17,8 @@
     <div class="row">
         <div class="col s12">
             <!-- <h3 class="fs-20">Your Analysis for Host challenges are ready.</h3> -->
-            <a class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-14" ui-sref="web.host-analytics">Go to Analytics Dashboard</a>
+            <a class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-14"
+                ui-sref="web.host-analytics">Go to Analytics Dashboard</a>
         </div>
     </div>
 </section>
@@ -24,31 +26,42 @@
     <div class="row">
         <div class="col s12 m4">
             <h3 class="fs-20 main-title">Ongoing Challenges</h3>
-            <h4 class="text-dark-black">{{dash.challengeCount || 0}}</h4>
-            <a class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-transparent fs-14" ui-sref="web.challenge-main">View All</a>
+            <h4 class="text-dark-black">
+                <span ng-if="!dash.isLoading">{{dash.challengeCount}}</span>
+                <span ng-if="dash.isLoading">—</span>
+            </h4>
+            <a class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-transparent fs-14"
+                ui-sref="web.challenge-main">View All</a>
         </div>
         <div class="col s12 m4">
             <h3 class="fs-20 main-title">My Host Teams</h3>
-            <h4 class="text-dark-black">{{dash.hostTeamCount || 0}}</h4>
-            <a class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-transparent fs-14" ui-sref="web.challenge-host-teams">View or Create</a>
+            <h4 class="text-dark-black">
+                <span ng-if="!dash.isLoading">{{dash.hostTeamCount}}</span>
+                <span ng-if="dash.isLoading">—</span>
+            </h4>
+            <a class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-transparent fs-14"
+                ui-sref="web.challenge-host-teams">View or Create</a>
         </div>
         <div class="col s12 m4">
             <h3 class="fs-20 main-title">My Participant Teams</h3>
-            <h4 class="text-dark-black">{{dash.participatedTeamCount || 0}}</h4>
-            <a class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-transparent fs-14" ui-sref="web.teams">View or Create</a>
+            <h4 class="text-dark-black">
+                <span ng-if="!dash.isLoading">{{dash.participatedTeamCount}}</span>
+                <span ng-if="dash.isLoading">—</span>
+            </h4>
+            <a class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-transparent fs-14"
+                ui-sref="web.teams">View or Create</a>
         </div>
     </div>
 </section>
 
 <!-- simple loader -->
-    <div class="loader-container" id="sim-loader">
-        <div class="text-white center w-300 loader-title">Loading</div>
-        <div class="loader">
-            <div></div>
-            <div></div>
-            <div></div>
-            <div></div>
-            <div></div>
-        </div>
+<div class="loader-container" id="sim-loader">
+    <div class="text-white center w-300 loader-title">Loading</div>
+    <div class="loader">
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
     </div>
-
+</div>


### PR DESCRIPTION
## Description
The dashboard stats (`challengeCount`, `hostTeamCount`, `participatedTeamCount`) historically used fallback expressions like `{{ dash.challengeCount || 0 }}`, which caused a "0" to flash briefly before the API response loaded. This was misleading to users, implying they had zero items when data was actually still fetching.

This PR introduces loading-aware rendering by:
1.  Adding an `isLoading` flag to the [DashCtrl]
2.  Updating the dashboard template to show a placeholder (`—`) while data is loading.
3.  Displaying the actual values only after the API calls complete.

## Changes
- **Views**: Updated [dashboard.html] to conditionally render placeholders using `ng-if` based on the loading state.
- **Controllers**: Updated [dashCtrl.js] to initialize `isLoading = true` and set it to `false` upon successful data retrieval.
