### PR TITLE
Improve submission artifact RCA with revision-aware logging

### DIFF
--- a/apps/base/utils.py
+++ b/apps/base/utils.py
@@ -135,6 +135,13 @@ class SubmissionArtifactFileName:
                 ]
             )
         else:
+            if phase_id and not challenge_id:
+                logger.warning(
+                    "Submission artifact flat path: ChallengePhase id=%s has no "
+                    "challenge_id row (submission pk=%s); check DB integrity.",
+                    phase_id,
+                    getattr(instance, "pk", None),
+                )
             path = "/".join(
                 ["submission_files", f"submission_{submission_id}"]
             )

--- a/apps/jobs/management/commands/verify_submission_artifact_paths.py
+++ b/apps/jobs/management/commands/verify_submission_artifact_paths.py
@@ -1,0 +1,56 @@
+from base.utils import SubmissionArtifactFileName
+from django.core.management.base import BaseCommand, CommandError
+from jobs.models import Submission
+
+
+class Command(BaseCommand):
+    """Print FK + revision context and a sample upload_to path for a submission.
+
+    Matches Phase 1 of the staging artifact-prefix checklist: confirms
+    ``challenge_phase_id`` and predicts nested vs flat prefixes from Django code.
+    """
+
+    help = (
+        "Show challenge_phase linkage and sample SubmissionArtifactFileName path "
+        "for a submission (operational RCA)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "submission_pk",
+            type=int,
+            help="Submission primary key.",
+        )
+
+    def handle(self, *args, **options):
+        pk = options["submission_pk"]
+        try:
+            submission = Submission.objects.select_related(
+                "challenge_phase",
+                "challenge_phase__challenge",
+            ).get(pk=pk)
+        except Submission.DoesNotExist:
+            raise CommandError(
+                "Submission {} does not exist.".format(pk)
+            ) from None
+
+        ch = submission.challenge_phase.challenge
+        naming = SubmissionArtifactFileName()
+        sample = naming(submission, "submission_result.json")
+        nested = "/challenge_" in sample and "/phase_" in sample
+
+        self.stdout.write(
+            "submission_pk={pk}\n"
+            "challenge_phase_id={phase}\n"
+            "challenge_pk={chid}\n"
+            "remote_evaluation={remote}\n"
+            "sample_upload_to_relative_path={sample!r}\n"
+            "appears_nested={nested}\n".format(
+                pk=submission.pk,
+                phase=submission.challenge_phase_id,
+                chid=ch.pk,
+                remote=ch.remote_evaluation,
+                sample=sample,
+                nested=nested,
+            )
+        )

--- a/apps/jobs/s3_retention.py
+++ b/apps/jobs/s3_retention.py
@@ -9,6 +9,29 @@ from django.core.files.storage import default_storage
 
 logger = logging.getLogger(__name__)
 
+
+def log_submission_artifact_upload_context(submission, source_label):
+    """Log revision + FK context whenever artifacts are persisted to storage.
+
+    Set ``EVALAI_GIT_REVISION`` at image build (see Dockerfiles); compare with
+    the API task to verify worker/API parity during incident response.
+    """
+    revision = os.environ.get("EVALAI_GIT_REVISION", "unknown")
+    phase_pk = getattr(submission, "challenge_phase_id", None)
+    remote_eval = submission.challenge_phase.challenge.remote_evaluation
+    logger.info(
+        "submission_artifact_upload_context source=%s evalai_revision=%s "
+        "submission_id=%s challenge_phase_id=%s challenge_id=%s "
+        "remote_evaluation=%s",
+        source_label,
+        revision,
+        submission.pk,
+        phase_pk,
+        submission.challenge_phase.challenge.pk,
+        remote_eval,
+    )
+
+
 SUBMISSION_ARTIFACT_FIELDS = (
     "input_file",
     "submission_input_file",

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -70,6 +70,7 @@ from .models import Submission
 from .s3_retention import (
     build_submission_artifact_s3_tags,
     enqueue_submission_artifact_retention_tagging,
+    log_submission_artifact_upload_context,
 )
 from .sender import publish_submission_message
 from .serializers import (
@@ -1448,6 +1449,11 @@ def update_submission(request, challenge_pk):
                     response_data, status=status.HTTP_400_BAD_REQUEST
                 )
 
+        log_submission_artifact_upload_context(
+            submission,
+            "jobs.views.update_submission.put",
+        )
+
         submission.status = submission_status
         submission.completed_at = timezone.now()
         submission.stdout_file.save("stdout.txt", ContentFile(stdout_content))
@@ -1908,6 +1914,11 @@ def update_partially_evaluated_submission(request, challenge_pk):
                     response_data, status=status.HTTP_400_BAD_REQUEST
                 )
 
+        log_submission_artifact_upload_context(
+            submission,
+            "jobs.views.update_partially_evaluated_submission.put",
+        )
+
         submission.status = submission_status
         submission.completed_at = timezone.now()
         submission.stdout_file.save("stdout.txt", ContentFile(stdout_content))
@@ -2105,6 +2116,11 @@ def update_partially_evaluated_submission(request, challenge_pk):
                 return Response(
                     response_data, status=status.HTTP_400_BAD_REQUEST
                 )
+
+            log_submission_artifact_upload_context(
+                submission,
+                "jobs.views.update_partially_evaluated_submission.patch_to_finished",
+            )
 
             submission.status = submission_status
             submission.completed_at = timezone.now()

--- a/docker/prod/celery/Dockerfile
+++ b/docker/prod/celery/Dockerfile
@@ -61,6 +61,9 @@ RUN apt-get update && \
 
 WORKDIR /code
 
+ARG EVALAI_GIT_REVISION=unknown
+ENV EVALAI_GIT_REVISION=${EVALAI_GIT_REVISION}
+
 # Copy installed packages from builder stage
 COPY --from=builder /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin

--- a/docker/prod/code-upload-worker/Dockerfile
+++ b/docker/prod/code-upload-worker/Dockerfile
@@ -46,6 +46,9 @@ RUN apt-get update && \
 
 WORKDIR /code
 
+ARG EVALAI_GIT_REVISION=unknown
+ENV EVALAI_GIT_REVISION=${EVALAI_GIT_REVISION}
+
 # Copy installed packages from builder stage
 COPY --from=builder /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin

--- a/docker/prod/django/Dockerfile
+++ b/docker/prod/django/Dockerfile
@@ -61,6 +61,10 @@ RUN apt-get update && \
 
 WORKDIR /code
 
+# Match worker images by passing the same value as ECS submission_worker builds.
+ARG EVALAI_GIT_REVISION=unknown
+ENV EVALAI_GIT_REVISION=${EVALAI_GIT_REVISION}
+
 # Copy installed packages from builder stage
 COPY --from=builder /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin

--- a/docker/prod/worker_py3_7/Dockerfile
+++ b/docker/prod/worker_py3_7/Dockerfile
@@ -112,6 +112,9 @@ RUN apt-get update && \
 
 WORKDIR /code
 
+ARG EVALAI_GIT_REVISION=unknown
+ENV EVALAI_GIT_REVISION=${EVALAI_GIT_REVISION}
+
 # Copy installed packages from builder stage
 COPY --from=builder /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin

--- a/docker/prod/worker_py3_8/Dockerfile
+++ b/docker/prod/worker_py3_8/Dockerfile
@@ -112,6 +112,9 @@ RUN apt-get update && \
 
 WORKDIR /code
 
+ARG EVALAI_GIT_REVISION=unknown
+ENV EVALAI_GIT_REVISION=${EVALAI_GIT_REVISION}
+
 # Copy installed packages from builder stage
 COPY --from=builder /usr/local/lib/python3.8/site-packages /usr/local/lib/python3.8/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin

--- a/docker/prod/worker_py3_9/Dockerfile
+++ b/docker/prod/worker_py3_9/Dockerfile
@@ -116,6 +116,11 @@ RUN apt-get update && \
 
 WORKDIR /code
 
+# Compare with Django API deployments: CI should inject the same git SHA via
+#   docker build ... --build-arg EVALAI_GIT_REVISION="$(git rev-parse HEAD)"
+ARG EVALAI_GIT_REVISION=unknown
+ENV EVALAI_GIT_REVISION=${EVALAI_GIT_REVISION}
+
 # Copy installed packages from builder stage
 COPY --from=builder /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin

--- a/scripts/deployment/push.sh
+++ b/scripts/deployment/push.sh
@@ -39,8 +39,11 @@ build_and_push_images() {
         return 0
     fi
 
+    # Image tag uses COMMIT_ID; embed same value into Python services for logs
+    # (Submission worker / Django diagnostic: EVALAI_GIT_REVISION).
     DOCKER_BUILDKIT=1 docker compose -f "${compose_file_path}" build \
         --build-arg COMMIT_ID="${COMMIT_ID}" \
+        --build-arg EVALAI_GIT_REVISION="${COMMIT_ID}" \
         --build-arg AWS_ACCOUNT_ID="${AWS_ACCOUNT_ID}" \
         --compress
     docker compose -f "${compose_file_path}" push

--- a/scripts/workers/remote_submission_worker.py
+++ b/scripts/workers/remote_submission_worker.py
@@ -44,6 +44,10 @@ SUBMISSION_DATA_DIR = join(
 SUBMISSION_INPUT_FILE_PATH = join(SUBMISSION_DATA_DIR, "{input_file}")
 CHALLENGE_IMPORT_STRING = "challenge_data.challenge_{challenge_id}"
 EVALUATION_SCRIPTS = {}
+
+# PUT ``update_submission_data`` → ``jobs.urls`` name ``jobs:update_submission``
+# (views.update_submission). Persists stdout/result blobs with the same Django
+# ``SubmissionArtifactFileName`` as in-container submission_worker uploads.
 URLS = {
     "get_message_from_sqs_queue": "/api/jobs/challenge/queues/{}/",
     "delete_message_from_sqs_queue": "/api/jobs/queues/{}/",

--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -44,6 +44,7 @@ from django.utils import timezone  # noqa:E402
 from jobs.models import Submission  # noqa:E402
 from jobs.s3_retention import (  # noqa:E402
     enqueue_submission_artifact_retention_tagging,
+    log_submission_artifact_upload_context,
 )
 from jobs.serializers import SubmissionSerializer  # noqa:E402
 
@@ -416,6 +417,9 @@ def load_challenge(challenge):
 def extract_submission_data(submission_id):
     """
     * Expects submission id and extracts input file for it.
+
+    Subsequent ``run_submission`` persistence uses Django ``FileField.save`` /
+    ``SubmissionArtifactFileName`` — same ``UploadTo`` as the API multipart flow.
     """
 
     try:
@@ -515,6 +519,9 @@ def run_submission(
     stderr = open(stderr_file, "a+")
 
     remote_evaluation = submission.challenge_phase.challenge.remote_evaluation
+    log_submission_artifact_upload_context(
+        submission, "submission_worker.run_submission.before_eval"
+    )
 
     if remote_evaluation:
         try:
@@ -543,6 +550,10 @@ def run_submission(
             submission.completed_at = timezone.now()
             submission.save()
             if not challenge_phase.disable_logs:
+                log_submission_artifact_upload_context(
+                    submission,
+                    "submission_worker.run_submission.remote_eval_failed_logs",
+                )
                 with open(stdout_file, "r") as stdout:
                     stdout_content = stdout.read()
                     submission.stdout_file.save(
@@ -693,6 +704,10 @@ def run_submission(
     # after the execution is finished, set `status` to finished and hence
     # `completed_at`
     if submission_output and successful_submission_flag:
+        log_submission_artifact_upload_context(
+            submission,
+            "submission_worker.run_submission.before_result_files",
+        )
         output = {}
         output["result"] = submission_output.get("result", "")
         submission.output = output
@@ -725,6 +740,9 @@ def run_submission(
 
     # TODO :: see if two updates can be combine into a single update.
     if not challenge_phase.disable_logs:
+        log_submission_artifact_upload_context(
+            submission, "submission_worker.run_submission.before_stdout_stderr"
+        )
         with open(stdout_file, "r") as stdout:
             stdout_content = stdout.read()
             submission.stdout_file.save(
@@ -897,6 +915,13 @@ def load_challenge_and_return_max_submissions(q_params):
 
 def main():
     killer = GracefulKiller()
+    logger.info(
+        "{} Submission worker revision {} "
+        "(set EVALAI_GIT_REVISION at image build to match Django API)".format(
+            WORKER_LOGS_PREFIX,
+            os.environ.get("EVALAI_GIT_REVISION", "unknown"),
+        )
+    )
     logger.info(
         "{} Using {} as temp directory to store data".format(
             WORKER_LOGS_PREFIX, BASE_TEMP_DIR


### PR DESCRIPTION
## Summary
- Correlate Django API and submission worker uploads with **`EVALAI_GIT_REVISION`** in container logs via **push.sh build-args** on prod Docker images.
- **`log_submission_artifact_upload_context`** is invoked from **`update_submission`** / **`update_partially_evaluated_submission`** and **`submission_worker`** at artifact save boundaries; **`SubmissionArtifactFileName`** logs when nested-path fallback lacks **`challenge`** context.
- New management command **`verify_submission_artifact_paths`** prints FK linkage, **`remote_evaluation`**, and a sample **`upload_to`** path for a submission PK.

## Test plan
- [x] **`pre-commit`** / CI green on touched Python + shell + Docker paths.
- [x] **`python manage.py verify_submission_artifact_paths <pk>`** against a staging or local submission with nested vs flat prefixes.
- [x] Smoke: build one prod image locally with **`--build-arg EVALAI_GIT_REVISION=abc123`** and confirm **`EVALAI_GIT_REVISION`** appears in **`env`** inside the container.
- [x] After deploy to a sandbox, grep logs for **`log_submission_artifact_upload_context`** around a test submission artifact upload.