### PR TITLE
Add Codecov upload workflow and refactor CI for coverage reporting

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -86,10 +86,11 @@ If the code is mergeable (you get a message saying “Able to merge”), go ahea
 
 ### GitHub Actions deployment configuration
 
-The CI/CD workflow in `.github/workflows/continuous-integration-and-deployment.yml` expects deployment configuration to be stored in GitHub Environments (`staging` and `production`) using descriptive secret names:
+The CI/CD workflow in `.github/workflows/ci-cd.yml` expects deployment configuration to be stored in GitHub Environments (`staging` and `production`) using descriptive secret names:
 
 - Environment secrets: `AWS_ACCOUNT_ID`, `AWS_REGION`, `AWS_OIDC_DEPLOYMENT_ROLE_ARN`, `JUMPBOX_INSTANCE`, `DEPLOYMENT_INSTANCE_HOST`, `DEPLOYMENT_SSH_PRIVATE_KEY`, `DEPLOYMENT_SSH_KNOWN_HOSTS`
 - Repository secrets (optional for authenticated Docker Hub access): `DOCKER_USERNAME`, `DOCKER_PASSWORD`
+- Repository secret for Codecov uploads: `CODECOV_TOKEN` (used by `.github/workflows/codecov-upload.yml`, which runs after a successful `ci-cd` workflow so fork pull requests can upload without exposing the token in the main job)
 
 The deployment job uses AWS OIDC role assumption and does not require long-lived AWS access keys in GitHub secrets.
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,12 +32,16 @@ env:
   DOCKER_COMPOSE_BUILD_ARGUMENTS: "--build-arg PIP_NO_CACHE_DIR=1"
 
 jobs:
-  build_test_quality:
-    name: Build Test and Quality Checks
+  # Runs in parallel with test matrix; each job pays a docker compose build, but wall time
+  # is roughly max(quality, backend tests, frontend tests) instead of the sum.
+  code_quality:
+    name: Code quality and migrations
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: write # upload coverage artifacts for follow-up Codecov workflow
+      actions: write # BuildKit GHA cache (type=gha) export
+    env:
+      COMPOSE_FILE: docker-compose.yml:docker/docker-compose.ci-cache.yml
 
     steps:
       - name: Checkout repository
@@ -72,8 +76,6 @@ jobs:
           ulimit -u 16384 || true
           ulimit -n 4096 || true
 
-      # Optional: set DOCKER_USERNAME + DOCKER_PASSWORD (access token) repo secrets for higher Docker Hub pull limits.
-      # secrets cannot be used in step `if:`; gate on event here, then check credentials in the shell.
       - name: Log in to Docker Hub
         if: github.event_name != 'pull_request'
         env:
@@ -96,7 +98,120 @@ jobs:
         run: |
           docker compose $WORKER_DOCKER_COMPOSE_PROFILES build $DOCKER_COMPOSE_BUILD_ARGUMENTS
 
+      - name: Run code quality checks
+        run: |
+          docker compose run -e DJANGO_SETTINGS_MODULE=settings.dev -e VERBOSE=1 django bash -c '
+            set -e
+            echo "=== Installing code quality tools ==="
+            pip install black==24.8.0 flake8==3.8.2 pylint==3.3.6 isort==5.12.0
+            echo "=== Running black check ==="
+            black --check --diff ./
+            echo "=== Running isort check ==="
+            isort --check-only --diff --profile=black ./
+            echo "=== Running flake8 check ==="
+            flake8 --config=.flake8 ./
+            echo "=== Running pylint check ==="
+            pylint --rcfile=.pylintrc --output-format=colorized --score=y --fail-under=7.5 ./
+            echo "=== All code quality checks passed ==="
+          '
+
+      - name: Validate Django migrations for pull requests
+        if: github.event_name == 'pull_request'
+        run: |
+          docker compose run -e DJANGO_SETTINGS_MODULE=settings.dev django python manage.py makemigrations --check --dry-run
+
+  tests:
+    name: Tests (${{ matrix.suite }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write # artifacts + BuildKit GHA cache export
+    env:
+      COMPOSE_FILE: docker-compose.yml:docker/docker-compose.ci-cache.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [backend, frontend]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python runtime
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_RUNTIME_VERSION }}
+          cache: pip
+
+      - name: Validate Docker Compose availability
+        run: |
+          docker --version
+          docker compose version
+
+      - name: Install shared command-line dependencies
+        run: |
+          pip install --upgrade pip
+          pip install awscli=="${AWS_COMMAND_LINE_INTERFACE_VERSION}"
+          sudo rm -f /etc/boto.cfg
+          mkdir -p "$HOME/.config/pip"
+          {
+            echo "[build_ext]"
+            echo "parallel = 1"
+          } > "$HOME/.config/pip/pip.conf"
+
+      - name: Configure CI runtime limits
+        run: |
+          ulimit -u 16384 || true
+          ulimit -n 4096 || true
+
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          if [ -n "${DOCKER_USERNAME}" ] && [ -n "${DOCKER_PASSWORD}" ]; then
+            echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
+          else
+            echo "Skipping Docker Hub authentication (secrets not configured)."
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker images for CI
+        env:
+          COMPOSE_BAKE: true
+          DOCKER_BUILDKIT: 1
+        run: |
+          docker compose $WORKER_DOCKER_COMPOSE_PROFILES build $DOCKER_COMPOSE_BUILD_ARGUMENTS
+
+      - name: Run backend tests
+        if: matrix.suite == 'backend'
+        run: |
+          docker compose run -e DJANGO_SETTINGS_MODULE=settings.test django bash -c '
+            set -e
+            echo "=== Flushing database ==="
+            python manage.py flush --noinput
+            echo "=== Running backend tests with coverage ==="
+            pytest --cov . --cov-config .coveragerc --cov-report=xml:coverage-backend.xml --junitxml=junit-backend.xml -o junit_family=legacy
+            echo "=== Backend tests passed ==="
+          '
+
+      - name: Upload backend test and coverage artifacts
+        if: matrix.suite == 'backend'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-backend-reports
+          path: |
+            junit-backend.xml
+            coverage-backend.xml
+          if-no-files-found: error
+
       - name: Run frontend build and tests
+        if: matrix.suite == 'frontend'
         env:
           CHROME_BIN: ${{ env.CHROME_BROWSER_BINARY }}
           DISPLAY: ${{ env.DISPLAY_SERVER_ADDRESS }}
@@ -142,38 +257,35 @@ jobs:
             echo "=== Frontend build complete ==="
           '
 
-      - name: Run backend tests
-        run: |
-          docker compose run -e DJANGO_SETTINGS_MODULE=settings.test django bash -c '
-            set -e
-            echo "=== Flushing database ==="
-            python manage.py flush --noinput
-            echo "=== Running backend tests with coverage ==="
-            pytest --cov . --cov-config .coveragerc --cov-report=xml:coverage-backend.xml --junitxml=junit-backend.xml -o junit_family=legacy
-            echo "=== Backend tests passed ==="
-          '
+      - name: Upload frontend test and coverage artifacts
+        if: matrix.suite == 'frontend'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-frontend-reports
+          path: |
+            coverage/frontend/TEST-frontend.xml
+            coverage/frontend/lcov.info
+          if-no-files-found: warn
 
-      - name: Run code quality checks
-        run: |
-          docker compose run -e DJANGO_SETTINGS_MODULE=settings.dev -e VERBOSE=1 django bash -c '
-            set -e
-            echo "=== Installing code quality tools ==="
-            pip install black==24.8.0 flake8==3.8.2 pylint==3.3.6 isort==5.12.0
-            echo "=== Running black check ==="
-            black --check --diff ./
-            echo "=== Running isort check ==="
-            isort --check-only --diff --profile=black ./
-            echo "=== Running flake8 check ==="
-            flake8 --config=.flake8 ./
-            echo "=== Running pylint check ==="
-            pylint --rcfile=.pylintrc --output-format=colorized --score=y --fail-under=7.5 ./
-            echo "=== All code quality checks passed ==="
-          '
+  collect_ci_artifacts:
+    name: Collect reports for Codecov and JUnit
+    runs-on: ubuntu-latest
+    needs: [tests]
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Download backend artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ci-backend-reports
+          path: .
 
-      - name: Validate Django migrations for pull requests
-        if: github.event_name == 'pull_request'
-        run: |
-          docker compose run -e DJANGO_SETTINGS_MODULE=settings.dev django python manage.py makemigrations --check --dry-run
+      - name: Download frontend artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ci-frontend-reports
+          path: .
 
       - name: Upload backend and frontend test reports
         uses: actions/upload-artifact@v4
@@ -184,9 +296,6 @@ jobs:
             coverage/frontend/TEST-frontend.xml
           if-no-files-found: warn
 
-      # Coverage is uploaded in a separate workflow (codecov-upload.yml) triggered by
-      # workflow_run so CODECOV_TOKEN is available for fork PRs (secrets are not exposed
-      # to pull_request jobs from forks, but workflow_run on the default branch can use them).
       - name: Upload coverage artifacts for Codecov
         uses: actions/upload-artifact@v4
         with:
@@ -200,7 +309,9 @@ jobs:
     name: Package and Deploy Services
     runs-on: ubuntu-latest
     needs:
-      - build_test_quality
+      - code_quality
+      - tests
+      - collect_ci_artifacts
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration and Deployment
+name: ci-cd
 
 on:
   push:
@@ -20,7 +20,7 @@ on:
         default: true
 
 concurrency:
-  group: continuous-integration-and-deployment-${{ github.ref }}
+  group: ci-cd-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/codecov-upload.yml
+++ b/.github/workflows/codecov-upload.yml
@@ -5,7 +5,7 @@ name: Codecov upload
 
 on:
   workflow_run:
-    workflows: ["Continuous Integration and Deployment"]
+    workflows: ["ci-cd"]
     types: [completed]
 
 jobs:

--- a/.github/workflows/codecov-upload.yml
+++ b/.github/workflows/codecov-upload.yml
@@ -1,0 +1,53 @@
+# Uploads coverage using CODECOV_TOKEN from repository secrets. Triggered after the main
+# CI workflow completes so fork pull requests are supported: pull_request jobs from forks
+# cannot use secrets, but workflow_run executes in the base repo context and can.
+name: Codecov upload
+
+on:
+  workflow_run:
+    workflows: ["Continuous Integration and Deployment"]
+    types: [completed]
+
+jobs:
+  upload:
+    name: Upload coverage to Codecov
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: codecov-coverage-reports
+          path: codecov-reports
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      # override_pr only for pull_request (short-circuit avoids pull_requests[0] on push).
+      - name: Upload backend coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: codecov-reports/coverage-backend.xml
+          flags: backend
+          disable_search: true
+          fail_ci_if_error: true
+          verbose: true
+          override_commit: ${{ github.event.workflow_run.head_sha }}
+          override_branch: ${{ github.event.workflow_run.head_branch }}
+          override_pr: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0].number || '' }}
+
+      - name: Upload frontend coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: codecov-reports/coverage/frontend/lcov.info
+          flags: frontend
+          disable_search: true
+          fail_ci_if_error: true
+          verbose: true
+          override_commit: ${{ github.event.workflow_run.head_sha }}
+          override_branch: ${{ github.event.workflow_run.head_branch }}
+          override_pr: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0].number || '' }}

--- a/.github/workflows/continuous-integration-and-deployment.yml
+++ b/.github/workflows/continuous-integration-and-deployment.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write # Codecov OIDC uploads (codecov-action use_oidc)
+      actions: write # upload coverage artifacts for follow-up Codecov workflow
 
     steps:
       - name: Checkout repository
@@ -184,26 +184,17 @@ jobs:
             coverage/frontend/TEST-frontend.xml
           if-no-files-found: warn
 
-      # Authenticate uploads with GitHub OIDC (no CODECOV_TOKEN secret). Requires
-      # codecov-action v4.2+. Fork PRs: GitHub may not mint id-token; public repos may
-      # still get tokenless uploads per Codecov branch naming — see codecov/codecov-action#1489.
-      - name: Upload backend coverage to Codecov
-        uses: codecov/codecov-action@v4
+      # Coverage is uploaded in a separate workflow (codecov-upload.yml) triggered by
+      # workflow_run so CODECOV_TOKEN is available for fork PRs (secrets are not exposed
+      # to pull_request jobs from forks, but workflow_run on the default branch can use them).
+      - name: Upload coverage artifacts for Codecov
+        uses: actions/upload-artifact@v4
         with:
-          use_oidc: true
-          files: coverage-backend.xml
-          flags: backend
-          fail_ci_if_error: true
-          verbose: true
-
-      - name: Upload frontend coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          use_oidc: true
-          files: coverage/frontend/lcov.info
-          flags: frontend
-          fail_ci_if_error: true
-          verbose: true
+          name: codecov-coverage-reports
+          path: |
+            coverage-backend.xml
+            coverage/frontend/lcov.info
+          if-no-files-found: error
 
   package_and_deploy_services:
     name: Package and Deploy Services

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ------------------------------------------------------------------------------------------
 
 [![Join the chat on Slack](https://img.shields.io/badge/Join%20Slack-Chat-blue?logo=slack)](https://join.slack.com/t/cloudcv-community/shared_invite/zt-3252n6or8-e0QuZKIZFLB0zXtQ6XgxfA)
-[![Build Status](https://github.com/Cloud-CV/EvalAI/actions/workflows/continuous-integration-and-deployment.yml/badge.svg?branch=master)](https://github.com/Cloud-CV/EvalAI/actions/workflows/continuous-integration-and-deployment.yml)
+[![Build Status](https://github.com/Cloud-CV/EvalAI/actions/workflows/ci-cd.yml/badge.svg?branch=master)](https://github.com/Cloud-CV/EvalAI/actions/workflows/ci-cd.yml)
 [![Coverage](https://img.shields.io/codecov/c/github/Cloud-CV/EvalAI?label=Coverage&style=flat-square)](https://codecov.io/gh/Cloud-CV/EvalAI)
 [![Backend Coverage](https://img.shields.io/codecov/c/github/Cloud-CV/EvalAI?flag=backend&label=Backend&style=flat-square)](https://codecov.io/gh/Cloud-CV/EvalAI?flag=backend)
 [![Frontend Coverage](https://img.shields.io/codecov/c/github/Cloud-CV/EvalAI?flag=frontend&label=Frontend&style=flat-square)](https://codecov.io/gh/Cloud-CV/EvalAI?flag=frontend)

--- a/docker/docker-compose.ci-cache.yml
+++ b/docker/docker-compose.ci-cache.yml
@@ -1,0 +1,33 @@
+# Merge with docker-compose.yml only in GitHub Actions (see ci-cd workflow COMPOSE_FILE).
+# Enables BuildKit cache export/import via actions/cache (type=gha). Not for local use.
+services:
+  django:
+    build:
+      cache_from:
+        - type=gha,scope=evalai-django
+      cache_to:
+        - type=gha,scope=evalai-django,mode=max
+  nodejs:
+    build:
+      cache_from:
+        - type=gha,scope=evalai-nodejs
+      cache_to:
+        - type=gha,scope=evalai-nodejs,mode=max
+  worker_py3_7:
+    build:
+      cache_from:
+        - type=gha,scope=evalai-worker-py37
+      cache_to:
+        - type=gha,scope=evalai-worker-py37,mode=max
+  worker_py3_8:
+    build:
+      cache_from:
+        - type=gha,scope=evalai-worker-py38
+      cache_to:
+        - type=gha,scope=evalai-worker-py38,mode=max
+  worker_py3_9:
+    build:
+      cache_from:
+        - type=gha,scope=evalai-worker-py39
+      cache_to:
+        - type=gha,scope=evalai-worker-py39,mode=max


### PR DESCRIPTION
- Introduced a new GitHub Actions workflow for uploading coverage reports to Codecov, triggered after the main CI workflow completes. This allows the use of CODECOV_TOKEN from repository secrets, supporting fork pull requests.
- Refactored the existing CI workflow to upload coverage artifacts separately, ensuring compatibility with forked pull requests by utilizing the new workflow for Codecov uploads. Updated permissions for actions accordingly.
