### PR TITLE
Restrict challenge management GET endpoints to hosts/creators

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -243,6 +243,14 @@ def challenge_detail(request, challenge_host_team_pk, challenge_pk):
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
     if request.method == "GET":
+        if not (
+            request.user.id == challenge.creator.created_by.id
+            or is_user_a_host_of_challenge(request.user, challenge.id)
+        ):
+            response_data = {
+                "error": "You are not authorized to make this request"
+            }
+            return Response(response_data, status=status.HTTP_403_FORBIDDEN)
         serializer = ChallengeSerializer(
             challenge, context={"request": request}
         )
@@ -5006,6 +5014,14 @@ def update_allowed_email_ids(request, challenge_pk, phase_pk):
             return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
     if request.method == "GET":
+        if not (
+            request.user.id == challenge.creator.created_by.id
+            or is_user_a_host_of_challenge(request.user, challenge.id)
+        ):
+            response_data = {
+                "error": "You are not authorized to make this request"
+            }
+            return Response(response_data, status=status.HTTP_403_FORBIDDEN)
         serializer = ChallengePhaseCreateSerializer(
             challenge_phase, context={"request": request}
         )

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -644,6 +644,13 @@ class GetParticularChallenge(BaseAPITestClass):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_get_particular_challenge_when_user_is_not_host_or_creator(self):
+        self.client.force_authenticate(user=self.participant_user)
+        expected = {"error": "You are not authorized to make this request"}
+        response = self.client.get(self.url, {})
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
     def test_update_challenge_when_user_is_not_its_creator(self):
         # pylint: disable=attribute-defined-outside-init
         self.user1 = User.objects.create(
@@ -6219,6 +6226,22 @@ class TestAllowedEmailIds(BaseChallengePhaseClass):
         response = self.client.get(self.url, {}, format="json")
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_get_allowed_email_ids_when_user_is_not_host_or_creator(self):
+        self.url = (  # pylint: disable=attribute-defined-outside-init
+            reverse_lazy(
+                "challenges:get_or_update_allowed_email_ids",
+                kwargs={
+                    "challenge_pk": self.challenge.pk,
+                    "phase_pk": self.challenge_phase.pk,
+                },
+            )
+        )
+        self.client.force_authenticate(user=self.participant_user)
+        expected = {"error": "You are not authorized to make this request"}
+        response = self.client.get(self.url, {}, format="json")
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_get_or_update_allowed_email_ids_patch_success(self):
         self.url = (  # pylint: disable=attribute-defined-outside-init


### PR DESCRIPTION
Related to #4949

### Context
Some challenge management endpoints expose configuration and administrative data through GET operations intended only for challenge hosts/creators.  
These endpoints relied on `IsChallengeCreator`, which allows `SAFE_METHODS`.  
In mixed-intent usage, this permitted non-host authenticated users to access host-management read surfaces.

### Change
Add explicit host/creator authorization checks to:
- `challenge_detail` (GET path)
- `update_allowed_email_ids` (GET path)

GET operations returning management/configuration data are now restricted to challenge hosts/creators.

### Scope & Safety
- No changes to `IsChallengeCreator` permission class behavior  
- Write operations remain unchanged  
- Existing response contracts preserved  

This is a targeted mitigation for host-management GET exposure without altering broader permission semantics.

### Tests
Added denial-path tests verifying:
- non-host authenticated users receive `403` on protected GET endpoints  

Existing success-path tests continue to validate host/creator access and write operations.

### Note
`IsChallengeCreator` is reused across endpoints with mixed intent.  
This PR intentionally avoids changing its global `SAFE_METHODS` behavior and focuses only on restricting host-management GET surfaces.  

Further discussion on permission behavior is tracked in #4949.