### PR TITLE
Add scripts for S3 orphan cleanup and challenge end date management

### DIFF
--- a/scripts/tools/cleanup_data/s3.py
+++ b/scripts/tools/cleanup_data/s3.py
@@ -1,0 +1,606 @@
+#!/usr/bin/env python
+"""
+Cleanup S3 files for challenges - Memory Optimized for 1GB RAM.
+
+Cleans up files from S3 folders (see constants section for folder names):
+    - LOGOS_FOLDER/ (Challenge.image) - NOTE: Logos are NOT deleted by this script
+    - EVALUATION_SCRIPTS_FOLDER/ (Challenge.evaluation_script)
+    - TEST_ANNOTATIONS_FOLDER/ (ChallengePhase.test_annotation)
+    - SUBMISSION_FILES_FOLDER/ (Submission files)
+    - ZIP_CONFIGURATION_FILES_FOLDER/ (ChallengeConfiguration files)
+    - CLUSTER_YAML_FOLDER/ (ChallengeEvaluationCluster.cluster_yaml)
+    - KUBE_CONFIG_FOLDER/ (ChallengeEvaluationCluster.kube_config)
+
+Memory Optimization Strategy:
+    - Uses values_list() to fetch only file paths, not full objects
+    - Skips S3 existence checks (we're deleting anyway)
+    - Processes submissions in streaming batches
+    - Minimal logging per file (summary only)
+    - Aggressive garbage collection
+
+Usage:
+    # Dry run (default) - show what would be deleted
+    python scripts/tools/cleanup_data/s3.py --challenge-ids 1 2 3
+
+    # Execute - actually delete files
+    python scripts/tools/cleanup_data/s3.py --challenge-ids 1 2 3 --execute
+
+Output:
+    Creates a log file: scripts/tools/cleanup_data/cleanup_YYYYMMDD_HHMMSS.log
+
+Progress bar:
+    If tqdm is installed, progress bars will be shown for challenges,
+    submissions, and S3 delete batches.
+
+Run from project root in an environment with database access.
+"""
+
+import argparse
+import gc
+import os
+import sys
+import time
+from datetime import datetime
+
+# =============================================================================
+# CONFIGURATION - Edit these constants as needed
+# =============================================================================
+# S3 prefix - set this if default_storage.location is not configured
+# Leave empty to auto-detect from Django settings
+MEDIA_PREFIX = "media"
+
+# S3 folder names (relative to MEDIA_PREFIX)
+# These correspond to the FileField upload_to paths in the models
+LOGOS_FOLDER = "logos"  # Challenge.image (NOT deleted by this script)
+EVALUATION_SCRIPTS_FOLDER = "evaluation_scripts"  # Challenge.evaluation_script
+TEST_ANNOTATIONS_FOLDER = "test_annotations"  # ChallengePhase.test_annotation
+SUBMISSION_FILES_FOLDER = "submission_files"  # Submission files
+ZIP_CONFIGURATION_FILES_FOLDER = (
+    "zip_configuration_files"  # ChallengeConfiguration files
+)
+CLUSTER_YAML_FOLDER = "cluster_yaml"  # ChallengeEvaluationCluster.cluster_yaml
+KUBE_CONFIG_FOLDER = "kube_config"  # ChallengeEvaluationCluster.kube_config
+
+# Batch sizes optimized for 1GB RAM
+SUBMISSION_BATCH_SIZE = 5000  # For DB queries (just path strings, low memory)
+S3_DELETE_BATCH_SIZE = 1000  # Max objects per S3 delete_objects call
+# =============================================================================
+
+try:
+    from tqdm import tqdm
+
+    TQDM_AVAILABLE = True
+except ImportError:
+    TQDM_AVAILABLE = False
+
+# Setup paths (for running outside container)
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(SCRIPT_DIR)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+    sys.path.insert(0, os.path.join(PROJECT_ROOT, "apps"))
+
+# Setup Django - skip if already configured (running inside Django container)
+import django  # noqa: E402
+from django.conf import settings  # noqa: E402
+
+if not settings.configured:
+    django.setup()
+
+# Disable query logging to save memory (critical in containers)
+settings.DEBUG = False
+from django.db import connection, reset_queries  # noqa: E402
+
+if hasattr(connection, "queries_log"):
+    connection.queries_log.clear()
+
+import boto3  # noqa: E402
+from challenges.models import (  # noqa: E402
+    Challenge,
+    ChallengeConfiguration,
+    ChallengeEvaluationCluster,
+    ChallengePhase,
+)
+from django.core.files.storage import default_storage  # noqa: E402
+from jobs.models import Submission  # noqa: E402
+
+
+class Logger:
+    """Simple logger that writes to both console and file."""
+
+    def __init__(self, log_file_path):
+        self.log_file = open(log_file_path, "w", buffering=1)  # Line buffered
+        self.log_file_path = log_file_path
+
+    def log(self, message=""):
+        print(message)
+        self.log_file.write(message + "\n")
+
+    def close(self):
+        self.log_file.close()
+
+
+def format_size(size_bytes):
+    """Convert bytes to human readable format."""
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if size_bytes < 1024:
+            return f"{size_bytes:.2f} {unit}"
+        size_bytes /= 1024
+    return f"{size_bytes:.2f} PB"
+
+
+def format_duration(seconds):
+    """Convert seconds to human readable duration format."""
+    if seconds < 60:
+        return f"{seconds:.1f} seconds"
+    elif seconds < 3600:
+        minutes = seconds / 60
+        return f"{minutes:.1f} minutes"
+    else:
+        hours = seconds / 3600
+        return f"{hours:.2f} hours"
+
+
+def get_s3_client_and_bucket():
+    """Get boto3 S3 client and bucket name from django-storages settings."""
+    bucket_name = getattr(default_storage, "bucket_name", None)
+    if not bucket_name:
+        bucket_name = getattr(settings, "AWS_STORAGE_BUCKET_NAME", None)
+    s3_client = boto3.client("s3")
+    return s3_client, bucket_name
+
+
+def get_s3_key(path):
+    """Convert database path to full S3 key (add media/ prefix if needed)."""
+    location = getattr(default_storage, "location", "") or MEDIA_PREFIX
+
+    if not location:
+        return path
+
+    location_normalized = location.rstrip("/")
+
+    if path.startswith(f"{location_normalized}/"):
+        return path
+
+    return f"{location_normalized}/{path}"
+
+
+def get_file_sizes_from_s3(file_paths, logger, dry_run=True):
+    """
+    Get file sizes from S3 using HEAD requests.
+
+    Memory optimized: Processes in batches to avoid memory spikes.
+    Returns: list of tuples (path, size) or (path, None) if not found
+
+    Note: Sizes are calculated in both dry run and execute modes.
+    """
+    if not file_paths:
+        return []
+
+    s3_client, bucket_name = get_s3_client_and_bucket()
+    if not bucket_name:
+        logger.log(
+            "  [WARNING] Could not determine S3 bucket name - skipping size calculation"
+        )
+        return [(path, None) for path in file_paths]
+
+    file_sizes = []
+    total = len(file_paths)
+
+    logger.log(f"  Getting file sizes from S3 for {total} files...")
+
+    # Process in batches to avoid too many concurrent requests
+    batch_size = (
+        100  # HEAD requests are lightweight, so smaller batches are fine
+    )
+    batch_range = range(0, total, batch_size)
+
+    if TQDM_AVAILABLE:
+        batch_range = tqdm(
+            batch_range,
+            desc="Getting sizes",
+            unit="batch",
+            total=(total + batch_size - 1) // batch_size,
+        )
+
+    for i in batch_range:
+        batch = file_paths[i : i + batch_size]  # noqa: E203
+
+        for path in batch:
+            key = get_s3_key(path)
+            try:
+                response = s3_client.head_object(Bucket=bucket_name, Key=key)
+                size = response.get("ContentLength", 0)
+                file_sizes.append((path, size))
+            except Exception:
+                # If HEAD fails, just continue (file might not exist or be inaccessible)
+                # Don't log every failure to avoid log spam - just mark as None
+                file_sizes.append((path, None))
+
+        gc.collect()
+
+    return file_sizes
+
+
+def bulk_delete_s3_files(file_paths, logger, dry_run=True):
+    """
+    Delete files in bulk using S3 delete_objects API.
+
+    Memory optimized: Processes paths in batches, clears after each batch.
+    """
+    if not file_paths:
+        return 0, 0
+
+    total_files = len(file_paths)
+
+    if dry_run:
+        logger.log(f"\n  [DRY RUN] Would delete {total_files} files in bulk")
+        return total_files, 0
+
+    s3_client, bucket_name = get_s3_client_and_bucket()
+    if not bucket_name:
+        logger.log("  [ERROR] Could not determine S3 bucket name")
+        return 0, total_files
+
+    location = getattr(default_storage, "location", "") or MEDIA_PREFIX
+    logger.log(f"  Using bucket: {bucket_name}, prefix: '{location}'")
+
+    if file_paths:
+        sample_path = file_paths[0]
+        sample_key = get_s3_key(sample_path)
+        logger.log(
+            f"  Sample path conversion: '{sample_path}' -> '{sample_key}'"
+        )
+
+    deleted = 0
+    failed = 0
+    total_batches = (
+        total_files + S3_DELETE_BATCH_SIZE - 1
+    ) // S3_DELETE_BATCH_SIZE
+
+    batch_range = range(0, total_files, S3_DELETE_BATCH_SIZE)
+    if TQDM_AVAILABLE:
+        batch_range = tqdm(
+            batch_range,
+            desc="Deleting S3 files",
+            unit="batch",
+            total=total_batches,
+        )
+
+    for i in batch_range:
+        batch = file_paths[i : i + S3_DELETE_BATCH_SIZE]  # noqa: E203
+        objects_to_delete = [{"Key": get_s3_key(path)} for path in batch]
+
+        try:
+            response = s3_client.delete_objects(
+                Bucket=bucket_name, Delete={"Objects": objects_to_delete}
+            )
+            deleted_count = len(response.get("Deleted", []))
+            error_count = len(response.get("Errors", []))
+            deleted += deleted_count
+            failed += error_count
+
+            if error_count > 0:
+                for error in response.get("Errors", [])[
+                    :3
+                ]:  # Log first 3 errors only
+                    logger.log(
+                        f"  [ERROR] Failed to delete {error['Key']}: {error['Message']}"
+                    )
+
+            logger.log(
+                f"  [BULK DELETE] Batch {i//S3_DELETE_BATCH_SIZE + 1}: {deleted_count} deleted, {error_count} failed"
+            )
+        except Exception as e:
+            logger.log(f"  [ERROR] Bulk delete failed: {e}")
+            failed += len(batch)
+
+        gc.collect()
+
+    return deleted, failed
+
+
+def collect_challenge_files_optimized(challenge_id, logger):
+    """
+    Collect all file paths for a challenge.
+
+    Memory optimized: Uses values_list() to fetch only path strings,
+    skips S3 existence checks (unnecessary for deletion).
+
+    Returns: list of file paths
+    """
+    all_paths = []
+
+    # Verify challenge exists
+    if not Challenge.objects.filter(pk=challenge_id).exists():
+        logger.log(
+            f"\n[ERROR] Challenge {challenge_id} does not exist - skipping"
+        )
+        return None
+
+    # Get challenge title for logging
+    challenge_title = (
+        Challenge.objects.filter(pk=challenge_id)
+        .values_list("title", flat=True)
+        .first()
+    )
+
+    logger.log(f"\n{'='*60}")
+    logger.log(f"Challenge: {challenge_title} (ID: {challenge_id})")
+    logger.log(f"{'='*60}")
+
+    # 1. Challenge files - use values_list (skip image/logos, only delete evaluation_script)
+    logger.log(
+        f"\n  [Challenge] Fields: evaluation_script (skipping {LOGOS_FOLDER}/image)"
+    )
+    for field in ["evaluation_script"]:
+        path = (
+            Challenge.objects.filter(pk=challenge_id)
+            .exclude(**{f"{field}__isnull": True})
+            .exclude(**{field: ""})
+            .values_list(field, flat=True)
+            .first()
+        )
+        if path:
+            all_paths.append(path)
+            logger.log(f"    [FOUND] {field}: {path}")
+        else:
+            logger.log(f"    [EMPTY] {field}")
+
+    # 2. ChallengePhase files
+    phase_count = ChallengePhase.objects.filter(
+        challenge_id=challenge_id
+    ).count()
+    logger.log(f"\n  [ChallengePhase] {phase_count} phases")
+
+    paths = (
+        ChallengePhase.objects.filter(challenge_id=challenge_id)
+        .exclude(test_annotation__isnull=True)
+        .exclude(test_annotation="")
+        .values_list("test_annotation", flat=True)
+    )
+
+    phase_files = list(paths)
+    all_paths.extend(phase_files)
+    logger.log(f"    Found {len(phase_files)} test_annotation files")
+
+    gc.collect()
+    reset_queries()
+
+    # 3. Submission files - largest, process field by field with streaming
+    submission_count = Submission.objects.filter(
+        challenge_phase__challenge_id=challenge_id
+    ).count()
+    logger.log(f"\n  [Submission] {submission_count} submissions")
+
+    submission_fields = [
+        "input_file",
+        "submission_input_file",
+        "stdout_file",
+        "stderr_file",
+        "environment_log_file",
+        "submission_result_file",
+        "submission_metadata_file",
+    ]
+
+    submission_files_count = 0
+    for field in submission_fields:
+        paths = (
+            Submission.objects.filter(
+                challenge_phase__challenge_id=challenge_id
+            )
+            .exclude(**{f"{field}__isnull": True})
+            .exclude(**{field: ""})
+            .values_list(field, flat=True)
+        )
+
+        # Stream in batches to avoid memory spike
+        field_count = 0
+        for path in paths.iterator(chunk_size=SUBMISSION_BATCH_SIZE):
+            all_paths.append(path)
+            field_count += 1
+            if field_count % 10000 == 0:
+                gc.collect()
+                reset_queries()
+
+        submission_files_count += field_count
+
+        gc.collect()
+        reset_queries()
+
+    logger.log(f"    Found {submission_files_count} submission files")
+
+    # 4. ChallengeConfiguration files
+    logger.log("\n  [ChallengeConfiguration]")
+    config_fields = ["zip_configuration", "stdout_file", "stderr_file"]
+    config_count = 0
+
+    for field in config_fields:
+        path = (
+            ChallengeConfiguration.objects.filter(challenge_id=challenge_id)
+            .exclude(**{f"{field}__isnull": True})
+            .exclude(**{field: ""})
+            .values_list(field, flat=True)
+            .first()
+        )
+
+        if path:
+            all_paths.append(path)
+            config_count += 1
+
+    if config_count > 0:
+        logger.log(f"    Found {config_count} configuration files")
+    else:
+        logger.log("    [SKIP] No ChallengeConfiguration found")
+
+    # 5. ChallengeEvaluationCluster files
+    logger.log("\n  [ChallengeEvaluationCluster]")
+    cluster_fields = ["cluster_yaml", "kube_config"]
+    cluster_count = 0
+
+    for field in cluster_fields:
+        path = (
+            ChallengeEvaluationCluster.objects.filter(
+                challenge_id=challenge_id
+            )
+            .exclude(**{f"{field}__isnull": True})
+            .exclude(**{field: ""})
+            .values_list(field, flat=True)
+            .first()
+        )
+
+        if path:
+            all_paths.append(path)
+            cluster_count += 1
+
+    if cluster_count > 0:
+        logger.log(f"    Found {cluster_count} cluster files")
+    else:
+        logger.log("    [SKIP] No ChallengeEvaluationCluster found")
+
+    logger.log(f"\n  Challenge Total: {len(all_paths)} files to delete")
+
+    gc.collect()
+    reset_queries()
+
+    return all_paths
+
+
+def main():
+    start_time = time.time()
+
+    parser = argparse.ArgumentParser(
+        description="Cleanup S3 files for challenges"
+    )
+    parser.add_argument(
+        "--challenge-ids",
+        type=int,
+        nargs="+",
+        required=True,
+        help="Challenge IDs to process",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually delete files (default is dry run)",
+    )
+    args = parser.parse_args()
+
+    dry_run = not args.execute
+
+    # Create log file
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_file_path = os.path.join(SCRIPT_DIR, f"cleanup_{timestamp}.log")
+    logger = Logger(log_file_path)
+
+    logger.log("=" * 60)
+    logger.log(f"S3 Cleanup - {'DRY RUN' if dry_run else 'EXECUTE'}")
+    logger.log(f"Timestamp: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    logger.log(
+        f"Challenge IDs: {len(args.challenge_ids)} challenges ({min(args.challenge_ids)} to {max(args.challenge_ids)})"
+    )
+    logger.log(f"Log file: {log_file_path}")
+    logger.log("=" * 60)
+    logger.log("\n[Memory Optimized for 1GB RAM]")
+
+    if dry_run:
+        logger.log("\n*** DRY RUN - No files will be deleted ***")
+        logger.log("*** Use --execute to actually delete files ***")
+
+    total_stats = {
+        "files_found": 0,
+        "files_deleted": 0,
+        "files_failed": 0,
+        "size": 0,
+        "processed": 0,
+        "skipped": 0,
+    }
+
+    # Collect all files from all challenges
+    all_files_to_delete = []
+
+    challenge_ids = args.challenge_ids
+    if TQDM_AVAILABLE:
+        challenge_ids = tqdm(
+            challenge_ids, desc="Collecting files", unit="challenge"
+        )
+
+    for challenge_id in challenge_ids:
+        file_paths = collect_challenge_files_optimized(challenge_id, logger)
+
+        if file_paths is None:
+            total_stats["skipped"] += 1
+            continue
+
+        all_files_to_delete.extend(file_paths)
+        total_stats["files_found"] += len(file_paths)
+        total_stats["processed"] += 1
+
+        # Free memory after each challenge
+        gc.collect()
+        reset_queries()
+        connection.close()
+
+    # Calculate total size (get sizes from S3 for both dry run and execute)
+    logger.log(f"\n{'='*60}")
+    logger.log("SIZE CALCULATION PHASE")
+    logger.log(f"{'='*60}")
+    logger.log(f"Total files to delete: {len(all_files_to_delete)}")
+    logger.log("  Getting file sizes from S3...")
+
+    file_sizes = get_file_sizes_from_s3(
+        all_files_to_delete, logger, dry_run=dry_run
+    )
+    total_size = sum(size for _, size in file_sizes if size is not None)
+    files_with_size = sum(1 for _, size in file_sizes if size is not None)
+    files_without_size = len(all_files_to_delete) - files_with_size
+
+    logger.log(
+        f"Total size {'to free' if dry_run else 'freed'}: {format_size(total_size)}"
+    )
+    if files_without_size > 0:
+        logger.log(
+            f"  Note: {files_without_size} files could not be sized (may not exist in S3)"
+        )
+
+    # Bulk delete all collected files
+    logger.log(f"\n{'='*60}")
+    logger.log("BULK DELETE PHASE")
+    logger.log(f"{'='*60}")
+    logger.log(f"Total files to delete: {len(all_files_to_delete)}")
+
+    deleted, failed = bulk_delete_s3_files(
+        all_files_to_delete, logger, dry_run
+    )
+    total_stats["files_deleted"] = deleted
+    total_stats["files_failed"] = failed
+    total_stats["size"] = total_size
+
+    # Summary
+    logger.log("\n" + "=" * 60)
+    logger.log("FINAL SUMMARY")
+    logger.log("=" * 60)
+    logger.log(f"Mode: {'DRY RUN' if dry_run else 'EXECUTE'}")
+    logger.log(f"Challenges processed: {total_stats['processed']}")
+    logger.log(f"Challenges skipped (not found): {total_stats['skipped']}")
+    logger.log(f"Files found: {total_stats['files_found']}")
+    logger.log(
+        f"Files {'to delete' if dry_run else 'deleted'}: {total_stats['files_deleted']}"
+    )
+    if not dry_run:
+        logger.log(f"Files failed to delete: {total_stats['files_failed']}")
+    if total_stats.get("size", 0) > 0:
+        logger.log(
+            f"Space {'to free' if dry_run else 'freed'}: {format_size(total_stats['size'])}"
+        )
+    elapsed_time = time.time() - start_time
+    logger.log(f"Execution time: {format_duration(elapsed_time)}")
+    logger.log(f"Log file: {log_file_path}")
+    logger.log("=" * 60)
+
+    logger.close()
+    print(f"\nLog saved to: {log_file_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tools/cleanup_data/s3_orphans.py
+++ b/scripts/tools/cleanup_data/s3_orphans.py
@@ -1,0 +1,661 @@
+#!/usr/bin/env python
+"""
+Cleanup orphaned S3 files - Memory Optimized for 1GB RAM.
+
+This script keeps all files referenced in the database and deletes
+any files in S3 that are not referenced by any challenge, phase,
+submission, configuration, or cluster.
+
+Memory Optimization Strategy:
+    - Uses values_list() to fetch only file paths, not full objects
+    - Streams S3 files and checks immediately (no list accumulation)
+    - Writes orphan keys to temp file instead of memory
+    - Processes deletions in streaming batches
+    - Aggressive garbage collection
+
+S3 folders scanned (under MEDIA_PREFIX):
+    - logos/
+    - evaluation_scripts/
+    - test_annotations/
+    - submission_files/
+    - zip_configuration_files/
+    - cluster_yaml/
+    - kube_config/
+
+Configuration:
+    Edit MEDIA_PREFIX and S3_FOLDER_NAMES at the top of the script
+    to adapt for different bucket structures.
+
+Usage:
+    # Dry run (default) - show what would be deleted
+    python scripts/tools/cleanup_data/s3_orphans.py
+
+    # Execute - actually delete orphaned files
+    python scripts/tools/cleanup_data/s3_orphans.py --execute
+
+Progress bar:
+    If tqdm is installed, progress bars will be shown.
+
+Run from project root in an environment with database access.
+"""
+
+import argparse
+import gc
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime
+
+try:
+    from tqdm import tqdm
+
+    TQDM_AVAILABLE = True
+except ImportError:
+    TQDM_AVAILABLE = False
+
+# Setup paths (for running outside container)
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(SCRIPT_DIR)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+    sys.path.insert(0, os.path.join(PROJECT_ROOT, "apps"))
+
+# Setup Django - skip if already configured (running inside Django container)
+import django  # noqa: E402
+from django.conf import settings  # noqa: E402
+
+if not settings.configured:
+    django.setup()
+
+# Disable query logging to save memory (critical in containers)
+settings.DEBUG = False
+from django.db import connection, reset_queries  # noqa: E402
+
+if hasattr(connection, "queries_log"):
+    connection.queries_log.clear()
+
+import boto3  # noqa: E402
+from challenges.models import (  # noqa: E402
+    Challenge,
+    ChallengeConfiguration,
+    ChallengeEvaluationCluster,
+    ChallengePhase,
+)
+from django.core.files.storage import default_storage  # noqa: E402
+from jobs.models import Submission  # noqa: E402
+
+# =============================================================================
+# CONFIGURATION - Change these for different environments/buckets
+# =============================================================================
+# S3 prefix (typically "media/" - change if your bucket uses a different prefix)
+MEDIA_PREFIX = "media/"
+
+# Folder names to scan (relative to MEDIA_PREFIX)
+S3_FOLDER_NAMES = [
+    "logos",
+    "evaluation_scripts",
+    "test_annotations",
+    "submission_files",
+    "zip_configuration_files",
+    "cluster_yaml",
+    "kube_config",
+]
+
+# Build full paths
+S3_FOLDERS = [f"{MEDIA_PREFIX}{folder}/" for folder in S3_FOLDER_NAMES]
+# =============================================================================
+
+# Batch sizes optimized for 1GB RAM
+DB_BATCH_SIZE = (
+    5000  # Larger batches for values_list (just strings, low memory)
+)
+S3_DELETE_BATCH_SIZE = 1000  # Max objects per S3 delete_objects call
+
+
+class Logger:
+    """Simple logger that writes to both console and file."""
+
+    def __init__(self, log_file_path):
+        self.log_file = open(log_file_path, "w", buffering=1)
+        self.log_file_path = log_file_path
+
+    def log(self, message=""):
+        print(message)
+        self.log_file.write(message + "\n")
+
+    def close(self):
+        self.log_file.close()
+
+
+def format_size(size_bytes):
+    """Convert bytes to human readable format."""
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if size_bytes < 1024:
+            return f"{size_bytes:.2f} {unit}"
+        size_bytes /= 1024
+    return f"{size_bytes:.2f} PB"
+
+
+def format_duration(seconds):
+    """Convert seconds to human readable duration format."""
+    if seconds < 60:
+        return f"{seconds:.1f} seconds"
+    elif seconds < 3600:
+        minutes = seconds / 60
+        return f"{minutes:.1f} minutes"
+    else:
+        hours = seconds / 3600
+        return f"{hours:.2f} hours"
+
+
+def collect_db_file_paths_optimized(logger):
+    """
+    Collect all file paths referenced in the database.
+
+    Memory optimized: Uses values_list() to fetch only path strings,
+    and normalizes paths in a single set with both prefix forms.
+    """
+    referenced_paths = set()
+    prefix_len = len(MEDIA_PREFIX)
+
+    def add_path_normalized(path):
+        """Add path in both forms (with and without MEDIA_PREFIX) for fast lookup."""
+        if not path:
+            return
+        referenced_paths.add(path)
+        # Also add alternate form for matching
+        if path.startswith(MEDIA_PREFIX):
+            referenced_paths.add(path[prefix_len:])
+        else:
+            referenced_paths.add(f"{MEDIA_PREFIX}{path}")
+
+    # 1. Challenge files - use values_list for memory efficiency
+    logger.log("\n  Collecting Challenge file paths...")
+    challenge_count = Challenge.objects.count()
+    logger.log(f"    Found {challenge_count} challenges")
+
+    for field in ["image", "evaluation_script"]:
+        # Exclude both NULL and empty string values
+        paths = (
+            Challenge.objects.exclude(**{f"{field}__isnull": True})
+            .exclude(**{field: ""})
+            .values_list(field, flat=True)
+        )
+        for path in paths.iterator(chunk_size=DB_BATCH_SIZE):
+            add_path_normalized(path)
+
+    gc.collect()
+    reset_queries()
+
+    # 2. ChallengePhase files
+    logger.log("\n  Collecting ChallengePhase file paths...")
+    phase_count = ChallengePhase.objects.count()
+    logger.log(f"    Found {phase_count} phases")
+
+    paths = (
+        ChallengePhase.objects.exclude(test_annotation__isnull=True)
+        .exclude(test_annotation="")
+        .values_list("test_annotation", flat=True)
+    )
+    for path in paths.iterator(chunk_size=DB_BATCH_SIZE):
+        add_path_normalized(path)
+
+    gc.collect()
+    reset_queries()
+
+    # 3. Submission files - largest table, process field by field
+    logger.log("\n  Collecting Submission file paths...")
+    submission_count = Submission.objects.count()
+    logger.log(f"    Found {submission_count} submissions")
+
+    submission_fields = [
+        "input_file",
+        "submission_input_file",
+        "stdout_file",
+        "stderr_file",
+        "environment_log_file",
+        "submission_result_file",
+        "submission_metadata_file",
+    ]
+
+    for field in submission_fields:
+        # Exclude both NULL and empty string values
+        paths = (
+            Submission.objects.exclude(**{f"{field}__isnull": True})
+            .exclude(**{field: ""})
+            .values_list(field, flat=True)
+        )
+        count = 0
+        for path in paths.iterator(chunk_size=DB_BATCH_SIZE):
+            add_path_normalized(path)
+            count += 1
+            if count % 50000 == 0:
+                gc.collect()
+                reset_queries()
+        gc.collect()
+        reset_queries()
+
+    # 4. ChallengeConfiguration files
+    logger.log("\n  Collecting ChallengeConfiguration file paths...")
+    config_count = ChallengeConfiguration.objects.count()
+    logger.log(f"    Found {config_count} configurations")
+
+    for field in ["zip_configuration", "stdout_file", "stderr_file"]:
+        # Exclude both NULL and empty string values
+        paths = (
+            ChallengeConfiguration.objects.exclude(
+                **{f"{field}__isnull": True}
+            )
+            .exclude(**{field: ""})
+            .values_list(field, flat=True)
+        )
+        field_count = 0
+        for path in paths.iterator(chunk_size=DB_BATCH_SIZE):
+            add_path_normalized(path)
+            field_count += 1
+        logger.log(f"    {field}: {field_count} files")
+
+    gc.collect()
+    reset_queries()
+
+    # 5. ChallengeEvaluationCluster files
+    logger.log("\n  Collecting ChallengeEvaluationCluster file paths...")
+    cluster_count = ChallengeEvaluationCluster.objects.count()
+    logger.log(f"    Found {cluster_count} clusters")
+
+    for field in ["cluster_yaml", "kube_config"]:
+        # Exclude both NULL and empty string values
+        paths = (
+            ChallengeEvaluationCluster.objects.exclude(
+                **{f"{field}__isnull": True}
+            )
+            .exclude(**{field: ""})
+            .values_list(field, flat=True)
+        )
+        for path in paths.iterator(chunk_size=DB_BATCH_SIZE):
+            add_path_normalized(path)
+
+    gc.collect()
+    reset_queries()
+    connection.close()
+
+    logger.log(
+        f"\n  Total normalized reference paths: {len(referenced_paths)}"
+    )
+    return referenced_paths
+
+
+def get_s3_client_and_bucket():
+    """Get boto3 S3 client and bucket name from django-storages settings."""
+    bucket_name = getattr(default_storage, "bucket_name", None)
+    if not bucket_name:
+        bucket_name = getattr(settings, "AWS_STORAGE_BUCKET_NAME", None)
+
+    s3_client = boto3.client("s3")
+    return s3_client, bucket_name
+
+
+def stream_s3_and_find_orphans(referenced_paths, orphan_file, logger):
+    """
+    Stream S3 files and write orphan keys to temp file.
+
+    Memory optimized: Never holds full S3 file list in memory.
+    Checks each file immediately and writes orphans to disk.
+
+    Returns: (total_s3_count, orphan_count, total_orphan_size, kept_count)
+    """
+    s3_client, bucket_name = get_s3_client_and_bucket()
+    if not bucket_name:
+        logger.log(
+            "  [ERROR] Could not determine S3 bucket name from settings"
+        )
+        return 0, 0, 0, 0
+
+    logger.log(f"  Using bucket: {bucket_name}")
+
+    total_s3_count = 0
+    orphan_count = 0
+    total_orphan_size = 0
+    kept_count = 0
+    prefix_len = len(MEDIA_PREFIX)
+
+    folder_iter = S3_FOLDERS
+    if TQDM_AVAILABLE:
+        folder_iter = tqdm(S3_FOLDERS, desc="    S3 folders", unit="folder")
+
+    for folder in folder_iter:
+        folder_count = 0
+        folder_orphans = 0
+
+        try:
+            paginator = s3_client.get_paginator("list_objects_v2")
+            page_iterator = paginator.paginate(
+                Bucket=bucket_name, Prefix=folder
+            )
+
+            for page in page_iterator:
+                for obj in page.get("Contents", []):
+                    key = obj["Key"]
+                    # Skip "folder" entries
+                    if key.endswith("/"):
+                        continue
+
+                    total_s3_count += 1
+                    folder_count += 1
+
+                    # Check if referenced (check both with and without prefix)
+                    key_without_prefix = (
+                        key[prefix_len:]
+                        if key.startswith(MEDIA_PREFIX)
+                        else key
+                    )
+
+                    if (
+                        key in referenced_paths
+                        or key_without_prefix in referenced_paths
+                    ):
+                        kept_count += 1
+                    else:
+                        # Write orphan to temp file: key\tsize\n
+                        orphan_file.write(f"{key}\t{obj['Size']}\n")
+                        orphan_count += 1
+                        folder_orphans += 1
+                        total_orphan_size += obj["Size"]
+
+                # Periodic cleanup within large folders
+                if folder_count % 100000 == 0:
+                    gc.collect()
+
+        except Exception as e:
+            logger.log(f"  [ERROR] Failed to list {folder}: {e}")
+
+        logger.log(
+            f"    {folder}: {folder_count} files ({folder_orphans} orphans)"
+        )
+
+    logger.log(f"\n  Total files in S3: {total_s3_count}")
+    logger.log(
+        f"  Orphaned files found: {orphan_count} ({format_size(total_orphan_size)})"
+    )
+    logger.log(f"  Referenced files (kept): {kept_count}")
+
+    return total_s3_count, orphan_count, total_orphan_size, kept_count
+
+
+def verify_no_overlap_streaming(
+    referenced_paths, orphan_file_path, logger, sample_limit=10
+):
+    """
+    Verify no overlap between orphans and referenced paths by streaming orphan file.
+
+    Memory optimized: Reads orphan file line by line.
+    """
+    logger.log(
+        "\n  Verifying no overlap between orphaned and referenced files..."
+    )
+
+    overlap_count = 0
+    prefix_len = len(MEDIA_PREFIX)
+
+    with open(orphan_file_path, "r") as f:
+        for line in f:
+            key = line.split("\t")[0]
+            key_without_prefix = (
+                key[prefix_len:] if key.startswith(MEDIA_PREFIX) else key
+            )
+
+            if (
+                key in referenced_paths
+                or key_without_prefix in referenced_paths
+            ):
+                overlap_count += 1
+                if overlap_count <= sample_limit:
+                    logger.log(f"    [WARNING] Overlap found: {key}")
+
+    if overlap_count > 0:
+        logger.log(f"\n  [ERROR] Found {overlap_count} overlapping files!")
+        return False
+
+    logger.log(
+        "  [OK] No overlap detected - all orphaned files are safe to delete"
+    )
+    return True
+
+
+def bulk_delete_from_file(orphan_file_path, logger, dry_run=True):
+    """
+    Delete orphaned files by streaming from temp file.
+
+    Memory optimized: Reads orphan file in batches, never loads all into memory.
+    """
+    # Count total for progress
+    total_orphans = sum(1 for _ in open(orphan_file_path, "r"))
+
+    if total_orphans == 0:
+        return 0, 0
+
+    if dry_run:
+        logger.log(
+            f"\n  [DRY RUN] Would delete {total_orphans} orphaned files in bulk"
+        )
+        return total_orphans, 0
+
+    s3_client, bucket_name = get_s3_client_and_bucket()
+    if not bucket_name:
+        logger.log("  [ERROR] Could not determine S3 bucket name")
+        return 0, total_orphans
+
+    deleted = 0
+    failed = 0
+    batch = []
+    batch_num = 0
+    total_batches = (
+        total_orphans + S3_DELETE_BATCH_SIZE - 1
+    ) // S3_DELETE_BATCH_SIZE
+
+    with open(orphan_file_path, "r") as f:
+        if TQDM_AVAILABLE:
+            f_iter = tqdm(
+                f, desc="Deleting S3 files", unit="file", total=total_orphans
+            )
+        else:
+            f_iter = f
+
+        for line in f_iter:
+            key = line.split("\t")[0]
+            batch.append({"Key": key})
+
+            if len(batch) >= S3_DELETE_BATCH_SIZE:
+                batch_num += 1
+                try:
+                    response = s3_client.delete_objects(
+                        Bucket=bucket_name, Delete={"Objects": batch}
+                    )
+                    deleted_count = len(response.get("Deleted", []))
+                    error_count = len(response.get("Errors", []))
+                    deleted += deleted_count
+                    failed += error_count
+
+                    if error_count > 0:
+                        for error in response.get("Errors", [])[
+                            :3
+                        ]:  # Log first 3 errors
+                            logger.log(
+                                f"  [ERROR] Failed to delete {error['Key']}: {error['Message']}"
+                            )
+
+                    logger.log(
+                        f"  [BULK DELETE] Batch {batch_num}/{total_batches}: {deleted_count} deleted, {error_count} failed"
+                    )
+                except Exception as e:
+                    logger.log(f"  [ERROR] Bulk delete failed: {e}")
+                    failed += len(batch)
+
+                batch = []
+                gc.collect()
+
+        # Process remaining batch
+        if batch:
+            batch_num += 1
+            try:
+                response = s3_client.delete_objects(
+                    Bucket=bucket_name, Delete={"Objects": batch}
+                )
+                deleted_count = len(response.get("Deleted", []))
+                error_count = len(response.get("Errors", []))
+                deleted += deleted_count
+                failed += error_count
+                logger.log(
+                    f"  [BULK DELETE] Batch {batch_num}/{total_batches}: {deleted_count} deleted, {error_count} failed"
+                )
+            except Exception as e:
+                logger.log(f"  [ERROR] Bulk delete failed: {e}")
+                failed += len(batch)
+
+    return deleted, failed
+
+
+def main():
+    start_time = time.time()
+
+    parser = argparse.ArgumentParser(
+        description="Cleanup orphaned S3 files not referenced in database"
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually delete files (default is dry run)",
+    )
+    args = parser.parse_args()
+
+    dry_run = not args.execute
+
+    # Create log file
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_file_path = os.path.join(
+        SCRIPT_DIR, f"orphans_cleanup_{timestamp}.log"
+    )
+    logger = Logger(log_file_path)
+
+    logger.log("=" * 60)
+    logger.log(f"S3 Orphan Cleanup - {'DRY RUN' if dry_run else 'EXECUTE'}")
+    logger.log(f"Timestamp: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    logger.log(f"Log file: {log_file_path}")
+    logger.log("=" * 60)
+    logger.log("\n[Memory Optimized for 1GB RAM]")
+
+    if dry_run:
+        logger.log("\n*** DRY RUN - No files will be deleted ***")
+        logger.log("*** Use --execute to actually delete files ***")
+
+    # Phase 1: Collect all file paths from database (memory: ~200-300MB for refs)
+    logger.log(f"\n{'='*60}")
+    logger.log("PHASE 1: Collecting database references")
+    logger.log("=" * 60)
+    referenced_paths = collect_db_file_paths_optimized(logger)
+    gc.collect()
+
+    # Phase 2 & 3: Stream S3 files and identify orphans (write to temp file)
+    logger.log(f"\n{'='*60}")
+    logger.log("PHASE 2: Streaming S3 files and identifying orphans")
+    logger.log("=" * 60)
+
+    # Create temp file for orphan keys (stored on disk, not memory)
+    orphan_temp_file = tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".txt",
+        prefix="orphans_",
+        dir=SCRIPT_DIR,
+        delete=False,
+    )
+    orphan_file_path = orphan_temp_file.name
+
+    try:
+        total_s3_files, orphan_count, orphan_size, kept_count = (
+            stream_s3_and_find_orphans(
+                referenced_paths, orphan_temp_file, logger
+            )
+        )
+        orphan_temp_file.close()
+
+        if total_s3_files == 0:
+            logger.log(
+                "\n[WARNING] No S3 files found. Check S3 bucket access."
+            )
+            logger.close()
+            os.unlink(orphan_file_path)
+            print(f"\nLog saved to: {log_file_path}")
+            return
+
+        if orphan_count == 0:
+            logger.log(
+                "\n[INFO] No orphaned files found. All S3 files are referenced in database."
+            )
+            logger.close()
+            os.unlink(orphan_file_path)
+            print(f"\nLog saved to: {log_file_path}")
+            return
+
+        # Phase 3: Verify no overlap (streaming verification)
+        logger.log(f"\n{'='*60}")
+        logger.log("PHASE 3: Verifying no overlap")
+        logger.log("=" * 60)
+
+        if not verify_no_overlap_streaming(
+            referenced_paths, orphan_file_path, logger
+        ):
+            logger.log(
+                "  [ERROR] Aborting to prevent data loss. Please investigate."
+            )
+            logger.close()
+            os.unlink(orphan_file_path)
+            print(f"\nLog saved to: {log_file_path}")
+            return
+
+        # Free referenced_paths - no longer needed
+        del referenced_paths
+        gc.collect()
+
+        # Phase 4: Delete orphaned files (streaming from temp file)
+        logger.log(f"\n{'='*60}")
+        logger.log("PHASE 4: Deleting orphaned files")
+        logger.log("=" * 60)
+        logger.log(f"Files to delete: {orphan_count}")
+        logger.log(f"Space to free: {format_size(orphan_size)}")
+
+        deleted, failed = bulk_delete_from_file(
+            orphan_file_path, logger, dry_run
+        )
+
+        # Summary
+        logger.log("\n" + "=" * 60)
+        logger.log("FINAL SUMMARY")
+        logger.log("=" * 60)
+        logger.log(f"Mode: {'DRY RUN' if dry_run else 'EXECUTE'}")
+        logger.log(f"Total S3 files scanned: {total_s3_files}")
+        logger.log(f"Files referenced in database (kept): {kept_count}")
+        logger.log(
+            f"Orphaned files {'to delete' if dry_run else 'deleted'}: {deleted}"
+        )
+        if not dry_run:
+            logger.log(f"Files failed to delete: {failed}")
+        logger.log(
+            f"Space {'to free' if dry_run else 'freed'}: {format_size(orphan_size)}"
+        )
+        elapsed_time = time.time() - start_time
+        logger.log(f"Execution time: {format_duration(elapsed_time)}")
+        logger.log(f"Log file: {log_file_path}")
+        logger.log("=" * 60)
+
+    finally:
+        # Cleanup temp file
+        if os.path.exists(orphan_file_path):
+            os.unlink(orphan_file_path)
+
+    logger.close()
+    print(f"\nLog saved to: {log_file_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tools/cleanup_data/set_challenge_end_date.py
+++ b/scripts/tools/cleanup_data/set_challenge_end_date.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python
+"""
+Set end date for specified challenges and their phases.
+
+Usage:
+    # Dry run (default) - show what would be updated
+    python scripts/tools/cleanup_data/set_challenge_end_date.py \
+        --challenge-ids 1 2 3 --end-date "2026-01-16"
+
+    # Execute - actually update the database
+    python scripts/tools/cleanup_data/set_challenge_end_date.py \
+        --challenge-ids 1 2 3 --end-date "2026-01-16" --execute
+
+Run from project root in an environment with database access.
+"""
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime
+
+import pytz
+
+# Setup paths
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(SCRIPT_DIR)))
+sys.path.insert(0, PROJECT_ROOT)
+sys.path.insert(0, os.path.join(PROJECT_ROOT, "apps"))
+
+# Print early to show script is starting
+print("Initializing script...", flush=True)
+print(f"Project root: {PROJECT_ROOT}", flush=True)
+
+# Setup Django - uses DJANGO_SETTINGS_MODULE from environment if set
+print("Setting up Django...", flush=True)
+import django  # noqa: E402
+
+django.setup()
+print("Django setup complete.", flush=True)
+
+print("Importing models...", flush=True)
+from challenges.models import Challenge, ChallengePhase  # noqa: E402
+
+print("Models imported.", flush=True)
+
+
+def parse_end_date(date_string: str) -> datetime:
+    """
+    Parse end date string and return datetime at 11:59:59 PM UTC.
+
+    Args:
+        date_string: Date string in format YYYY-MM-DD
+
+    Returns:
+        datetime object at 23:59:59 UTC
+    """
+    try:
+        # Parse the date
+        date_obj = datetime.strptime(date_string, "%Y-%m-%d")
+        # Set time to 23:59:59 UTC
+        end_datetime = datetime.combine(
+            date_obj.date(), datetime.max.time().replace(microsecond=0)
+        )
+        # Localize to UTC
+        utc = pytz.UTC
+        return utc.localize(end_datetime)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(
+            f"Invalid date format: {date_string}. Expected format: YYYY-MM-DD"
+        ) from e
+
+
+def setup_logging(log_file_path: str) -> None:
+    """
+    Set up logging to write to both file and console.
+
+    Args:
+        log_file_path: Path to the log file
+    """
+    # Create formatter
+    formatter = logging.Formatter(
+        "%(asctime)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    # File handler
+    file_handler = logging.FileHandler(
+        log_file_path, mode="w", encoding="utf-8"
+    )
+    file_handler.setFormatter(formatter)
+    file_handler.setLevel(logging.INFO)
+
+    # Console handler
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setFormatter(formatter)
+    console_handler.setLevel(logging.INFO)
+
+    # Configure root logger
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    root_logger.addHandler(file_handler)
+    root_logger.addHandler(console_handler)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Set end date for specified challenges and their phases",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--challenge-ids",
+        type=int,
+        nargs="+",
+        required=True,
+        help="List of challenge IDs to update (e.g., --challenge-ids 1 2 3)",
+    )
+    parser.add_argument(
+        "--end-date",
+        type=parse_end_date,
+        required=True,
+        help="End date in YYYY-MM-DD format (will be set to 11:59:59 PM UTC)",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually update the database (default is dry run)",
+    )
+    parser.add_argument(
+        "--log-file",
+        type=str,
+        default=None,
+        help="Path to log file (default: auto-generated with timestamp)",
+    )
+    args = parser.parse_args()
+
+    dry_run = not args.execute
+    challenge_ids = args.challenge_ids
+    target_end_date = args.end_date
+
+    # Set up log file path
+    if args.log_file:
+        log_file_path = args.log_file
+    else:
+        # Generate log file name with timestamp
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        mode_str = "dryrun" if dry_run else "execute"
+        log_file_path = os.path.join(
+            SCRIPT_DIR, f"set_challenge_end_date_{mode_str}_{timestamp}.log"
+        )
+
+    # Set up logging
+    print(f"Setting up logging to: {log_file_path}", flush=True)
+    setup_logging(log_file_path)
+    logger = logging.getLogger(__name__)
+
+    logger.info("=" * 60)
+    logger.info(
+        f"Set End Date for Challenges - {'DRY RUN' if dry_run else 'EXECUTE'}"
+    )
+    logger.info(f"Challenge IDs: {challenge_ids}")
+    logger.info(f"Target end date: {target_end_date} (11:59:59 PM UTC)")
+    logger.info(f"Log file: {log_file_path}")
+    logger.info("=" * 60)
+
+    if dry_run:
+        logger.info("")
+        logger.info("*** DRY RUN - No changes will be made ***")
+        logger.info("*** Use --execute to actually update ***")
+        logger.info("")
+
+    # Process challenges one at a time to minimize memory usage
+    # Check each challenge ID individually instead of loading all into memory
+    logger.info("Validating challenge IDs...")
+    valid_challenge_ids = []
+    missing_ids = []
+
+    # Check each ID individually to avoid loading all at once
+    for challenge_id in challenge_ids:
+        if Challenge.objects.filter(id=challenge_id).exists():
+            valid_challenge_ids.append(challenge_id)
+        else:
+            missing_ids.append(challenge_id)
+
+    if missing_ids:
+        logger.warning("")
+        logger.warning(
+            f"⚠️  WARNING: The following challenge IDs were not found: {missing_ids}"
+        )
+        if not valid_challenge_ids:
+            logger.error("")
+            logger.error("❌ No valid challenge IDs provided. Exiting.")
+            return
+
+    challenge_count = len(valid_challenge_ids)
+    logger.info(f"Found {challenge_count} valid challenge(s)")
+
+    if dry_run:
+        # Dry run: use .values() to avoid model __init__ issues with .only()
+        logger.info("")
+        logger.info("Challenges to update:")
+        total_phases = 0
+
+        # Use .values() to get dictionaries instead of model instances
+        # This avoids the __init__ recursion issue when using .only()
+        logger.info("Fetching challenge details...")
+        for challenge_data in (
+            Challenge.objects.filter(id__in=valid_challenge_ids)
+            .values("id", "title", "end_date")
+            .order_by("id")
+            .iterator(chunk_size=10)
+        ):
+            challenge_id_val = challenge_data["id"]
+            logger.info(
+                f"  Challenge {challenge_id_val}: {challenge_data['title']}"
+            )
+            logger.info(f"    Current end_date: {challenge_data['end_date']}")
+            logger.info(f"    New end_date: {target_end_date}")
+
+            # Count and process phases for this challenge
+            logger.info(
+                f"    Processing phases for challenge {challenge_id_val}..."
+            )
+            phase_count = ChallengePhase.objects.filter(
+                challenge_id=challenge_id_val
+            ).count()
+            total_phases += phase_count
+
+            if phase_count > 0:
+                logger.info(f"    Phases for this challenge ({phase_count}):")
+                # Process phases using .values() to avoid similar issues
+                for phase_data in (
+                    ChallengePhase.objects.filter(
+                        challenge_id=challenge_id_val
+                    )
+                    .values("id", "name", "end_date")
+                    .order_by("id")
+                    .iterator(chunk_size=10)
+                ):
+                    logger.info(
+                        f"      Phase {phase_data['id']}: {phase_data['name']}"
+                    )
+                    logger.info(
+                        f"        Current end_date: {phase_data['end_date']}"
+                    )
+                    logger.info(f"        New end_date: {target_end_date}")
+
+        logger.info("")
+        logger.info(f"Total phases to update: {total_phases}")
+        phase_count = total_phases
+    else:
+        # Execute: process one challenge at a time to minimize memory
+        challenges_updated = 0
+        phases_updated = 0
+
+        logger.info("")
+        logger.info("Updating challenges and phases...")
+
+        for challenge_id in valid_challenge_ids:
+            # Update challenge
+            updated = Challenge.objects.filter(id=challenge_id).update(
+                end_date=target_end_date
+            )
+            if updated:
+                challenges_updated += 1
+                logger.info(f"  Updated challenge {challenge_id}")
+
+            # Update phases for this challenge
+            phase_count_for_challenge = ChallengePhase.objects.filter(
+                challenge_id=challenge_id
+            ).update(end_date=target_end_date)
+            phases_updated += phase_count_for_challenge
+
+            if phase_count_for_challenge > 0:
+                logger.info(
+                    f"    Updated {phase_count_for_challenge} phase(s) for challenge {challenge_id}"
+                )
+
+        logger.info("")
+        logger.info(f"Updated {challenges_updated} challenge(s)")
+        logger.info(f"Updated {phases_updated} phase(s)")
+        phase_count = phases_updated
+
+    # Summary (avoid sorted() to save memory - just show lists)
+    logger.info("")
+    logger.info("=" * 60)
+    logger.info("SUMMARY")
+    logger.info("=" * 60)
+    logger.info(f"Mode: {'DRY RUN' if dry_run else 'EXECUTE'}")
+    logger.info(f"Challenge IDs requested: {challenge_ids}")
+    logger.info(f"Valid challenge IDs found: {valid_challenge_ids}")
+    if missing_ids:
+        logger.info(f"Missing challenge IDs: {missing_ids}")
+    logger.info(f"Target end date: {target_end_date} (11:59:59 PM UTC)")
+    logger.info(
+        f"Challenges {'to update' if dry_run else 'updated'}: {challenge_count}"
+    )
+    logger.info(
+        f"Phases {'to update' if dry_run else 'updated'}: {phase_count}"
+    )
+    logger.info("=" * 60)
+    logger.info("Script completed successfully.")
+
+    # Clean up references to free memory
+    del valid_challenge_ids
+    if missing_ids:
+        del missing_ids
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Introduced `s3_orphans.py` for identifying and deleting orphaned S3 files not referenced in the database, optimized for low memory usage.
- Added `s3.py` to clean up S3 files associated with specific challenges, allowing for dry runs and actual deletions.
- Created `set_challenge_end_date.py` to set end dates for specified challenges and their phases, with options for dry runs and execution.
- All scripts include detailed logging and memory optimization strategies to handle large datasets efficiently.
