### PR TITLE
Update Dockerfiles to replace libopencv4.5 with python3-opencv

### DIFF
--- a/docker/dev/worker_py3_8/Dockerfile
+++ b/docker/dev/worker_py3_8/Dockerfile
@@ -91,7 +91,7 @@ RUN (apt-get update && \
      default-jre-headless \
      libpq5 \
      libcurl4 \
-     libopencv4.5 \
+     python3-opencv \
      libgmp10 \
      libjpeg62-turbo \
      zlib1g \
@@ -104,7 +104,7 @@ RUN (apt-get update && \
          default-jre-headless \
          libpq5 \
          libcurl4 \
-         libopencv4.5 \
+         python3-opencv \
          libgmp10 \
          libjpeg62-turbo \
          zlib1g \

--- a/docker/prod/worker_py3_7/Dockerfile
+++ b/docker/prod/worker_py3_7/Dockerfile
@@ -95,7 +95,7 @@ RUN (apt-get update && \
      libfreetype6 \
      liblcms2-2 \
      libwebp6 \
-     libopencv4.5 \
+     python3-opencv \
      libgmp10 \
      || (apt-get update && apt-get install -y --no-install-recommends --fix-missing \
          libpq5 \
@@ -107,7 +107,7 @@ RUN (apt-get update && \
          libfreetype6 \
          liblcms2-2 \
          libwebp6 \
-         libopencv4.5 \
+         python3-opencv \
          libgmp10)) && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*

--- a/docker/prod/worker_py3_8/Dockerfile
+++ b/docker/prod/worker_py3_8/Dockerfile
@@ -95,7 +95,7 @@ RUN (apt-get update && \
      libfreetype6 \
      liblcms2-2 \
      libwebp6 \
-     libopencv4.5 \
+     python3-opencv \
      libgmp10 \
      || (apt-get update && apt-get install -y --no-install-recommends --fix-missing \
          libpq5 \
@@ -107,7 +107,7 @@ RUN (apt-get update && \
          libfreetype6 \
          liblcms2-2 \
          libwebp6 \
-         libopencv4.5 \
+         python3-opencv \
          libgmp10)) && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*

--- a/docker/prod/worker_py3_9/Dockerfile
+++ b/docker/prod/worker_py3_9/Dockerfile
@@ -99,7 +99,7 @@ RUN (apt-get update && \
      libfreetype6 \
      liblcms2-2 \
      libwebp6 \
-     libopencv4.5 \
+     python3-opencv \
      libgmp10 \
      || (apt-get update && apt-get install -y --no-install-recommends --fix-missing \
          libpq5 \
@@ -111,7 +111,7 @@ RUN (apt-get update && \
          libfreetype6 \
          liblcms2-2 \
          libwebp6 \
-         libopencv4.5 \
+         python3-opencv \
          libgmp10)) && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*


### PR DESCRIPTION
Improved compatibility across worker environments: Update Dockerfiles to replace libopencv4.5 with python3-opencv