### PR TITLE
Update upload-coverage workflow to simplify coverage file paths

### DIFF
--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           set -euo pipefail
           test -f codecov-reports/coverage-backend.xml
-          test -f codecov-reports/coverage/frontend/lcov.info
+          test -f codecov-reports/lcov.info
 
       - name: Upload combined JUnit test reports
         uses: actions/upload-artifact@v4
@@ -74,7 +74,7 @@ jobs:
           name: junit-test-reports
           path: |
             codecov-reports/junit-backend.xml
-            codecov-reports/coverage/frontend/TEST-frontend.xml
+            codecov-reports/TEST-frontend.xml
           if-no-files-found: warn
 
       - name: Upload backend coverage to Codecov
@@ -94,7 +94,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: codecov-reports/coverage/frontend/lcov.info
+          files: codecov-reports/lcov.info
           flags: frontend
           disable_search: true
           fail_ci_if_error: true


### PR DESCRIPTION
- Modified the paths for coverage files in the GitHub Actions workflow to streamline the upload process. This change consolidates the location of coverage reports, ensuring that the correct files are referenced for both verification and upload to Codecov, enhancing clarity and reducing potential errors during CI runs.
