### PR TITLE
Infra: Bump Postgres image from 16.8 to 17.10

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:16.8
+    image: postgres:17.10
     ports:
       - "5432:5432"
     env_file:


### PR DESCRIPTION
## Summary
- Upgrades the `db` service in `docker-compose.yml` from `postgres:16.8` to `postgres:17.10` (latest 17.x).

## Notes
- This is a **major version bump** (16 → 17). Existing local `postgres_data/` volumes from 16.x will not start under 17 — contributors will need to either wipe their local data directory or run `pg_upgrade`.
- Verified locally: containers come up clean with `docker compose up -d`; Postgres logs report `starting PostgreSQL 17.10`.

## Test plan
- [x] `docker compose up -d` starts the `db` container without errors
- [x] Django migrations run successfully against the fresh 17.10 database
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)