### PR TITLE
Backend: Stabilize nested S3 paths for submission artifacts

### DIFF
--- a/apps/base/utils.py
+++ b/apps/base/utils.py
@@ -93,14 +93,39 @@ class RandomFileName:
 
 @deconstructible
 class SubmissionArtifactFileName:
+    """Build S3-relative paths under ``media/submission_files/``.
+
+    Uses ``challenge_phase_id`` when present so the nested layout is stable
+    even if the cached ``challenge_phase`` relation is not populated (some
+    querysets omit or defer the FK cache). Resolved ``(challenge_id, phase_id)``
+    is memoized per instance across multiple ``FileField`` saves.
+    """
+
+    _phase_ctx_attr = "_submission_artifact_challenge_phase_ctx"
+
     def __call__(self, instance, filename):
         extension = os.path.splitext(filename)[1]
         submission_id = instance.pk or "pending"
-        challenge_phase = getattr(instance, "challenge_phase", None)
+        phase_id = getattr(instance, "challenge_phase_id", None)
+        challenge_id = None
 
-        if challenge_phase and getattr(challenge_phase, "pk", None):
-            challenge_id = challenge_phase.challenge_id
-            phase_id = challenge_phase.pk
+        if phase_id:
+            ctx = getattr(instance, self._phase_ctx_attr, None)
+            if isinstance(ctx, tuple) and ctx[1] == phase_id:
+                challenge_id = ctx[0]
+            else:
+                from challenges.models import ChallengePhase
+
+                challenge_id = (
+                    ChallengePhase.objects.filter(pk=phase_id)
+                    .values_list("challenge_id", flat=True)
+                    .first()
+                )
+                setattr(
+                    instance, self._phase_ctx_attr, (challenge_id, phase_id)
+                )
+
+        if challenge_id and phase_id:
             path = "/".join(
                 [
                     "submission_files",

--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -419,7 +419,11 @@ def extract_submission_data(submission_id):
     """
 
     try:
-        submission = Submission.objects.get(id=submission_id)
+        # Preload FKs used during evaluation and for FileField(upload_to).
+        submission = Submission.objects.select_related(
+            "challenge_phase",
+            "challenge_phase__challenge",
+        ).get(id=submission_id)
     except Submission.DoesNotExist:
         logger.critical(
             "{} Submission {} does not exist".format(

--- a/tests/unit/base/test_utils.py
+++ b/tests/unit/base/test_utils.py
@@ -159,6 +159,24 @@ class TestSubmissionArtifactFileName(BaseAPITestClass):
             r"submission_files/submission_101/[0-9a-f\-]{36}\.bin",
         )
 
+    def test_nested_path_uses_challenge_phase_id_without_relation_loaded(self):
+        naming = SubmissionArtifactFileName()
+
+        class StubSubmission:
+            pass
+
+        stub = StubSubmission()
+        stub.pk = self.submission.pk
+        stub.challenge_phase_id = self.challenge_phase.pk
+
+        filename = naming(stub, "stdout.txt")
+
+        self.assertIn(
+            f"submission_files/challenge_{self.challenge.pk}",
+            filename,
+        )
+        self.assertIn(f"phase_{self.challenge_phase.pk}", filename)
+
 
 class TestSeeding(BaseAPITestClass):
     def test_if_seeding_works(self):

--- a/tests/unit/worker/test_submission_worker.py
+++ b/tests/unit/worker/test_submission_worker.py
@@ -1192,16 +1192,23 @@ class DeleteOldTempDirectoriesTest(BaseAPITestClass):
 
 class ExtractSubmissionDataCancelledTest(BaseAPITestClass):
     @patch("scripts.workers.submission_worker.logger.info")
-    @patch("scripts.workers.submission_worker.Submission.objects.get")
+    @patch("scripts.workers.submission_worker.Submission.objects")
     def test_extract_submission_data_cancelled(
-        self, mock_submission_get, mock_logger_info
+        self, mock_submission_objects, mock_logger_info
     ):
         mock_submission = MagicMock()
         mock_submission.status = Submission.CANCELLED
-        mock_submission_get.return_value = mock_submission
+        queryset = MagicMock()
+        queryset.get.return_value = mock_submission
+        mock_submission_objects.select_related.return_value = queryset
 
         result = extract_submission_data(123)
         assert result is None
+        mock_submission_objects.select_related.assert_called_once_with(
+            "challenge_phase",
+            "challenge_phase__challenge",
+        )
+        queryset.get.assert_called_once_with(id=123)
         mock_logger_info.assert_called_with(
             "{} Submission {} was cancelled by the user".format(
                 "SUBMISSION_LOG", 123


### PR DESCRIPTION
## Summary
- Resolve `submission_files/challenge_/phase_/submission_/` prefixes from `challenge_phase_id` with a memoized ChallengePhase lookup, so evaluator-uploaded artifacts match participant input layout instead of legacy `submission_{id}/`.
- Load `challenge_phase` and `challenge` in the Django submission worker when fetching a submission before evaluation (`select_related`).
- Extend unit coverage for upload naming and worker cancellation mocks.

## Test plan
- [ ] Run `python manage.py test tests.unit.base.test_utils.TestSubmissionArtifactFileName tests.unit.worker.test_submission_worker.ExtractSubmissionDataCancelledTest` (or CI).
- [ ] Deploy web + submission worker together; verify a new run stores stdout/results under `media/submission_files/challenge_<id>/phase_<id>/submission_<id>/`.