### PR TITLE
Add step to list downloaded artifacts in upload-coverage workflow

### DIFF
--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -57,6 +57,11 @@ jobs:
           pr_number="$(tr -d '[:space:]' < pr-metadata/pr_number.txt || true)"
           echo "number=${pr_number}" >> "$GITHUB_OUTPUT"
 
+      - name: List downloaded artifacts
+        run: |
+          echo "=== codecov-reports tree ==="
+          find codecov-reports -type f | sort || echo "(empty or missing)"
+
       - name: Verify coverage files exist
         run: |
           set -euo pipefail


### PR DESCRIPTION
- Introduced a new step in the GitHub Actions workflow to list downloaded artifacts, enhancing visibility of the coverage reports directory. This addition helps in debugging and ensures that users can confirm the presence of expected files before proceeding with further actions.