### PR TITLE
Implement submission pause handling in challenge submission workflow and fix flake8

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,7 +66,7 @@ jobs:
           docker compose run -e DJANGO_SETTINGS_MODULE=settings.dev -e VERBOSE=1 django bash -c '
             set -e
             echo "=== Installing code quality tools ==="
-            pip install black==24.8.0 flake8==3.8.2 pylint==3.3.6 isort==5.12.0
+            pip install black==24.8.0 flake8==7.1.2 pylint==3.3.6 isort==5.12.0
             echo "=== Running black check ==="
             black --check --diff ./
             echo "=== Running isort check ==="

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         verbose: true
 
   - repo: https://github.com/pycqa/flake8
-    rev: 3.8.2
+    rev: 7.1.2
     hooks:
       - id: flake8
         args: ['--config=.flake8', '--verbose']

--- a/apps/jobs/tasks.py
+++ b/apps/jobs/tasks.py
@@ -28,6 +28,17 @@ def download_file_and_publish_submission_message(
     """
     user = User.objects.get(pk=user_pk)
     challenge_phase = ChallengePhase.objects.get(pk=challenge_phase_id)
+    if (
+        challenge_phase.challenge.is_submission_paused
+        or challenge_phase.is_submission_paused
+    ):
+        logger.warning(
+            "Skipping URL-based submission task: submissions paused for "
+            "challenge_pk=%s phase_pk=%s",
+            challenge_phase.challenge.pk,
+            challenge_phase.pk,
+        )
+        return
     participant_team_id = get_participant_team_id_of_user_for_a_challenge(
         user, challenge_phase.challenge.pk
     )

--- a/apps/jobs/utils.py
+++ b/apps/jobs/utils.py
@@ -17,6 +17,7 @@ from hosts.utils import is_user_a_staff_or_host
 from participants.models import ParticipantTeam
 from participants.utils import get_participant_team_id_of_user_for_a_challenge
 from rest_framework import status
+from rest_framework.response import Response
 
 from .constants import submission_status_to_exclude
 from .models import Submission
@@ -26,6 +27,24 @@ get_submission_model = get_model_object(Submission)
 get_challenge_phase_split_model = get_model_object(ChallengePhaseSplit)
 
 logger = logging.getLogger(__name__)
+
+
+def response_if_submissions_paused(challenge, challenge_phase):
+    """
+    Return HTTP 406 if new submissions are paused at challenge or phase level.
+    Error payloads match challenge_submission.
+    """
+    if challenge.is_submission_paused:
+        response_data = {
+            "error": "Submissions are currently paused for this challenge. Please try again later."
+        }
+        return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
+    if challenge_phase.is_submission_paused:
+        response_data = {
+            "error": "Submissions are currently paused for this challenge phase. Please try again later."
+        }
+        return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
+    return None
 
 
 def get_remaining_submission_for_a_phase(

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -84,6 +84,7 @@ from .utils import (
     is_url_valid,
     reorder_submissions_comparator,
     reorder_submissions_comparator_to_key,
+    response_if_submissions_paused,
 )
 
 logger = logging.getLogger(__name__)
@@ -214,14 +215,6 @@ def challenge_submission(request, challenge_id, challenge_phase_id):
                 response_data, status=status.HTTP_406_NOT_ACCEPTABLE
             )
 
-        if challenge.is_submission_paused:
-            response_data = {
-                "error": "Submissions are currently paused for this challenge. Please try again later."
-            }
-            return Response(
-                response_data, status=status.HTTP_406_NOT_ACCEPTABLE
-            )
-
         # check if challenge phase is active
         if not challenge_phase.is_active:
             response_data = {
@@ -231,13 +224,9 @@ def challenge_submission(request, challenge_id, challenge_phase_id):
                 response_data, status=status.HTTP_406_NOT_ACCEPTABLE
             )
 
-        if challenge_phase.is_submission_paused:
-            response_data = {
-                "error": "Submissions are currently paused for this challenge phase. Please try again later."
-            }
-            return Response(
-                response_data, status=status.HTTP_406_NOT_ACCEPTABLE
-            )
+        paused = response_if_submissions_paused(challenge, challenge_phase)
+        if paused is not None:
+            return paused
 
         # check if user is a challenge host or a participant
         is_host = is_user_a_host_of_challenge(request.user, challenge_id)
@@ -2859,6 +2848,10 @@ def get_submission_file_presigned_url(request, challenge_phase_pk):
         }
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
+    paused = response_if_submissions_paused(challenge, challenge_phase)
+    if paused is not None:
+        return paused
+
     # Check if user is a challenge host or a participant
     is_host = is_user_a_host_of_challenge(request.user, challenge.pk)
     if not is_host:
@@ -3041,6 +3034,10 @@ def finish_submission_file_upload(request, challenge_phase_pk, submission_pk):
         }
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
 
+    paused = response_if_submissions_paused(challenge, challenge_phase)
+    if paused is not None:
+        return paused
+
     # Check if user is a challenge host or a participant
     if not is_user_a_host_of_challenge(request.user, challenge.pk):
         # Check if challenge phase is public and accepting solutions
@@ -3160,6 +3157,10 @@ def send_submission_message(request, challenge_phase_pk, submission_pk):
             "error": "Sorry, cannot accept submissions since challenge phase is not active"
         }
         return Response(response_data, status=status.HTTP_406_NOT_ACCEPTABLE)
+
+    paused = response_if_submissions_paused(challenge, challenge_phase)
+    if paused is not None:
+        return paused
 
     is_host = is_user_a_host_of_challenge(request.user, challenge.pk)
     if not is_host:

--- a/tests/unit/jobs/test_tasks.py
+++ b/tests/unit/jobs/test_tasks.py
@@ -31,6 +31,8 @@ def test_download_file_and_publish_submission_message_success(
     mock_challenge_phase = MagicMock()
     mock_challenge_phase.challenge.pk = 1
     mock_challenge_phase.pk = 2
+    mock_challenge_phase.challenge.is_submission_paused = False
+    mock_challenge_phase.is_submission_paused = False
     mock_challenge_phase_get.return_value = mock_challenge_phase
 
     mock_get_participant_team_id.return_value = 3
@@ -89,6 +91,8 @@ def test_download_file_and_publish_submission_message_exception(
     mock_challenge_phase = MagicMock()
     mock_challenge_phase.challenge.pk = 1
     mock_challenge_phase.pk = 2
+    mock_challenge_phase.challenge.is_submission_paused = False
+    mock_challenge_phase.is_submission_paused = False
     mock_challenge_phase_get.return_value = mock_challenge_phase
 
     mock_get_participant_team_id.return_value = 3
@@ -137,6 +141,8 @@ def test_download_file_and_publish_submission_message_exception_with_temp_dir(
     mock_challenge_phase = MagicMock()
     mock_challenge_phase.challenge.pk = 1
     mock_challenge_phase.pk = 2
+    mock_challenge_phase.challenge.is_submission_paused = False
+    mock_challenge_phase.is_submission_paused = False
     mock_challenge_phase_get.return_value = mock_challenge_phase
 
     mock_get_participant_team_id.return_value = 3
@@ -163,3 +169,83 @@ def test_download_file_and_publish_submission_message_exception_with_temp_dir(
 
     mock_rmtree.assert_called_once_with("/tmp/test")
     assert mock_logger.exception.call_count == 1
+
+
+@patch("jobs.tasks.User.objects.get")
+@patch("jobs.tasks.ChallengePhase.objects.get")
+@patch("jobs.tasks.get_participant_team_id_of_user_for_a_challenge")
+@patch("jobs.tasks.ParticipantTeam.objects.get")
+@patch("jobs.tasks.publish_submission_message")
+@patch("jobs.tasks.logger")
+def test_download_file_and_publish_submission_message_skipped_when_challenge_paused(
+    mock_logger,
+    mock_publish,
+    mock_participant_team_get,
+    mock_get_participant_team_id,
+    mock_challenge_phase_get,
+    mock_user_get,
+):
+    mock_user_get.return_value = MagicMock()
+    mock_challenge_phase = MagicMock()
+    mock_challenge_phase.challenge.pk = 42
+    mock_challenge_phase.pk = 99
+    mock_challenge_phase.challenge.is_submission_paused = True
+    mock_challenge_phase.is_submission_paused = False
+    mock_challenge_phase_get.return_value = mock_challenge_phase
+
+    request_data = {
+        "file_url": "http://test/file.txt",
+        "method_name": "test",
+        "method_description": "desc",
+        "project_url": "http://project",
+        "publication_url": "http://pub",
+    }
+
+    download_file_and_publish_submission_message(
+        request_data, user_pk=1, request_method="POST", challenge_phase_id=99
+    )
+
+    mock_logger.warning.assert_called_once()
+    mock_publish.assert_not_called()
+    mock_get_participant_team_id.assert_not_called()
+    mock_participant_team_get.assert_not_called()
+
+
+@patch("jobs.tasks.User.objects.get")
+@patch("jobs.tasks.ChallengePhase.objects.get")
+@patch("jobs.tasks.get_participant_team_id_of_user_for_a_challenge")
+@patch("jobs.tasks.ParticipantTeam.objects.get")
+@patch("jobs.tasks.publish_submission_message")
+@patch("jobs.tasks.logger")
+def test_download_file_and_publish_submission_message_skipped_when_phase_paused(
+    mock_logger,
+    mock_publish,
+    mock_participant_team_get,
+    mock_get_participant_team_id,
+    mock_challenge_phase_get,
+    mock_user_get,
+):
+    mock_user_get.return_value = MagicMock()
+    mock_challenge_phase = MagicMock()
+    mock_challenge_phase.challenge.pk = 42
+    mock_challenge_phase.pk = 99
+    mock_challenge_phase.challenge.is_submission_paused = False
+    mock_challenge_phase.is_submission_paused = True
+    mock_challenge_phase_get.return_value = mock_challenge_phase
+
+    request_data = {
+        "file_url": "http://test/file.txt",
+        "method_name": "test",
+        "method_description": "desc",
+        "project_url": "http://project",
+        "publication_url": "http://pub",
+    }
+
+    download_file_and_publish_submission_message(
+        request_data, user_pk=1, request_method="POST", challenge_phase_id=99
+    )
+
+    mock_logger.warning.assert_called_once()
+    mock_publish.assert_not_called()
+    mock_get_participant_team_id.assert_not_called()
+    mock_participant_team_get.assert_not_called()

--- a/tests/unit/jobs/test_utils.py
+++ b/tests/unit/jobs/test_utils.py
@@ -13,8 +13,10 @@ from jobs.utils import (
     handle_submission_resume,
     is_url_valid,
     reorder_submissions_comparator_to_key,
+    response_if_submissions_paused,
 )
 from jobs.views import _compute_remaining_limits
+from rest_framework import status
 
 
 class TestUtils(unittest.TestCase):
@@ -1327,6 +1329,49 @@ class TestComputeRemainingLimits(unittest.TestCase):
         result = _compute_remaining_limits(phase, 0, 3, 0, now)
         self.assertEqual(result["remaining_submissions_this_month_count"], 2)
         self.assertEqual(result["remaining_submissions_today_count"], 2)
+
+
+class TestResponseIfSubmissionsPaused(unittest.TestCase):
+    def test_returns_none_when_not_paused(self):
+        challenge = MagicMock()
+        challenge.is_submission_paused = False
+        phase = MagicMock()
+        phase.is_submission_paused = False
+        self.assertIsNone(response_if_submissions_paused(challenge, phase))
+
+    def test_challenge_paused_returns_406_body(self):
+        challenge = MagicMock()
+        challenge.is_submission_paused = True
+        phase = MagicMock()
+        phase.is_submission_paused = False
+        resp = response_if_submissions_paused(challenge, phase)
+        self.assertIsNotNone(resp)
+        self.assertEqual(resp.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertEqual(
+            resp.data["error"],
+            "Submissions are currently paused for this challenge. Please try again later.",
+        )
+
+    def test_phase_paused_returns_406_body(self):
+        challenge = MagicMock()
+        challenge.is_submission_paused = False
+        phase = MagicMock()
+        phase.is_submission_paused = True
+        resp = response_if_submissions_paused(challenge, phase)
+        self.assertIsNotNone(resp)
+        self.assertEqual(resp.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertEqual(
+            resp.data["error"],
+            "Submissions are currently paused for this challenge phase. Please try again later.",
+        )
+
+    def test_challenge_paused_wins_when_both_paused(self):
+        challenge = MagicMock()
+        challenge.is_submission_paused = True
+        phase = MagicMock()
+        phase.is_submission_paused = True
+        resp = response_if_submissions_paused(challenge, phase)
+        self.assertIn("challenge", resp.data["error"])
 
 
 class Submission:

--- a/tests/unit/jobs/test_views.py
+++ b/tests/unit/jobs/test_views.py
@@ -267,6 +267,44 @@ class BaseAPITestClass(APITestCase):
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
 
+    @mock.patch(
+        "jobs.views.download_file_and_publish_submission_message.delay"
+    )
+    @mock.patch("jobs.views.is_url_valid", return_value=True)
+    def test_challenge_submission_file_url_not_queued_when_challenge_paused(
+        self, mock_is_url_valid, mock_delay
+    ):
+        self.url = reverse_lazy(
+            "jobs:challenge_submission",
+            kwargs={
+                "challenge_id": self.challenge.pk,
+                "challenge_phase_id": self.challenge_phase.pk,
+            },
+        )
+        self.challenge.participant_teams.add(self.participant_team)
+        self.challenge.is_submission_paused = True
+        self.challenge.save()
+        expected = {
+            "error": "Submissions are currently paused for this challenge. Please try again later."
+        }
+        response = self.client.post(
+            self.url,
+            {
+                "status": "submitting",
+                "file_url": "http://example.com/submission.bin",
+                "method_name": "test",
+                "method_description": "desc",
+                "project_url": "http://project.example.com",
+                "publication_url": "http://pub.example.com",
+            },
+        )
+        self.assertEqual(response.data, expected)
+        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        mock_delay.assert_not_called()
+
+        self.challenge.is_submission_paused = False
+        self.challenge.save()
+
     def test_challenge_submission_when_phase_submissions_are_paused(self):
         self.url = reverse_lazy(
             "jobs:challenge_submission",
@@ -290,6 +328,32 @@ class BaseAPITestClass(APITestCase):
         )
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+
+    def test_challenge_submission_inactive_phase_errors_before_challenge_paused(
+        self,
+    ):
+        """Phase activity is checked before submission pause (same as multipart APIs)."""
+        self.url = reverse_lazy(
+            "jobs:challenge_submission",
+            kwargs={
+                "challenge_id": self.challenge.pk,
+                "challenge_phase_id": self.challenge_phase.pk,
+            },
+        )
+        self.challenge_phase.end_date = timezone.now() - timedelta(days=1)
+        self.challenge_phase.save()
+        self.challenge.is_submission_paused = True
+        self.challenge.save()
+        expected = {
+            "error": "Sorry, cannot accept submissions since challenge phase is not active"
+        }
+        response = self.client.post(
+            self.url,
+            {"status": "submitting", "input_file": self.input_file},
+            format="multipart",
+        )
+        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertEqual(response.data, expected)
 
     def test_challenge_submission_when_phase_submissions_unpaused(self):
         self.url = reverse_lazy(
@@ -2897,3 +2961,359 @@ class PresignedURLSubmissionTest(BaseAPITestClass):
 
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    @mock.patch("jobs.views.ensure_workers_for_submission")
+    @mock.patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_get_submission_presigned_url_rejected_when_challenge_paused(
+        self, mock_get_aws_creds, mock_ensure_workers
+    ):
+        self.challenge.is_submission_paused = True
+        self.challenge.save()
+        url = reverse_lazy(
+            "jobs:get_submission_file_presigned_url",
+            kwargs={"challenge_phase_pk": self.challenge_phase.pk},
+        )
+        expected = {
+            "error": "Submissions are currently paused for this challenge. Please try again later."
+        }
+        self.client.force_authenticate(user=self.challenge_host.user)
+        mock_get_aws_creds.return_value = {
+            "AWS_ACCESS_KEY_ID": "dummy-key",
+            "AWS_SECRET_ACCESS_KEY": "dummy-access-key",
+            "AWS_STORAGE_BUCKET_NAME": "test-bucket",
+            "AWS_REGION": "us-east-1",
+        }
+        boto3.client("s3").create_bucket(Bucket="test-bucket")
+        response = self.client.post(
+            url,
+            data={
+                "status": "submitting",
+                "num_file_chunks": 1,
+                "file_name": "media/submissions/dummy.txt",
+            },
+        )
+        mock_ensure_workers.assert_not_called()
+        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertEqual(response.data, expected)
+        self.challenge.is_submission_paused = False
+        self.challenge.save()
+
+    @mock.patch("jobs.views.ensure_workers_for_submission")
+    @mock.patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_get_submission_presigned_url_rejected_when_phase_paused(
+        self, mock_get_aws_creds, mock_ensure_workers
+    ):
+        self.challenge_phase.is_submission_paused = True
+        self.challenge_phase.save()
+        url = reverse_lazy(
+            "jobs:get_submission_file_presigned_url",
+            kwargs={"challenge_phase_pk": self.challenge_phase.pk},
+        )
+        expected = {
+            "error": "Submissions are currently paused for this challenge phase. Please try again later."
+        }
+        self.client.force_authenticate(user=self.challenge_host.user)
+        mock_get_aws_creds.return_value = {
+            "AWS_ACCESS_KEY_ID": "dummy-key",
+            "AWS_SECRET_ACCESS_KEY": "dummy-access-key",
+            "AWS_STORAGE_BUCKET_NAME": "test-bucket",
+            "AWS_REGION": "us-east-1",
+        }
+        boto3.client("s3").create_bucket(Bucket="test-bucket")
+        response = self.client.post(
+            url,
+            data={
+                "status": "submitting",
+                "num_file_chunks": 1,
+                "file_name": "media/submissions/dummy.txt",
+            },
+        )
+        mock_ensure_workers.assert_not_called()
+        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertEqual(response.data, expected)
+        self.challenge_phase.is_submission_paused = False
+        self.challenge_phase.save()
+
+    @mock.patch("jobs.views.ensure_workers_for_submission")
+    @mock.patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_finish_submission_file_upload_rejected_when_challenge_paused_after_presign(
+        self, mock_get_aws_creds, mock_ensure_workers
+    ):
+        self.url = reverse_lazy(
+            "jobs:get_submission_file_presigned_url",
+            kwargs={"challenge_phase_pk": self.challenge_phase.pk},
+        )
+        self.client.force_authenticate(user=self.challenge_host.user)
+        mock_get_aws_creds.return_value = {
+            "AWS_ACCESS_KEY_ID": "dummy-key",
+            "AWS_SECRET_ACCESS_KEY": "dummy-access-key",
+            "AWS_STORAGE_BUCKET_NAME": "test-bucket",
+            "AWS_REGION": "us-east-1",
+        }
+        boto3.client("s3").create_bucket(Bucket="test-bucket")
+        response = self.client.post(
+            self.url,
+            data={
+                "status": "submitting",
+                "num_file_chunks": 1,
+                "file_name": "media/submissions/dummy.txt",
+            },
+        )
+        submission_pk = response.data["submission_pk"]
+        upload_id = response.data["upload_id"]
+        submission = Submission.objects.get(pk=submission_pk)
+        presigned_url_object = response.data["presigned_urls"][0]
+        file_data = submission.input_file.read()
+        put_resp = requests.put(presigned_url_object["url"], data=file_data)
+        self.assertEqual(put_resp.status_code, status.HTTP_200_OK)
+        parts = [
+            {
+                "ETag": put_resp.headers["ETag"],
+                "PartNumber": presigned_url_object["partNumber"],
+            }
+        ]
+
+        self.challenge.is_submission_paused = True
+        self.challenge.save()
+
+        finish_url = reverse_lazy(
+            "jobs:finish_submission_file_upload",
+            kwargs={
+                "challenge_phase_pk": self.challenge_phase.pk,
+                "submission_pk": submission_pk,
+            },
+        )
+        expected = {
+            "error": "Submissions are currently paused for this challenge. Please try again later."
+        }
+        response = self.client.post(
+            finish_url,
+            data={
+                "parts": json.dumps(parts),
+                "upload_id": upload_id,
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertEqual(response.data, expected)
+
+        self.challenge.is_submission_paused = False
+        self.challenge.save()
+
+    @mock.patch("jobs.views.ensure_workers_for_submission")
+    @mock.patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_send_submission_message_rejected_when_challenge_paused(
+        self, mock_get_aws_creds, mock_ensure_workers
+    ):
+        self.url = reverse_lazy(
+            "jobs:get_submission_file_presigned_url",
+            kwargs={"challenge_phase_pk": self.challenge_phase.pk},
+        )
+        self.client.force_authenticate(user=self.challenge_host.user)
+        mock_get_aws_creds.return_value = {
+            "AWS_ACCESS_KEY_ID": "dummy-key",
+            "AWS_SECRET_ACCESS_KEY": "dummy-access-key",
+            "AWS_STORAGE_BUCKET_NAME": "test-bucket",
+            "AWS_REGION": "us-east-1",
+        }
+        boto3.client("s3").create_bucket(Bucket="test-bucket")
+        response = self.client.post(
+            self.url,
+            data={
+                "status": "submitting",
+                "num_file_chunks": 1,
+                "file_name": "media/submissions/dummy.txt",
+            },
+        )
+        submission_pk = response.data["submission_pk"]
+        upload_id = response.data["upload_id"]
+        submission = Submission.objects.get(pk=submission_pk)
+        presigned_url_object = response.data["presigned_urls"][0]
+        put_resp = requests.put(
+            presigned_url_object["url"],
+            data=submission.input_file.read(),
+        )
+        self.assertEqual(put_resp.status_code, status.HTTP_200_OK)
+        parts = [
+            {
+                "ETag": put_resp.headers["ETag"],
+                "PartNumber": presigned_url_object["partNumber"],
+            }
+        ]
+        finish_url = reverse_lazy(
+            "jobs:finish_submission_file_upload",
+            kwargs={
+                "challenge_phase_pk": self.challenge_phase.pk,
+                "submission_pk": submission_pk,
+            },
+        )
+        finish_resp = self.client.post(
+            finish_url,
+            data={
+                "parts": json.dumps(parts),
+                "upload_id": upload_id,
+            },
+        )
+        self.assertEqual(finish_resp.status_code, status.HTTP_201_CREATED)
+
+        self.challenge.is_submission_paused = True
+        self.challenge.save()
+
+        send_url = reverse_lazy(
+            "jobs:send_submission_message",
+            kwargs={
+                "challenge_phase_pk": self.challenge_phase.pk,
+                "submission_pk": submission_pk,
+            },
+        )
+        expected = {
+            "error": "Submissions are currently paused for this challenge. Please try again later."
+        }
+        response = self.client.post(send_url, data={})
+        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertEqual(response.data, expected)
+
+        self.challenge.is_submission_paused = False
+        self.challenge.save()
+
+    @mock.patch("jobs.views.ensure_workers_for_submission")
+    @mock.patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_finish_submission_file_upload_rejected_when_phase_paused_after_presign(
+        self, mock_get_aws_creds, mock_ensure_workers
+    ):
+        self.url = reverse_lazy(
+            "jobs:get_submission_file_presigned_url",
+            kwargs={"challenge_phase_pk": self.challenge_phase.pk},
+        )
+        self.client.force_authenticate(user=self.challenge_host.user)
+        mock_get_aws_creds.return_value = {
+            "AWS_ACCESS_KEY_ID": "dummy-key",
+            "AWS_SECRET_ACCESS_KEY": "dummy-access-key",
+            "AWS_STORAGE_BUCKET_NAME": "test-bucket",
+            "AWS_REGION": "us-east-1",
+        }
+        boto3.client("s3").create_bucket(Bucket="test-bucket")
+        response = self.client.post(
+            self.url,
+            data={
+                "status": "submitting",
+                "num_file_chunks": 1,
+                "file_name": "media/submissions/dummy.txt",
+            },
+        )
+        submission_pk = response.data["submission_pk"]
+        upload_id = response.data["upload_id"]
+        submission = Submission.objects.get(pk=submission_pk)
+        presigned_url_object = response.data["presigned_urls"][0]
+        put_resp = requests.put(
+            presigned_url_object["url"],
+            data=submission.input_file.read(),
+        )
+        self.assertEqual(put_resp.status_code, status.HTTP_200_OK)
+        parts = [
+            {
+                "ETag": put_resp.headers["ETag"],
+                "PartNumber": presigned_url_object["partNumber"],
+            }
+        ]
+
+        self.challenge_phase.is_submission_paused = True
+        self.challenge_phase.save()
+
+        finish_url = reverse_lazy(
+            "jobs:finish_submission_file_upload",
+            kwargs={
+                "challenge_phase_pk": self.challenge_phase.pk,
+                "submission_pk": submission_pk,
+            },
+        )
+        expected = {
+            "error": "Submissions are currently paused for this challenge phase. Please try again later."
+        }
+        response = self.client.post(
+            finish_url,
+            data={
+                "parts": json.dumps(parts),
+                "upload_id": upload_id,
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertEqual(response.data, expected)
+
+        self.challenge_phase.is_submission_paused = False
+        self.challenge_phase.save()
+
+    @mock.patch("jobs.views.ensure_workers_for_submission")
+    @mock.patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_send_submission_message_rejected_when_phase_paused(
+        self, mock_get_aws_creds, mock_ensure_workers
+    ):
+        self.url = reverse_lazy(
+            "jobs:get_submission_file_presigned_url",
+            kwargs={"challenge_phase_pk": self.challenge_phase.pk},
+        )
+        self.client.force_authenticate(user=self.challenge_host.user)
+        mock_get_aws_creds.return_value = {
+            "AWS_ACCESS_KEY_ID": "dummy-key",
+            "AWS_SECRET_ACCESS_KEY": "dummy-access-key",
+            "AWS_STORAGE_BUCKET_NAME": "test-bucket",
+            "AWS_REGION": "us-east-1",
+        }
+        boto3.client("s3").create_bucket(Bucket="test-bucket")
+        response = self.client.post(
+            self.url,
+            data={
+                "status": "submitting",
+                "num_file_chunks": 1,
+                "file_name": "media/submissions/dummy.txt",
+            },
+        )
+        submission_pk = response.data["submission_pk"]
+        upload_id = response.data["upload_id"]
+        submission = Submission.objects.get(pk=submission_pk)
+        presigned_url_object = response.data["presigned_urls"][0]
+        put_resp = requests.put(
+            presigned_url_object["url"],
+            data=submission.input_file.read(),
+        )
+        self.assertEqual(put_resp.status_code, status.HTTP_200_OK)
+        parts = [
+            {
+                "ETag": put_resp.headers["ETag"],
+                "PartNumber": presigned_url_object["partNumber"],
+            }
+        ]
+        finish_url = reverse_lazy(
+            "jobs:finish_submission_file_upload",
+            kwargs={
+                "challenge_phase_pk": self.challenge_phase.pk,
+                "submission_pk": submission_pk,
+            },
+        )
+        finish_resp = self.client.post(
+            finish_url,
+            data={
+                "parts": json.dumps(parts),
+                "upload_id": upload_id,
+            },
+        )
+        self.assertEqual(finish_resp.status_code, status.HTTP_201_CREATED)
+
+        self.challenge_phase.is_submission_paused = True
+        self.challenge_phase.save()
+
+        send_url = reverse_lazy(
+            "jobs:send_submission_message",
+            kwargs={
+                "challenge_phase_pk": self.challenge_phase.pk,
+                "submission_pk": submission_pk,
+            },
+        )
+        expected = {
+            "error": "Submissions are currently paused for this challenge phase. Please try again later."
+        }
+        response = self.client.post(send_url, data={})
+        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertEqual(response.data, expected)
+
+        self.challenge_phase.is_submission_paused = False
+        self.challenge_phase.save()


### PR DESCRIPTION
- Bump flake8 version from 3.8.2 to 7.1.2 in both pre-commit configuration and CI/CD workflow to ensure up-to-date linting practices.
- Implement logic in the submission tasks to skip processing when submissions are paused at either the challenge or phase level, improving user feedback and system reliability.
- Introduce a new utility function to handle response generation for paused submissions, centralizing error handling and reducing code duplication.
- Add unit tests to verify the new behavior for paused submissions, ensuring robustness in the submission process.

This update enhances code quality checks and improves the overall user experience during submission processes.
