### PR TITLE
Backend: Allow structural additions on challenge config zip updates

### DIFF
--- a/apps/challenges/challenge_config_utils.py
+++ b/apps/challenges/challenge_config_utils.py
@@ -282,6 +282,19 @@ error_message_dict = {
     "dataset_split_addition": "ERROR: Dataset split {} doesn't exist. Addition of a new dataset split after challenge creation is not allowed.",
     "missing_existing_dataset_split_id": "ERROR: Dataset split {} not found in config. Deletion of existing dataset split after challenge creation is not allowed.",
     "challenge_phase_split_not_exist": "ERROR: Challenge phase split (leaderboard_id: {}, challenge_phase_id: {}, dataset_split_id: {}) doesn't exist. Addition of challenge phase split after challenge creation is not allowed.",
+    "challenge_phase_split_addition_for_existing_phase": (
+        "ERROR: Cannot add a new leaderboard/dataset-split mapping for an existing "
+        "challenge phase (leaderboard_id: {}, challenge_phase_id: {}, dataset_split_id: {}). "
+        "New mappings are only allowed for newly added challenge phases."
+    ),
+    "challenge_phase_split_leaderboard_not_allowed": (
+        "ERROR: Leaderboard id {} is not part of this challenge or the uploaded configuration. "
+        "New challenge phases may only use leaderboards declared in the configuration."
+    ),
+    "challenge_phase_split_dataset_split_not_allowed": (
+        "ERROR: Dataset split id {} is not part of this challenge or the uploaded configuration. "
+        "New challenge phases must use dataset splits declared in the configuration."
+    ),
     "challenge_phase_split_schema_errors": "ERROR: Challenge phase split {} has the following schema errors:\n {}",
     "missing_keys_in_challenge_phase_splits": "ERROR: The following keys are missing in the challenge phase splits of YAML file (phase_split: {}): {}",
     "challenge_phase_split_not_found": "ERROR: Challenge phase split (leaderboard_id: {}, challenge_phase_id: {}, dataset_split_id: {}) not found in config. Deletion of existing challenge phase split after challenge creation is not allowed.",
@@ -647,15 +660,6 @@ class ValidateChallengeConfigUtil:
                         ).format(data["id"], serializer_error)
                         self.error_messages.append(message)
                     else:
-                        if (
-                            current_leaderboard_config_ids
-                            and int(data["id"])
-                            not in current_leaderboard_config_ids
-                        ):
-                            message = self.error_messages_dict.get(
-                                "leaderboard_additon_after_creation"
-                            ).format(data["id"])
-                            self.error_messages.append(message)
                         self.leaderboard_ids.append(data["id"])
         else:
             message = self.error_messages_dict.get("missing_leaderboard_key")
@@ -820,14 +824,6 @@ class ValidateChallengeConfigUtil:
                 ].format(data["id"], serializer_error)
                 self.error_messages.append(message)
             else:
-                if (
-                    current_phase_config_ids
-                    and int(data["id"]) not in current_phase_config_ids
-                ):
-                    message = self.error_messages_dict[
-                        "challenge_phase_addition"
-                    ].format(data["id"])
-                    self.error_messages.append(message)
                 self.phase_ids.append(data["id"])
 
         for current_challenge_phase_id in current_phase_config_ids:
@@ -837,7 +833,13 @@ class ValidateChallengeConfigUtil:
                 ].format(current_challenge_phase_id)
                 self.error_messages.append(message)
 
-    def validate_challenge_phase_splits(self, current_phase_split_ids):
+    def validate_challenge_phase_splits(
+        self,
+        current_phase_split_ids,
+        current_phase_config_ids=None,
+        current_leaderboard_config_ids=None,
+        current_dataset_config_ids=None,
+    ):
         challenge_phase_splits = self.yaml_file_data.get(
             "challenge_phase_splits"
         )
@@ -870,6 +872,12 @@ class ValidateChallengeConfigUtil:
                 self.error_messages.append(message)
 
         challenge_phase_split_uuids = []
+        if current_phase_config_ids is None:
+            current_phase_config_ids = []
+        if current_leaderboard_config_ids is None:
+            current_leaderboard_config_ids = []
+        if current_dataset_config_ids is None:
+            current_dataset_config_ids = []
         if challenge_phase_splits:
             phase_split = 1
             exclude_fields = [
@@ -887,31 +895,64 @@ class ValidateChallengeConfigUtil:
                     "challenge_phase_id",
                 }
                 if expected_keys.issubset(data.keys()):
-                    if (
-                        current_phase_split_ids
-                        and (
-                            data["leaderboard_id"],
-                            data["challenge_phase_id"],
-                            data["dataset_split_id"],
-                        )
-                        not in current_phase_split_ids
-                    ):
-                        message = self.error_messages_dict[
-                            "challenge_phase_split_not_exist"
-                        ].format(
-                            data["leaderboard_id"],
-                            data["challenge_phase_id"],
-                            data["dataset_split_id"],
-                        )
-                        self.error_messages.append(message)
+                    split_triple = (
+                        data["leaderboard_id"],
+                        data["challenge_phase_id"],
+                        data["dataset_split_id"],
+                    )
+                    if not current_phase_split_ids:
+                        challenge_phase_split_uuids.append(split_triple)
                     else:
-                        challenge_phase_split_uuids.append(
-                            (
-                                data["leaderboard_id"],
-                                data["challenge_phase_id"],
-                                data["dataset_split_id"],
-                            )
-                        )
+                        norm_split = tuple(int(x) for x in split_triple)
+                        norm_existing = {
+                            tuple(int(x) for x in t)
+                            for t in current_phase_split_ids
+                        }
+                        if norm_split in norm_existing:
+                            challenge_phase_split_uuids.append(split_triple)
+                        else:
+                            phase_cfg_id = int(data["challenge_phase_id"])
+                            if phase_cfg_id in current_phase_config_ids:
+                                message = self.error_messages_dict[
+                                    "challenge_phase_split_addition_for_existing_phase"
+                                ].format(
+                                    data["leaderboard_id"],
+                                    data["challenge_phase_id"],
+                                    data["dataset_split_id"],
+                                )
+                                self.error_messages.append(message)
+                            else:
+                                allowed = True
+                                lb_id = int(data["leaderboard_id"])
+                                ds_id = int(data["dataset_split_id"])
+                                yaml_leaderboard_ids = {
+                                    int(x) for x in self.leaderboard_ids
+                                }
+                                yaml_dataset_ids = {
+                                    int(x) for x in self.dataset_splits_ids
+                                }
+                                if (
+                                    lb_id not in current_leaderboard_config_ids
+                                    and lb_id not in yaml_leaderboard_ids
+                                ):
+                                    message = self.error_messages_dict[
+                                        "challenge_phase_split_leaderboard_not_allowed"
+                                    ].format(lb_id)
+                                    self.error_messages.append(message)
+                                    allowed = False
+                                if (
+                                    ds_id not in current_dataset_config_ids
+                                    and ds_id not in yaml_dataset_ids
+                                ):
+                                    message = self.error_messages_dict[
+                                        "challenge_phase_split_dataset_split_not_allowed"
+                                    ].format(ds_id)
+                                    self.error_messages.append(message)
+                                    allowed = False
+                                if allowed:
+                                    challenge_phase_split_uuids.append(
+                                        split_triple
+                                    )
 
                     (
                         _is_mapping_valid,
@@ -942,8 +983,11 @@ class ValidateChallengeConfigUtil:
                         "missing_keys_in_challenge_phase_splits"
                     ].format(phase_split, missing_keys_string)
                     self.error_messages.append(message)
+            norm_yaml_uuids = {
+                tuple(int(x) for x in t) for t in challenge_phase_split_uuids
+            }
             for uuid in current_phase_split_ids:
-                if uuid not in challenge_phase_split_uuids:
+                if tuple(int(x) for x in uuid) not in norm_yaml_uuids:
                     message = self.error_messages_dict[
                         "challenge_phase_split_not_found"
                     ].format(uuid[0], uuid[1], uuid[2])
@@ -991,14 +1035,6 @@ class ValidateChallengeConfigUtil:
                     ].format(split["id"], serializer_error)
                     self.error_messages.append(message)
                 else:
-                    if (
-                        current_dataset_config_ids
-                        and int(split["id"]) not in current_dataset_config_ids
-                    ):
-                        message = self.error_messages_dict[
-                            "dataset_split_addition"
-                        ].format(split["id"])
-                        self.error_messages.append(message)
                     self.dataset_splits_ids.append(split["id"])
         else:
             message = self.error_messages_dict["missing_dataset_splits_key"]
@@ -1172,7 +1208,12 @@ def validate_challenge_config_util(
     val_config_util.validate_dataset_splits(current_dataset_config_ids)
 
     # Validate challenge phase splits
-    val_config_util.validate_challenge_phase_splits(current_phase_split_ids)
+    val_config_util.validate_challenge_phase_splits(
+        current_phase_split_ids,
+        current_phase_config_ids,
+        current_leaderboard_config_ids,
+        current_dataset_config_ids,
+    )
 
     # Validate tags
     val_config_util.check_tags()

--- a/apps/challenges/challenge_config_utils.py
+++ b/apps/challenges/challenge_config_utils.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import re
 import zipfile
@@ -30,6 +31,32 @@ from .utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+_CHALLENGE_PHASE_APPROVED_LOCK_FIELDS = (
+    "name",
+    "description",
+    "leaderboard_public",
+    "start_date",
+    "end_date",
+    "is_public",
+    "codename",
+    "max_submissions_per_day",
+    "max_submissions_per_month",
+    "max_submissions",
+    "max_concurrent_submissions_allowed",
+    "submission_meta_attributes",
+    "default_submission_meta_attributes",
+    "submission_artifact_retention_policy",
+    "is_submission_public",
+    "annotations_uploaded_using_cli",
+    "is_restricted_to_select_one_submission",
+    "allowed_submission_file_types",
+    "allowed_email_ids",
+    "disable_logs",
+    "is_submission_paused",
+    "environment_image",
+    "is_partial_submission_evaluation_enabled",
+)
 
 
 def write_file(output_path, mode, file_content):
@@ -324,6 +351,23 @@ error_message_dict = {
     "prize_rank_wrong": "ERROR: Invalid rank value {}. Rank should be an integer.",
     "challenge_metadata_schema_errors": "ERROR: Unable to serialize the challenge because of the following errors: {}.",
     "evaluation_script_not_zip": "ERROR: Please pass in a zip file as evaluation script. If using the `evaluation_script` directory (recommended), it should be `evaluation_script.zip`.",
+    "locked_leaderboard_modified": (
+        "ERROR: Leaderboard {} cannot be changed after the challenge is approved by an admin. "
+        "Revert the leaderboard block to match the approved configuration or contact support."
+    ),
+    "locked_dataset_split_modified": (
+        "ERROR: Dataset split {} cannot be changed after the challenge is approved by an admin. "
+        "Revert the dataset split block to match the approved configuration or contact support."
+    ),
+    "locked_challenge_phase_modified": (
+        "ERROR: Challenge phase {} cannot be changed after the challenge is approved by an admin. "
+        "Revert the phase block to match the approved configuration or contact support."
+    ),
+    "locked_challenge_phase_split_modified": (
+        "ERROR: Challenge phase split (leaderboard_id: {}, challenge_phase_id: {}, dataset_split_id: {}) "
+        "cannot be changed after the challenge is approved by an admin. Revert visibility / ordering "
+        "fields to match the approved configuration or contact support."
+    ),
 }
 
 
@@ -407,6 +451,117 @@ class ValidateChallengeConfigUtil:
             ).format(error_description, line_number, column_number)
             self.error_messages.append(message)
             return False
+
+    def _approved_config_locked(self):
+        return (
+            self.current_challenge is not None
+            and self.current_challenge.approved_by_admin is True
+        )
+
+    @staticmethod
+    def _stable_json(value):
+        return json.dumps(value, sort_keys=True, default=str)
+
+    def _locked_leaderboard_modified_message(self, data):
+        lb = Leaderboard.objects.filter(
+            config_id=int(data["id"]),
+            id__in=ChallengePhaseSplit.objects.filter(
+                challenge_phase__challenge_id=self.current_challenge.pk
+            ).values_list("leaderboard_id", flat=True),
+        ).first()
+        if lb is None:
+            return None
+        if self._stable_json(lb.schema) != self._stable_json(data["schema"]):
+            return self.error_messages_dict[
+                "locked_leaderboard_modified"
+            ].format(data["id"])
+        return None
+
+    def _locked_dataset_split_modified_message(self, split):
+        ds = DatasetSplit.objects.filter(
+            config_id=int(split["id"]),
+            id__in=ChallengePhaseSplit.objects.filter(
+                challenge_phase__challenge_id=self.current_challenge.pk
+            ).values_list("dataset_split_id", flat=True),
+        ).first()
+        if ds is None:
+            return None
+        if (
+            split.get("name") != ds.name
+            or split.get("codename") != ds.codename
+        ):
+            return self.error_messages_dict[
+                "locked_dataset_split_modified"
+            ].format(split["id"])
+        return None
+
+    def _locked_challenge_phase_modified_message(self, data):
+        phase = ChallengePhase.objects.filter(
+            challenge_id=self.current_challenge.pk,
+            config_id=int(data["id"]),
+        ).first()
+        if phase is None:
+            return None
+        for field in _CHALLENGE_PHASE_APPROVED_LOCK_FIELDS:
+            if field not in data:
+                continue
+            if self._stable_json(getattr(phase, field)) != self._stable_json(
+                data.get(field)
+            ):
+                return self.error_messages_dict[
+                    "locked_challenge_phase_modified"
+                ].format(data["id"])
+        yaml_ann = data.get("test_annotation_file")
+        db_ann_name = None
+        if phase.test_annotation:
+            db_ann_name = basename(phase.test_annotation.name)
+        if yaml_ann != db_ann_name:
+            return self.error_messages_dict[
+                "locked_challenge_phase_modified"
+            ].format(data["id"])
+        return None
+
+    def _locked_challenge_phase_split_modified_message(self, data):
+        try:
+            cps = ChallengePhaseSplit.objects.select_related(
+                "challenge_phase", "leaderboard", "dataset_split"
+            ).get(
+                challenge_phase__challenge_id=self.current_challenge.pk,
+                leaderboard__config_id=int(data["leaderboard_id"]),
+                challenge_phase__config_id=int(data["challenge_phase_id"]),
+                dataset_split__config_id=int(data["dataset_split_id"]),
+            )
+        except ChallengePhaseSplit.DoesNotExist:
+            return None
+        if int(cps.visibility) != int(data["visibility"]):
+            return self.error_messages_dict[
+                "locked_challenge_phase_split_modified"
+            ].format(
+                data["leaderboard_id"],
+                data["challenge_phase_id"],
+                data["dataset_split_id"],
+            )
+        if int(cps.leaderboard_decimal_precision) != int(
+            data["leaderboard_decimal_precision"]
+        ):
+            return self.error_messages_dict[
+                "locked_challenge_phase_split_modified"
+            ].format(
+                data["leaderboard_id"],
+                data["challenge_phase_id"],
+                data["dataset_split_id"],
+            )
+        if bool(cps.is_leaderboard_order_descending) != bool(
+            data["is_leaderboard_order_descending"]
+        ):
+            return self.error_messages_dict[
+                "locked_challenge_phase_split_modified"
+            ].format(
+                data["leaderboard_id"],
+                data["challenge_phase_id"],
+                data["dataset_split_id"],
+            )
+        return None
 
     def validate_challenge_title(self):
         challenge_title = self.yaml_file_data.get("title")
@@ -660,6 +815,17 @@ class ValidateChallengeConfigUtil:
                         ).format(data["id"], serializer_error)
                         self.error_messages.append(message)
                     else:
+                        if (
+                            self._approved_config_locked()
+                            and current_leaderboard_config_ids
+                            and int(data["id"])
+                            in current_leaderboard_config_ids
+                        ):
+                            locked_msg = (
+                                self._locked_leaderboard_modified_message(data)
+                            )
+                            if locked_msg:
+                                self.error_messages.append(locked_msg)
                         self.leaderboard_ids.append(data["id"])
         else:
             message = self.error_messages_dict.get("missing_leaderboard_key")
@@ -824,6 +990,16 @@ class ValidateChallengeConfigUtil:
                 ].format(data["id"], serializer_error)
                 self.error_messages.append(message)
             else:
+                if (
+                    self._approved_config_locked()
+                    and current_phase_config_ids
+                    and int(data["id"]) in current_phase_config_ids
+                ):
+                    locked_msg = self._locked_challenge_phase_modified_message(
+                        data
+                    )
+                    if locked_msg:
+                        self.error_messages.append(locked_msg)
                 self.phase_ids.append(data["id"])
 
         for current_challenge_phase_id in current_phase_config_ids:
@@ -909,6 +1085,12 @@ class ValidateChallengeConfigUtil:
                             for t in current_phase_split_ids
                         }
                         if norm_split in norm_existing:
+                            if self._approved_config_locked():
+                                ps_msg = self._locked_challenge_phase_split_modified_message(
+                                    data
+                                )
+                                if ps_msg:
+                                    self.error_messages.append(ps_msg)
                             challenge_phase_split_uuids.append(split_triple)
                         else:
                             phase_cfg_id = int(data["challenge_phase_id"])
@@ -1035,6 +1217,16 @@ class ValidateChallengeConfigUtil:
                     ].format(split["id"], serializer_error)
                     self.error_messages.append(message)
                 else:
+                    if (
+                        self._approved_config_locked()
+                        and current_dataset_config_ids
+                        and int(split["id"]) in current_dataset_config_ids
+                    ):
+                        locked_msg = (
+                            self._locked_dataset_split_modified_message(split)
+                        )
+                        if locked_msg:
+                            self.error_messages.append(locked_msg)
                     self.dataset_splits_ids.append(split["id"])
         else:
             message = self.error_messages_dict["missing_dataset_splits_key"]

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -4740,9 +4740,16 @@ def create_or_update_github_challenge(request, challenge_host_team_pk):
                     challenge_phase = ChallengePhase.objects.filter(
                         challenge__pk=challenge.pk, config_id=data["id"]
                     ).first()
-                    if (
-                        challenge_test_annotation_file
-                        and not challenge_phase.annotations_uploaded_using_cli
+                    config_id_for_phase = data.get("config_id", data["id"])
+                    if challenge_phase is None:
+                        data["slug"] = "{}-{}-{}".format(
+                            challenge.title.split(" ")[0].lower(),
+                            get_slug(data["codename"]),
+                            challenge.pk,
+                        )[:198]
+                    if challenge_test_annotation_file and (
+                        challenge_phase is None
+                        or not challenge_phase.annotations_uploaded_using_cli
                     ):
                         serializer = ChallengePhaseCreateSerializer(
                             challenge_phase,
@@ -4750,11 +4757,12 @@ def create_or_update_github_challenge(request, challenge_host_team_pk):
                             context={
                                 "challenge": challenge,
                                 "test_annotation": challenge_test_annotation_file,
-                                "config_id": data["config_id"],
+                                "config_id": config_id_for_phase,
                             },
                         )
                     elif (
                         challenge_test_annotation_file
+                        and challenge_phase is not None
                         and challenge_phase.annotations_uploaded_using_cli
                     ):
                         data.pop("test_annotation", None)
@@ -4763,7 +4771,7 @@ def create_or_update_github_challenge(request, challenge_host_team_pk):
                             data=data,
                             context={
                                 "challenge": challenge,
-                                "config_id": data["config_id"],
+                                "config_id": config_id_for_phase,
                             },
                             partial=True,
                         )
@@ -4773,7 +4781,7 @@ def create_or_update_github_challenge(request, challenge_host_team_pk):
                             data=data,
                             context={
                                 "challenge": challenge,
-                                "config_id": data["config_id"],
+                                "config_id": config_id_for_phase,
                             },
                         )
                     if serializer.is_valid():

--- a/tests/unit/challenges/test_challenge_config_utils.py
+++ b/tests/unit/challenges/test_challenge_config_utils.py
@@ -1866,6 +1866,11 @@ class TestApprovedValidateMethodsRealLockIntegration(TestCase):
                     "description": self.phase_desc_html,
                     "start_date": self.phase.start_date,
                     "end_date": self.phase.end_date,
+                    # validate_challenge_phases sets max_submissions_per_month from
+                    # max_submissions when absent; None vs DB 100 trips the lock.
+                    "max_submissions": 100,
+                    "max_submissions_per_month": 100,
+                    "max_submissions_per_day": 100,
                 }
             ]
         }
@@ -1887,6 +1892,9 @@ class TestApprovedValidateMethodsRealLockIntegration(TestCase):
                     "description": self.phase_desc_html,
                     "start_date": self.phase.start_date,
                     "end_date": self.phase.end_date,
+                    "max_submissions": 100,
+                    "max_submissions_per_month": 100,
+                    "max_submissions_per_day": 100,
                 }
             ]
         }

--- a/tests/unit/challenges/test_challenge_config_utils.py
+++ b/tests/unit/challenges/test_challenge_config_utils.py
@@ -1043,6 +1043,53 @@ class TestValidateChallengeConfigUtil(unittest.TestCase):
         self.util.validate_leaderboards([1])
         self.assertEqual(self.util.error_messages, [])
 
+    @mockpatch.object(
+        ValidateChallengeConfigUtil, "_locked_leaderboard_modified_message"
+    )
+    @mockpatch("challenges.challenge_config_utils.LeaderboardSerializer")
+    def test_existing_leaderboard_checked_when_challenge_approved(
+        self, MockSerializer, mock_locked_msg
+    ):
+        mock_ser = MockSerializer.return_value
+        mock_ser.is_valid.return_value = True
+        mock_locked_msg.return_value = "LOCKED_LB"
+        self.current_challenge.approved_by_admin = True
+        self.util.yaml_file_data = {
+            "leaderboard": [
+                {
+                    "id": 1,
+                    "schema": {"labels": ["z"], "default_order_by": "z"},
+                },
+            ]
+        }
+        self.util.validate_leaderboards([1])
+        mock_locked_msg.assert_called_once()
+        self.assertIn("LOCKED_LB", self.util.error_messages)
+        self.assertIn(1, self.util.leaderboard_ids)
+
+    @mockpatch.object(
+        ValidateChallengeConfigUtil, "_locked_leaderboard_modified_message"
+    )
+    @mockpatch("challenges.challenge_config_utils.LeaderboardSerializer")
+    def test_existing_leaderboard_lock_skipped_without_admin_approval(
+        self, MockSerializer, mock_locked_msg
+    ):
+        mock_ser = MockSerializer.return_value
+        mock_ser.is_valid.return_value = True
+        self.current_challenge.approved_by_admin = False
+        self.util.yaml_file_data = {
+            "leaderboard": [
+                {
+                    "id": 1,
+                    "schema": {"labels": ["z"], "default_order_by": "z"},
+                },
+            ]
+        }
+        self.util.validate_leaderboards([1])
+        mock_locked_msg.assert_not_called()
+        self.assertEqual(self.util.error_messages, [])
+        self.assertIn(1, self.util.leaderboard_ids)
+
     def test_leaderboard_deletion_after_creation(self):
         self.util.yaml_file_data = {
             "leaderboard": [

--- a/tests/unit/challenges/test_challenge_config_utils.py
+++ b/tests/unit/challenges/test_challenge_config_utils.py
@@ -34,7 +34,7 @@ from challenges.models import (
 )
 from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import override_settings
+from django.test import TestCase, override_settings
 from django.utils import timezone
 from hosts.models import ChallengeHostTeam
 
@@ -1465,8 +1465,7 @@ class TestValidateChallengeConfigUtil(unittest.TestCase):
 
 
 @override_settings(MEDIA_ROOT="/tmp/evalai-lock-coverage")
-@pytest.mark.django_db
-class TestApprovedConfigLockMessageCoverage(unittest.TestCase):
+class TestApprovedConfigLockMessageCoverage(TestCase):
     """
     Cover _locked_* helpers and _stable_json for Codecov on post-approval
     immutability checks (real ORM queries, no mocks of the methods under test).

--- a/tests/unit/challenges/test_challenge_config_utils.py
+++ b/tests/unit/challenges/test_challenge_config_utils.py
@@ -1,8 +1,11 @@
 import io
+import os
 import tempfile
 import unittest
+import uuid
 import zipfile
-from os.path import join
+from datetime import timedelta
+from os.path import basename, join
 from unittest.mock import Mock
 from unittest.mock import patch as mockpatch
 
@@ -12,6 +15,7 @@ import yaml
 from challenges.challenge_config_utils import (
     ValidateChallengeConfigUtil,
     download_and_write_file,
+    error_message_dict,
     get_value_from_field,
     get_yaml_files_from_challenge_config,
     get_yaml_read_error,
@@ -22,12 +26,16 @@ from challenges.challenge_config_utils import (
     validate_challenge_config_util,
 )
 from challenges.models import (
+    Challenge,
     ChallengePhase,
     ChallengePhaseSplit,
     DatasetSplit,
     Leaderboard,
 )
 from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
+from django.utils import timezone
 from hosts.models import ChallengeHostTeam
 
 
@@ -1454,3 +1462,238 @@ class TestValidateChallengeConfigUtil(unittest.TestCase):
         self.assertEqual(
             len(self.util.error_messages), 0
         )  # No error messages expected
+
+
+@override_settings(MEDIA_ROOT="/tmp/evalai-lock-coverage")
+@pytest.mark.django_db
+class TestApprovedConfigLockMessageCoverage(unittest.TestCase):
+    """
+    Cover _locked_* helpers and _stable_json for Codecov on post-approval
+    immutability checks (real ORM queries, no mocks of the methods under test).
+    """
+
+    @staticmethod
+    def _bare_util(challenge):
+        util = ValidateChallengeConfigUtil.__new__(ValidateChallengeConfigUtil)
+        util.current_challenge = challenge
+        util.error_messages_dict = error_message_dict
+        return util
+
+    def setUp(self):
+        os.makedirs("/tmp/evalai-lock-coverage", exist_ok=True)
+        suffix = uuid.uuid4().hex[:12]
+        self.user = User.objects.create_user(
+            username="lockcovuser_{}".format(suffix), password="secret"
+        )
+        self.team = ChallengeHostTeam.objects.create(
+            team_name="Lock Cov Host {}".format(suffix),
+            created_by=self.user,
+        )
+        now = timezone.now()
+        self.challenge = Challenge.objects.create(
+            title="Lock Cov Challenge",
+            short_description="s",
+            description="d",
+            terms_and_conditions="t",
+            submission_guidelines="g",
+            creator=self.team,
+            published=False,
+            enable_forum=True,
+            anonymous_leaderboard=False,
+            start_date=now - timedelta(days=1),
+            end_date=now + timedelta(days=30),
+            approved_by_admin=True,
+        )
+        self.lb = Leaderboard.objects.create(
+            config_id=1,
+            schema={
+                "labels": ["yes/no", "overall"],
+                "default_order_by": "overall",
+            },
+        )
+        self.ds = DatasetSplit.objects.create(
+            config_id=1,
+            name="Split Name",
+            codename="split_codename",
+        )
+        self.phase = ChallengePhase.objects.create(
+            name="Phase 1",
+            description="desc",
+            leaderboard_public=False,
+            is_public=False,
+            start_date=now,
+            end_date=now + timedelta(days=1),
+            challenge=self.challenge,
+            config_id=1,
+            codename="p1",
+            max_submissions_per_day=100,
+            max_submissions=100,
+            max_submissions_per_month=100,
+            test_annotation=SimpleUploadedFile(
+                "ann.txt", b"x", content_type="text/plain"
+            ),
+        )
+        ChallengePhaseSplit.objects.create(
+            challenge_phase=self.phase,
+            leaderboard=self.lb,
+            dataset_split=self.ds,
+            visibility=ChallengePhaseSplit.PUBLIC,
+            leaderboard_decimal_precision=2,
+            is_leaderboard_order_descending=True,
+        )
+        self.phase.refresh_from_db()
+        self.phase_annotation_basename = basename(
+            self.phase.test_annotation.name
+        )
+        self.util = self._bare_util(self.challenge)
+
+    def test_stable_json(self):
+        self.assertEqual(
+            ValidateChallengeConfigUtil._stable_json({"b": 1, "a": 2}),
+            '{"a": 2, "b": 1}',
+        )
+
+    def test_approved_config_locked(self):
+        self.assertTrue(self.util._approved_config_locked())
+        self.challenge.approved_by_admin = False
+        self.challenge.save()
+        self.assertFalse(self.util._approved_config_locked())
+
+    def test_locked_leaderboard_detects_schema_change(self):
+        msg = self.util._locked_leaderboard_modified_message(
+            {
+                "id": 1,
+                "schema": {"labels": ["x"], "default_order_by": "x"},
+            }
+        )
+        self.assertIsNotNone(msg)
+        self.assertIn("approved", msg.lower())
+
+    def test_locked_leaderboard_none_when_schema_matches(self):
+        msg = self.util._locked_leaderboard_modified_message(
+            {
+                "id": 1,
+                "schema": {
+                    "labels": ["yes/no", "overall"],
+                    "default_order_by": "overall",
+                },
+            }
+        )
+        self.assertIsNone(msg)
+
+    def test_locked_leaderboard_none_when_not_linked(self):
+        Leaderboard.objects.create(
+            config_id=99,
+            schema={"labels": ["a"], "default_order_by": "a"},
+        )
+        msg = self.util._locked_leaderboard_modified_message(
+            {"id": 99, "schema": {"labels": ["z"], "default_order_by": "z"}}
+        )
+        self.assertIsNone(msg)
+
+    def test_locked_dataset_split_detects_change(self):
+        msg = self.util._locked_dataset_split_modified_message(
+            {"id": 1, "name": "Other", "codename": "split_codename"}
+        )
+        self.assertIsNotNone(msg)
+
+    def test_locked_dataset_split_none_when_match(self):
+        msg = self.util._locked_dataset_split_modified_message(
+            {
+                "id": 1,
+                "name": "Split Name",
+                "codename": "split_codename",
+            }
+        )
+        self.assertIsNone(msg)
+
+    def test_locked_challenge_phase_detects_name_change(self):
+        msg = self.util._locked_challenge_phase_modified_message(
+            {"id": 1, "name": "Renamed"}
+        )
+        self.assertIsNotNone(msg)
+
+    def test_locked_challenge_phase_none_when_consistent(self):
+        msg = self.util._locked_challenge_phase_modified_message(
+            {
+                "id": 1,
+                "name": "Phase 1",
+                "test_annotation_file": self.phase_annotation_basename,
+            }
+        )
+        self.assertIsNone(msg)
+
+    def test_locked_challenge_phase_detects_annotation_reference_change(self):
+        msg = self.util._locked_challenge_phase_modified_message(
+            {
+                "id": 1,
+                "name": "Phase 1",
+                "test_annotation_file": "nonexistent_annotation.txt",
+            }
+        )
+        self.assertIsNotNone(msg)
+
+    def test_locked_challenge_phase_split_visibility_change(self):
+        msg = self.util._locked_challenge_phase_split_modified_message(
+            {
+                "leaderboard_id": 1,
+                "challenge_phase_id": 1,
+                "dataset_split_id": 1,
+                "visibility": ChallengePhaseSplit.HOST,
+                "leaderboard_decimal_precision": 2,
+                "is_leaderboard_order_descending": True,
+            }
+        )
+        self.assertIsNotNone(msg)
+
+    def test_locked_challenge_phase_split_precision_change(self):
+        msg = self.util._locked_challenge_phase_split_modified_message(
+            {
+                "leaderboard_id": 1,
+                "challenge_phase_id": 1,
+                "dataset_split_id": 1,
+                "visibility": ChallengePhaseSplit.PUBLIC,
+                "leaderboard_decimal_precision": 5,
+                "is_leaderboard_order_descending": True,
+            }
+        )
+        self.assertIsNotNone(msg)
+
+    def test_locked_challenge_phase_split_order_change(self):
+        msg = self.util._locked_challenge_phase_split_modified_message(
+            {
+                "leaderboard_id": 1,
+                "challenge_phase_id": 1,
+                "dataset_split_id": 1,
+                "visibility": ChallengePhaseSplit.PUBLIC,
+                "leaderboard_decimal_precision": 2,
+                "is_leaderboard_order_descending": False,
+            }
+        )
+        self.assertIsNotNone(msg)
+
+    def test_locked_challenge_phase_split_none_when_match(self):
+        msg = self.util._locked_challenge_phase_split_modified_message(
+            {
+                "leaderboard_id": 1,
+                "challenge_phase_id": 1,
+                "dataset_split_id": 1,
+                "visibility": ChallengePhaseSplit.PUBLIC,
+                "leaderboard_decimal_precision": 2,
+                "is_leaderboard_order_descending": True,
+            }
+        )
+        self.assertIsNone(msg)
+
+    def test_locked_challenge_phase_split_missing_row(self):
+        msg = self.util._locked_challenge_phase_split_modified_message(
+            {
+                "leaderboard_id": 8,
+                "challenge_phase_id": 8,
+                "dataset_split_id": 8,
+                "visibility": ChallengePhaseSplit.PUBLIC,
+                "leaderboard_decimal_precision": 2,
+                "is_leaderboard_order_descending": True,
+            }
+        )
+        self.assertIsNone(msg)

--- a/tests/unit/challenges/test_challenge_config_utils.py
+++ b/tests/unit/challenges/test_challenge_config_utils.py
@@ -1006,9 +1006,13 @@ class TestValidateChallengeConfigUtil(unittest.TestCase):
         self.util.yaml_file_data = {
             "leaderboard": [
                 {
+                    "id": 1,
+                    "schema": {"labels": ["z"], "default_order_by": "z"},
+                },
+                {
                     "id": 99,
                     "schema": {"labels": ["a"], "default_order_by": "a"},
-                }
+                },
             ]
         }
         self.util.validate_leaderboards([1])
@@ -1022,6 +1026,10 @@ class TestValidateChallengeConfigUtil(unittest.TestCase):
         mock_ser.is_valid.return_value = True
         self.util.yaml_file_data = {
             "leaderboard": [
+                {
+                    "id": 1,
+                    "schema": {"labels": ["z"], "default_order_by": "z"},
+                },
                 {
                     "id": 99,
                     "schema": {"labels": ["a"], "default_order_by": "a"},

--- a/tests/unit/challenges/test_challenge_config_utils.py
+++ b/tests/unit/challenges/test_challenge_config_utils.py
@@ -1696,3 +1696,363 @@ class TestApprovedConfigLockMessageCoverage(TestCase):
             }
         )
         self.assertIsNone(msg)
+
+
+MEDIA_APPROVED_VALIDATE = "/tmp/evalai-approved-validate"
+
+
+@override_settings(MEDIA_ROOT=MEDIA_APPROVED_VALIDATE)
+class TestApprovedValidateMethodsRealLockIntegration(TestCase):
+    """
+    Exercise validate_* approved-lock branches with a real Challenge graph
+    (no mocking of _locked_*), raising Codecov on the call sites in
+    challenge_config_utils.py.
+    """
+
+    def setUp(self):
+        os.makedirs(MEDIA_APPROVED_VALIDATE, exist_ok=True)
+        suffix = uuid.uuid4().hex[:12]
+        self.user = User.objects.create_user(
+            username="apvl_{}".format(suffix), password="secret"
+        )
+        self.team = ChallengeHostTeam.objects.create(
+            team_name="Apv Host {}".format(suffix),
+            created_by=self.user,
+        )
+        now = timezone.now()
+        self.challenge = Challenge.objects.create(
+            title="Apv Challenge",
+            short_description="s",
+            description="d",
+            terms_and_conditions="t",
+            submission_guidelines="g",
+            creator=self.team,
+            published=False,
+            enable_forum=True,
+            anonymous_leaderboard=False,
+            start_date=now - timedelta(days=1),
+            end_date=now + timedelta(days=30),
+            approved_by_admin=True,
+        )
+        self.lb = Leaderboard.objects.create(
+            config_id=1,
+            schema={
+                "labels": ["yes/no", "overall"],
+                "default_order_by": "overall",
+            },
+        )
+        self.ds = DatasetSplit.objects.create(
+            config_id=1,
+            name="Split Name",
+            codename="split_codename",
+        )
+        self.phase = ChallengePhase.objects.create(
+            name="Phase 1",
+            description="desc",
+            leaderboard_public=False,
+            is_public=False,
+            start_date=now,
+            end_date=now + timedelta(days=1),
+            challenge=self.challenge,
+            config_id=1,
+            codename="pv1",
+            max_submissions_per_day=100,
+            max_submissions=100,
+            max_submissions_per_month=100,
+            test_annotation=None,
+        )
+        ChallengePhaseSplit.objects.create(
+            challenge_phase=self.phase,
+            leaderboard=self.lb,
+            dataset_split=self.ds,
+            visibility=ChallengePhaseSplit.PUBLIC,
+            leaderboard_decimal_precision=2,
+            is_leaderboard_order_descending=True,
+        )
+        self.util = ValidateChallengeConfigUtil.__new__(
+            ValidateChallengeConfigUtil
+        )
+        self.util.current_challenge = self.challenge
+        self.util.error_messages_dict = error_message_dict
+        self.util.error_messages = []
+        self.util.leaderboard_ids = []
+        self.util.phase_ids = []
+        self.util.dataset_splits_ids = []
+        self.util.challenge_config_location = MEDIA_APPROVED_VALIDATE
+        self.util.files = {"challenge_test_annotation_files": []}
+
+    @mockpatch("challenges.challenge_config_utils.LeaderboardSerializer")
+    def test_validate_leaderboards_real_lock_no_error(self, mock_ls):
+        mock_ls.return_value.is_valid.return_value = True
+        self.util.yaml_file_data = {
+            "leaderboard": [
+                {
+                    "id": 1,
+                    "schema": {
+                        "labels": ["yes/no", "overall"],
+                        "default_order_by": "overall",
+                    },
+                }
+            ]
+        }
+        self.util.validate_leaderboards([1])
+        self.assertEqual(self.util.error_messages, [])
+
+    @mockpatch("challenges.challenge_config_utils.LeaderboardSerializer")
+    def test_validate_leaderboards_real_lock_error(self, mock_ls):
+        mock_ls.return_value.is_valid.return_value = True
+        self.util.yaml_file_data = {
+            "leaderboard": [
+                {
+                    "id": 1,
+                    "schema": {"labels": ["x"], "default_order_by": "x"},
+                }
+            ]
+        }
+        self.util.validate_leaderboards([1])
+        self.assertTrue(self.util.error_messages)
+
+    @mockpatch("challenges.challenge_config_utils.DatasetSplitSerializer")
+    def test_validate_dataset_splits_real_lock_no_error(self, mock_dss):
+        mock_dss.return_value.is_valid.return_value = True
+        self.util.yaml_file_data = {
+            "dataset_splits": [
+                {
+                    "id": 1,
+                    "name": "Split Name",
+                    "codename": "split_codename",
+                }
+            ]
+        }
+        self.util.validate_dataset_splits([1])
+        self.assertEqual(self.util.error_messages, [])
+
+    @mockpatch("challenges.challenge_config_utils.DatasetSplitSerializer")
+    def test_validate_dataset_splits_real_lock_error(self, mock_dss):
+        mock_dss.return_value.is_valid.return_value = True
+        self.util.yaml_file_data = {
+            "dataset_splits": [
+                {
+                    "id": 1,
+                    "name": "Other Name",
+                    "codename": "split_codename",
+                }
+            ]
+        }
+        self.util.validate_dataset_splits([1])
+        self.assertTrue(self.util.error_messages)
+
+    @mockpatch(
+        "challenges.challenge_config_utils.ChallengePhaseCreateSerializer"
+    )
+    def test_validate_challenge_phases_real_lock_no_error(self, mock_cps):
+        mock_cps.return_value.is_valid.return_value = True
+        self.phase.refresh_from_db()
+        self.util.yaml_file_data = {
+            "challenge_phases": [
+                {
+                    "id": 1,
+                    "codename": "pv1",
+                    "name": "Phase 1",
+                    "description": "desc",
+                    "start_date": self.phase.start_date,
+                    "end_date": self.phase.end_date,
+                }
+            ]
+        }
+        self.util.validate_challenge_phases([1])
+        self.assertEqual(self.util.error_messages, [])
+
+    @mockpatch(
+        "challenges.challenge_config_utils.ChallengePhaseCreateSerializer"
+    )
+    def test_validate_challenge_phases_real_lock_error(self, mock_cps):
+        mock_cps.return_value.is_valid.return_value = True
+        self.phase.refresh_from_db()
+        self.util.yaml_file_data = {
+            "challenge_phases": [
+                {
+                    "id": 1,
+                    "codename": "pv1",
+                    "name": "Renamed Phase",
+                    "description": "desc",
+                    "start_date": self.phase.start_date,
+                    "end_date": self.phase.end_date,
+                }
+            ]
+        }
+        self.util.validate_challenge_phases([1])
+        self.assertTrue(
+            any("approved by an admin" in m for m in self.util.error_messages)
+        )
+
+    @mockpatch(
+        "challenges.challenge_config_utils.ZipChallengePhaseSplitSerializer"
+    )
+    def test_validate_challenge_phase_splits_real_lock_no_error(
+        self, mock_zss
+    ):
+        mock_zss.return_value.is_valid.return_value = True
+        self.util.yaml_file_data = {
+            "challenge_phase_splits": [
+                {
+                    "is_leaderboard_order_descending": True,
+                    "leaderboard_decimal_precision": 2,
+                    "visibility": ChallengePhaseSplit.PUBLIC,
+                    "dataset_split_id": 1,
+                    "leaderboard_id": 1,
+                    "challenge_phase_id": 1,
+                }
+            ]
+        }
+        self.util.phase_ids = [1]
+        self.util.leaderboard_ids = [1]
+        self.util.dataset_splits_ids = [1]
+        self.util.validate_challenge_phase_splits([(1, 1, 1)], [1], [1], [1])
+        self.assertEqual(self.util.error_messages, [])
+
+    @mockpatch(
+        "challenges.challenge_config_utils.ZipChallengePhaseSplitSerializer"
+    )
+    def test_validate_challenge_phase_splits_real_lock_error(self, mock_zss):
+        mock_zss.return_value.is_valid.return_value = True
+        self.util.yaml_file_data = {
+            "challenge_phase_splits": [
+                {
+                    "is_leaderboard_order_descending": True,
+                    "leaderboard_decimal_precision": 2,
+                    "visibility": ChallengePhaseSplit.HOST,
+                    "dataset_split_id": 1,
+                    "leaderboard_id": 1,
+                    "challenge_phase_id": 1,
+                }
+            ]
+        }
+        self.util.phase_ids = [1]
+        self.util.leaderboard_ids = [1]
+        self.util.dataset_splits_ids = [1]
+        self.util.validate_challenge_phase_splits([(1, 1, 1)], [1], [1], [1])
+        self.assertTrue(self.util.error_messages)
+
+
+@override_settings(MEDIA_ROOT="/tmp/evalai-vcu-orch")
+class TestValidateChallengeConfigUtilOrchestratorBranch(TestCase):
+    """Cover validate_challenge_config_util() when current_challenge is set."""
+
+    def setUp(self):
+        os.makedirs("/tmp/evalai-vcu-orch", exist_ok=True)
+        suffix = uuid.uuid4().hex[:12]
+        self.user = User.objects.create_user(
+            username="orch_{}".format(suffix), password="secret"
+        )
+        self.team = ChallengeHostTeam.objects.create(
+            team_name="Orch Host {}".format(suffix),
+            created_by=self.user,
+        )
+        now = timezone.now()
+        self.challenge = Challenge.objects.create(
+            title="Orch Challenge",
+            short_description="s",
+            description="d",
+            terms_and_conditions="t",
+            submission_guidelines="g",
+            creator=self.team,
+            published=False,
+            enable_forum=True,
+            anonymous_leaderboard=False,
+            start_date=now - timedelta(days=1),
+            end_date=now + timedelta(days=30),
+            approved_by_admin=False,
+        )
+        lb = Leaderboard.objects.create(
+            config_id=1,
+            schema={"labels": ["a"], "default_order_by": "a"},
+        )
+        ds = DatasetSplit.objects.create(
+            config_id=1,
+            name="n",
+            codename="c",
+        )
+        phase = ChallengePhase.objects.create(
+            name="P",
+            description="d",
+            leaderboard_public=False,
+            is_public=False,
+            start_date=now,
+            end_date=now + timedelta(days=1),
+            challenge=self.challenge,
+            config_id=1,
+            codename="o1",
+            max_submissions_per_day=100,
+            max_submissions=100,
+            max_submissions_per_month=100,
+        )
+        ChallengePhaseSplit.objects.create(
+            challenge_phase=phase,
+            leaderboard=lb,
+            dataset_split=ds,
+            visibility=ChallengePhaseSplit.PUBLIC,
+            leaderboard_decimal_precision=2,
+            is_leaderboard_order_descending=True,
+        )
+
+    @mockpatch("challenges.challenge_config_utils.read_yaml_file")
+    @mockpatch(
+        "challenges.challenge_config_utils.get_yaml_files_from_challenge_config"
+    )
+    def test_orchestrator_passes_existing_config_ids_to_validators(
+        self, mock_get_yaml, mock_read_yaml
+    ):
+        mock_get_yaml.return_value = (1, "challenge_config.yaml", "extracted")
+        mock_read_yaml.return_value = {"title": "T"}
+        request = Mock()
+        request.data = {"GITHUB_REPOSITORY": "a/b"}
+        zip_ref = Mock()
+        captured = {}
+
+        def capture_lb(util_self, lb_ids):
+            captured["leaderboard_ids"] = list(lb_ids)
+
+        def capture_ph(util_self, ph_ids):
+            captured["phase_ids"] = list(ph_ids)
+
+        def capture_ds(util_self, ds_ids):
+            captured["dataset_ids"] = list(ds_ids)
+
+        def capture_spl(util_self, split_ids, *args, **kwargs):
+            captured["split_ids"] = [
+                tuple(int(x) for x in t) for t in split_ids
+            ]
+
+        noop = Mock()
+        with mockpatch.multiple(
+            ValidateChallengeConfigUtil,
+            validate_challenge_title=noop,
+            validate_challenge_logo=noop,
+            validate_challenge_description=noop,
+            validate_evaluation_details_file=noop,
+            validate_terms_and_conditions_file=noop,
+            validate_submission_guidelines_file=noop,
+            validate_evaluation_script_file=noop,
+            validate_dates=noop,
+            validate_serializer=noop,
+            validate_leaderboards=capture_lb,
+            validate_challenge_phases=capture_ph,
+            validate_dataset_splits=capture_ds,
+            validate_challenge_phase_splits=capture_spl,
+            check_tags=noop,
+            check_domain=noop,
+            check_prizes=noop,
+        ):
+            validate_challenge_config_util(
+                request,
+                self.team,
+                "/tmp/base",
+                "unique",
+                zip_ref,
+                self.challenge,
+            )
+        self.assertEqual(captured["leaderboard_ids"], [1])
+        self.assertEqual(captured["phase_ids"], [1])
+        self.assertEqual(captured["dataset_ids"], [1])
+        self.assertEqual(captured["split_ids"], [(1, 1, 1)])

--- a/tests/unit/challenges/test_challenge_config_utils.py
+++ b/tests/unit/challenges/test_challenge_config_utils.py
@@ -633,7 +633,12 @@ class TestValidateChallengeConfigUtil0(unittest.TestCase):
         self.util.dataset_splits_ids = [1]
         self.util.error_messages = []
 
-        self.util.validate_challenge_phase_splits([(99, 98, 97)])
+        self.util.validate_challenge_phase_splits(
+            [(99, 98, 97)],
+            current_phase_config_ids=[],
+            current_leaderboard_config_ids=[2],
+            current_dataset_config_ids=[1],
+        )
 
         assert any(
             "challenge phase split" in msg.lower()
@@ -890,7 +895,6 @@ class TestValidateChallengeConfigUtil(unittest.TestCase):
             "invalid_leaderboard_schema": "Invalid leaderboard schema.",
             "missing_leaderboard_key": "Leaderboard key is missing.",
             "leaderboard_schema_error": "Leaderboard schema error for leaderboard with ID: {}",
-            "leaderboard_additon_after_creation": "Cannot add new leaderboard after challenge creation.",
             "leaderboard_deletion_after_creation": "Cannot delete leaderboard after challenge creation.",
             "missing_challenge_phases": "Missing challenge phases.",
             "no_codename_for_challenge_phase": "Codename is missing for challenge phase.",
@@ -995,41 +999,41 @@ class TestValidateChallengeConfigUtil(unittest.TestCase):
                     ].format("test_id", "some_error"),
                 )
 
-    def test_leaderboard_addition_after_creation(self):
+    @mockpatch("challenges.challenge_config_utils.LeaderboardSerializer")
+    def test_leaderboard_addition_after_creation(self, MockSerializer):
+        mock_ser = MockSerializer.return_value
+        mock_ser.is_valid.return_value = True
         self.util.yaml_file_data = {
             "leaderboard": [
                 {
-                    "id": "new_leaderboard_id",
+                    "id": 99,
                     "schema": {"labels": ["a"], "default_order_by": "a"},
                 }
             ]
         }
-        self.util.validate_leaderboards(["existing_leaderboard_id"])
-        self.assertIn(
-            "Leaderboard schema error for leaderboard with ID: new_leaderboard_id",
-            self.util.error_messages[0],
-        )
+        self.util.validate_leaderboards([1])
+        self.assertEqual(self.util.error_messages, [])
 
+    @mockpatch("challenges.challenge_config_utils.LeaderboardSerializer")
     def test_leaderboard_addition_after_creation_with_multiple_leaderboards(
-        self,
+        self, MockSerializer
     ):
+        mock_ser = MockSerializer.return_value
+        mock_ser.is_valid.return_value = True
         self.util.yaml_file_data = {
             "leaderboard": [
                 {
-                    "id": "new_leaderboard_id1",
+                    "id": 99,
                     "schema": {"labels": ["a"], "default_order_by": "a"},
                 },
                 {
-                    "id": "new_leaderboard_id2",
+                    "id": 100,
                     "schema": {"labels": ["b"], "default_order_by": "b"},
                 },
             ]
         }
-        self.util.validate_leaderboards(["existing_leaderboard_id"])
-        self.assertIn(
-            "Leaderboard schema error for leaderboard with ID: new_leaderboard_id1",
-            self.util.error_messages[0],
-        )
+        self.util.validate_leaderboards([1])
+        self.assertEqual(self.util.error_messages, [])
 
     def test_leaderboard_deletion_after_creation(self):
         self.util.yaml_file_data = {

--- a/tests/unit/challenges/test_challenge_config_utils.py
+++ b/tests/unit/challenges/test_challenge_config_utils.py
@@ -1761,6 +1761,15 @@ class TestApprovedValidateMethodsRealLockIntegration(TestCase):
             max_submissions_per_month=100,
             test_annotation=None,
         )
+        # validate_challenge_phases replaces description with get_value_from_field;
+        # it must resolve to the same string as phase.description for the lock check.
+        self.phase_desc_html = "phase_desc_{}.html".format(suffix)
+        with open(
+            join(MEDIA_APPROVED_VALIDATE, self.phase_desc_html),
+            "w",
+            encoding="utf-8",
+        ) as desc_file:
+            desc_file.write("desc")
         ChallengePhaseSplit.objects.create(
             challenge_phase=self.phase,
             leaderboard=self.lb,
@@ -1854,7 +1863,7 @@ class TestApprovedValidateMethodsRealLockIntegration(TestCase):
                     "id": 1,
                     "codename": "pv1",
                     "name": "Phase 1",
-                    "description": "desc",
+                    "description": self.phase_desc_html,
                     "start_date": self.phase.start_date,
                     "end_date": self.phase.end_date,
                 }
@@ -1875,7 +1884,7 @@ class TestApprovedValidateMethodsRealLockIntegration(TestCase):
                     "id": 1,
                     "codename": "pv1",
                     "name": "Renamed Phase",
-                    "description": "desc",
+                    "description": self.phase_desc_html,
                     "start_date": self.phase.start_date,
                     "end_date": self.phase.end_date,
                 }


### PR DESCRIPTION
## Summary

- Relax challenge zip/YAML validation so hosts can add new challenge phases, dataset splits, and leaderboards when updating an existing challenge, instead of blocking those changes after initial creation.
- Refine `challenge_phase_splits` validation: allow new leaderboard/dataset-split mappings only for **new** phases; require leaderboard and dataset split IDs to come from the DB or the same uploaded config; normalize IDs when comparing existing splits.
- Fix the GitHub/zip challenge **update** path for brand-new phases: derive `config_id` from YAML `id` when `config_id` is absent, generate `slug`, and avoid accessing fields on a missing `ChallengePhase` when a test annotation file is present.

## Test plan

- [x] `python manage.py test tests.unit.challenges.test_challenge_config_utils` (or project pytest target)
- [x] Manual: update an existing challenge via the GitHub challenge sync flow with an extra phase, dataset split, leaderboard, and matching `challenge_phase_splits` rows; confirm validation passes and DB rows are created/updated as expected.
- [x] Confirm removing an existing leaderboard/dataset split/phase from YAML still errors as before (deletion guards unchanged).