### PR TITLE
Implement get_config method in ChallengeConfigSerializer for streamlined challenge configuration handling

### DIFF
--- a/apps/challenges/serializers.py
+++ b/apps/challenges/serializers.py
@@ -215,6 +215,38 @@ class ChallengeConfigSerializer(serializers.ModelSerializer):
             request = context.get("request")
             kwargs["data"]["user"] = request.user.pk
 
+    @classmethod
+    def get_config(cls, challenge_queryset, data, request):
+        """
+        Get a serializer for creating or updating a ChallengeConfiguration.
+
+        If a challenge exists in the queryset and has an existing ChallengeConfiguration,
+        returns a serializer for updating. Otherwise, returns a serializer for creating.
+
+        Arguments:
+            challenge_queryset {QuerySet} -- QuerySet of challenges (filtered by github_repository)
+            data {dict} -- Request data containing zip_configuration
+            request {Request} -- The HTTP request object
+
+        Returns:
+            ChallengeConfigSerializer -- Serializer instance configured for create or update
+        """
+        existing_challenge_config = None
+        if challenge_queryset:
+            challenge = challenge_queryset[0]
+            existing_challenge_config = ChallengeConfiguration.objects.filter(
+                challenge=challenge.pk
+            ).first()
+
+        if existing_challenge_config:
+            return cls(
+                existing_challenge_config,
+                data=data,
+                context={"request": request},
+            )
+        else:
+            return cls(data=data, context={"request": request})
+
     class Meta:
         model = ChallengeConfiguration
         fields = ("zip_configuration", "user")

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -3380,9 +3380,8 @@ def validate_challenge_config(request, challenge_host_team_pk):
         github_repository=request.data["GITHUB_REPOSITORY"]
     )
 
-    data = request.data
-    challenge_config_serializer = ChallengeConfigSerializer(
-        data=data, context={"request": request}
+    challenge_config_serializer = ChallengeConfigSerializer.get_config(
+        challenge_queryset, request.data, request
     )
     if challenge_config_serializer.is_valid():
         challenge_config_serializer.save()
@@ -4049,25 +4048,10 @@ def create_or_update_github_challenge(request, challenge_host_team_pk):
         BASE_LOCATION, "{}.zip".format(unique_folder_name)
     )
 
-    data = request.data
-    # Check if challenge already exists, if so find existing
-    # ChallengeConfiguration
-    existing_challenge_config = None
-    if challenge_queryset:
-        challenge = challenge_queryset[0]
-        existing_challenge_config = ChallengeConfiguration.objects.filter(
-            challenge=challenge.pk
-        ).first()
-
-    # Use existing instance if found, otherwise create new
-    if existing_challenge_config:
-        challenge_config_serializer = ChallengeConfigSerializer(
-            existing_challenge_config, data=data, context={"request": request}
-        )
-    else:
-        challenge_config_serializer = ChallengeConfigSerializer(
-            data=data, context={"request": request}
-        )
+    # Get serializer for creating or updating ChallengeConfiguration
+    challenge_config_serializer = ChallengeConfigSerializer.get_config(
+        challenge_queryset, request.data, request
+    )
     if challenge_config_serializer.is_valid():
         uploaded_zip_file = challenge_config_serializer.save()
         uploaded_zip_file_path = challenge_config_serializer.data[


### PR DESCRIPTION
* Add a class method to ChallengeConfigSerializer that determines whether to create or update a ChallengeConfiguration based on the existence of a challenge in the queryset.
* Refactor views to utilize the new get_config method, simplifying the logic for serializer instantiation.
* Enhance unit tests to cover various scenarios for the get_config method, ensuring correct behavior for both create and update cases.
