### PR TITLE
Make seeding test non-interactive during pytest

### DIFF
--- a/tests/unit/base/test_utils.py
+++ b/tests/unit/base/test_utils.py
@@ -132,6 +132,7 @@ class TestRandomFileName(BaseAPITestClass):
 
 
 class TestSeeding(BaseAPITestClass):
+    @patch("scripts.seed.settings.TEST", True)
     def test_if_seeding_works(self):
         seed.run(1)
         self.assertEqual(Challenge.objects.all().count(), 1)


### PR DESCRIPTION
`TestSeeding.test_if_seeding_works` fails under pytest because `seed.run()` attempts to read from `input()`.

The seeding script already supports non-interactive execution via `settings.TEST`, so this patch enables test mode during the test to avoid stdin usage while preserving existing behavior.
