### PR TITLE
Update frontend to display total counts for ongoing, upcoming, and past challenges from API responses.

### DIFF
--- a/apps/challenges/admin_filters.py
+++ b/apps/challenges/admin_filters.py
@@ -27,8 +27,8 @@ class ChallengeFilter(SimpleListFilter):
             return challenges
 
         elif self.value() == "present":
-            q_params["start_date__lt"] = timezone.now()
-            q_params["end_date__gt"] = timezone.now()
+            q_params["start_date__lte"] = timezone.now()
+            q_params["end_date__gte"] = timezone.now()
             challenges = queryset.filter(**q_params)
             return challenges
 

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -770,8 +770,8 @@ def get_all_challenges(
         q_params["end_date__lt"] = timezone.now()
 
     elif challenge_time.lower() == "present":
-        q_params["start_date__lt"] = timezone.now()
-        q_params["end_date__gt"] = timezone.now()
+        q_params["start_date__lte"] = timezone.now()
+        q_params["end_date__gte"] = timezone.now()
 
     elif challenge_time.lower() == "future":
         q_params["start_date__gt"] = timezone.now()
@@ -918,8 +918,8 @@ def get_all_participated_challenges(request, challenge_time):
         q_params["end_date__lt"] = timezone.now()
 
     elif challenge_time.lower() == "present":
-        q_params["start_date__lt"] = timezone.now()
-        q_params["end_date__gt"] = timezone.now()
+        q_params["start_date__lte"] = timezone.now()
+        q_params["end_date__gte"] = timezone.now()
 
     # don't return disabled challenges
     q_params["is_disabled"] = False
@@ -2966,8 +2966,8 @@ def get_broker_urls(request):
 
     q_params = {"approved_by_admin": True}
     if is_active:
-        q_params["start_date__lt"] = timezone.now()
-        q_params["end_date__gt"] = timezone.now()
+        q_params["start_date__lte"] = timezone.now()
+        q_params["end_date__gte"] = timezone.now()
 
     if not request.user.is_superuser:
         response_data = {

--- a/frontend/src/views/web/challenge-list.html
+++ b/frontend/src/views/web/challenge-list.html
@@ -6,17 +6,17 @@
             <ul class="nav nav-underline" ng-init="tab = 1">
                 <li class="nav-item">
                     <a href="#" ng-click="tab = 1" class="nav-link" ng-class="{'active': tab === 1}">
-                        <strong class="text-med-black">Ongoing ({{challengeList.currentList.length}})</strong>
+                        <strong class="text-med-black">Ongoing ({{challengeList.currentCount}})</strong>
                     </a>
                 </li>
                 <li class="nav-item">
                     <a href="#" ng-click="tab = 2" class="nav-link" ng-class="{'active': tab === 2}">
-                        <strong class="text-med-black">Upcoming ({{challengeList.upcomingList.length}})</strong>
+                        <strong class="text-med-black">Upcoming ({{challengeList.upcomingCount}})</strong>
                     </a>
                 </li>
                 <li class="nav-item">
                     <a href="#" ng-click="tab = 3" class="nav-link" ng-class="{'active': tab === 3}">
-                        <strong class="text-med-black">Past ({{challengeList.pastList.length}})</strong>
+                        <strong class="text-med-black">Past ({{challengeList.pastCount}})</strong>
                     </a>
                 </li>
             </ul>

--- a/frontend/tests/controllers-test/challengeListCtrl.test.js
+++ b/frontend/tests/controllers-test/challengeListCtrl.test.js
@@ -29,6 +29,9 @@ describe('Unit tests for challenge list controller', function () {
             expect(vm.currentList).toEqual([]);
             expect(vm.upcomingList).toEqual([]);
             expect(vm.pastList).toEqual([]);
+            expect(vm.currentCount).toEqual(0);
+            expect(vm.upcomingCount).toEqual(0);
+            expect(vm.pastCount).toEqual(0);
             expect(vm.noneCurrentChallenge).toBeFalsy();
             expect(vm.noneUpcomingChallenge).toBeFalsy();
             expect(vm.nonePastChallenge).toBeFalsy();
@@ -65,11 +68,13 @@ describe('Unit tests for challenge list controller', function () {
             isUpcomingChallengeSucess = null;
             isPastChallengeSuccess = null;
             successResponse = {
+                count: 0,
                 next: null,
                 results: []
             };
             vm = createController();
             expect(vm.currentList).toEqual(successResponse.results);
+            expect(vm.currentCount).toEqual(0);
             expect(vm.noneCurrentChallenge).toBeTruthy();
         });
 
@@ -78,6 +83,7 @@ describe('Unit tests for challenge list controller', function () {
             isUpcomingChallengeSucess = null;
             isPastChallengeSuccess = null;
             successResponse = {
+                count: 2,
                 next: null,
                 results: [
                     {
@@ -102,6 +108,7 @@ describe('Unit tests for challenge list controller', function () {
             };
             vm = createController();
             expect(vm.currentList).toEqual(successResponse.results);
+            expect(vm.currentCount).toEqual(2);
             expect(vm.noneCurrentChallenge).toBeFalsy();
 
             var timezone = moment.tz.guess();
@@ -137,11 +144,13 @@ describe('Unit tests for challenge list controller', function () {
             isPresentChallengeSuccess = true;
             isPastChallengeSuccess = null;
             successResponse = {
+                count: 0,
                 next: null,
                 results: []
             };
             vm = createController();
             expect(vm.upcomingList).toEqual(successResponse.results);
+            expect(vm.upcomingCount).toEqual(0);
             expect(vm.noneUpcomingChallenge).toBeTruthy();
         });
 
@@ -150,6 +159,7 @@ describe('Unit tests for challenge list controller', function () {
             isPresentChallengeSuccess = true;
             isPastChallengeSuccess = null;
             successResponse = {
+                count: 2,
                 next: null,
                 results: [
                     {
@@ -174,6 +184,7 @@ describe('Unit tests for challenge list controller', function () {
             };
             vm = createController();
             expect(vm.upcomingList).toEqual(successResponse.results);
+            expect(vm.upcomingCount).toEqual(2);
             expect(vm.noneUpcomingChallenge).toBeFalsy();
 
             var timezone = moment.tz.guess();
@@ -198,6 +209,7 @@ describe('Unit tests for challenge list controller', function () {
             isPastChallengeSuccess = null;
             // success response for the ongoing challenge
             successResponse = {
+                count: 0,
                 next: null,
                 results: []
             };
@@ -211,11 +223,13 @@ describe('Unit tests for challenge list controller', function () {
             isPresentChallengeSuccess = true;
             isUpcomingChallengeSucess = true;
             successResponse = {
+                count: 0,
                 next: null,
                 results: []
             };
             vm = createController();
             expect(vm.pastList).toEqual(successResponse.results);
+            expect(vm.pastCount).toEqual(0);
             expect(vm.nonePastChallenge).toBeTruthy();
         });
 
@@ -224,6 +238,7 @@ describe('Unit tests for challenge list controller', function () {
             isPresentChallengeSuccess = true;
             isUpcomingChallengeSucess = true;
             successResponse = {
+                count: 2,
                 next: null,
                 results: [
                     {
@@ -248,6 +263,7 @@ describe('Unit tests for challenge list controller', function () {
             };
             vm = createController();
             expect(vm.pastList).toEqual(successResponse.results);
+            expect(vm.pastCount).toEqual(2);
             expect(vm.nonePastChallenge).toBeFalsy();
 
             var timezone = moment.tz.guess();
@@ -273,6 +289,7 @@ describe('Unit tests for challenge list controller', function () {
             isUpcomingChallengeSucess = true;
             // success response for the ongoing and upcoming challenge
             successResponse = {
+                count: 0,
                 next: null,
                 results: []
             };
@@ -289,6 +306,7 @@ describe('Unit tests for challenge list controller', function () {
 
             // mock response with next property set to a non-null value
             successResponse = {
+                count: 1,
                 next: 'http://example.com/challenges/?page=2',
                 results: [
                     {
@@ -308,9 +326,10 @@ describe('Unit tests for challenge list controller', function () {
             const parameters = {
                 url: 'challenges/challenge/present/approved/public',
                 method: 'GET',
+                token: null,
                 callback: jasmine.any(Function)
             };
-            vm.getAllResults(parameters, []);
+            vm.getAllResults(parameters, [], 'noneCurrentChallenge', 'currentCount', true);
             expect(vm.currentList).toEqual(successResponse.results);
             expect(vm.noneCurrentChallenge).toBeFalsy();
             expect(vm.getAllResults).toHaveBeenCalledTimes(2);
@@ -321,6 +340,7 @@ describe('Unit tests for challenge list controller', function () {
             isUpcomingChallengeSucess = null;
             isPastChallengeSuccess = null;
             successResponse = {
+                count: 0,
                 next: null,
                 results: []
             };
@@ -329,10 +349,11 @@ describe('Unit tests for challenge list controller', function () {
             spyOn(utilities, 'sendRequest').and.callThrough();
             
             const parameters = {
-                url: 'challenges/challenge/present/approved/public'
+                url: 'challenges/challenge/present/approved/public',
+                token: null
             };
             
-            vm.getAllResults(parameters, [], 'noneCurrentChallenge');
+            vm.getAllResults(parameters, [], 'noneCurrentChallenge', 'currentCount', true);
             
             expect(utilities.sendRequest).toHaveBeenCalled();
             expect(utilities.sendRequest.calls.argsFor(0)[0].method).toEqual('GET');

--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -885,7 +885,7 @@ def main():
     sys.path.append(COMPUTE_DIRECTORY_PATH)
 
     q_params = {}
-    q_params["end_date__gt"] = timezone.now()
+    q_params["end_date__gte"] = timezone.now()
 
     challenge_pk = os.environ.get("CHALLENGE_PK")
     if challenge_pk:


### PR DESCRIPTION
Refactor date filtering in challenge queries to use inclusive bounds for present challenges. Update frontend to display total counts for ongoing, upcoming, and past challenges from API responses. Enhance tests to verify new count functionality.