### PR TITLE
Add serializer validation test for ChallengeSerializer

### DIFF
--- a/tests/unit/challenges/test_serializers.py
+++ b/tests/unit/challenges/test_serializers.py
@@ -95,6 +95,17 @@ class ChallengeSerializerTest(BaseTestCase):
         )
         self.assertIn("is_approval_requested", serializer.data)
         self.assertTrue(serializer.data["is_approval_requested"])
+    def test_serializer_invalid_without_title(self):
+    """
+    Test that ChallengeSerializer fails validation when title is missing.
+    """
+    data = {
+        "description": "Test challenge without title"
+    }
+
+    serializer = ChallengeSerializer(data=data)
+
+    self.assertFalse(serializer.is_valid())
 
 
 class ChallengePhaseCreateSerializerTest(BaseTestCase):


### PR DESCRIPTION
### Description

This PR adds an additional validation test for `ChallengeSerializer`.

### Changes Made

* Added a test to verify that the serializer fails validation when the required `title` field is missing.

### Purpose

Improves test coverage for serializer validation in the challenges module and helps prevent regressions related to invalid challenge data.
