### PR TITLE
Backend: Normalize approved-config lock field comparison

### DIFF
--- a/apps/challenges/challenge_config_utils.py
+++ b/apps/challenges/challenge_config_utils.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 import zipfile
+from datetime import datetime
 from os.path import basename, isfile, join
 
 import requests
@@ -14,6 +15,7 @@ from challenges.models import (
     Leaderboard,
 )
 from django.core.files.base import ContentFile
+from django.utils import dateparse, timezone
 from rest_framework import status
 from yaml.scanner import ScannerError
 
@@ -57,6 +59,33 @@ _CHALLENGE_PHASE_APPROVED_LOCK_FIELDS = (
     "environment_image",
     "is_partial_submission_evaluation_enabled",
 )
+
+_CHALLENGE_PHASE_DATE_LOCK_FIELDS = frozenset({"start_date", "end_date"})
+
+
+def _parse_lock_datetime(value):
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, str):
+        stripped = value.strip()
+        dt = dateparse.parse_datetime(stripped)
+        if dt is None:
+            dt = dateparse.parse_datetime(stripped.replace(" ", "T", 1))
+    else:
+        return value
+    if timezone.is_naive(dt):
+        dt = timezone.make_aware(dt, timezone.utc)
+    return dt.astimezone(timezone.utc).replace(microsecond=0)
+
+
+def _normalize_lock_field_value(field, value):
+    if field in _CHALLENGE_PHASE_DATE_LOCK_FIELDS:
+        return _parse_lock_datetime(value)
+    if field == "description" and isinstance(value, str):
+        return value.rstrip()
+    return value
 
 
 def write_file(output_path, mode, file_content):
@@ -462,6 +491,13 @@ class ValidateChallengeConfigUtil:
     def _stable_json(value):
         return json.dumps(value, sort_keys=True, default=str)
 
+    def _lock_field_values_equal(self, field, db_value, yaml_value):
+        norm_db = _normalize_lock_field_value(field, db_value)
+        norm_yaml = _normalize_lock_field_value(field, yaml_value)
+        if isinstance(norm_db, datetime) and isinstance(norm_yaml, datetime):
+            return norm_db == norm_yaml
+        return self._stable_json(norm_db) == self._stable_json(norm_yaml)
+
     def _locked_leaderboard_modified_message(self, data):
         lb = Leaderboard.objects.filter(
             config_id=int(data["id"]),
@@ -505,8 +541,8 @@ class ValidateChallengeConfigUtil:
         for field in _CHALLENGE_PHASE_APPROVED_LOCK_FIELDS:
             if field not in data:
                 continue
-            if self._stable_json(getattr(phase, field)) != self._stable_json(
-                data.get(field)
+            if not self._lock_field_values_equal(
+                field, getattr(phase, field), data.get(field)
             ):
                 return self.error_messages_dict[
                     "locked_challenge_phase_modified"

--- a/tests/unit/challenges/test_challenge_config_utils.py
+++ b/tests/unit/challenges/test_challenge_config_utils.py
@@ -4,7 +4,7 @@ import tempfile
 import unittest
 import uuid
 import zipfile
-from datetime import timedelta
+from datetime import datetime, timedelta
 from os.path import basename, join
 from unittest.mock import Mock
 from unittest.mock import patch as mockpatch
@@ -1617,6 +1617,64 @@ class TestApprovedConfigLockMessageCoverage(TestCase):
             {
                 "id": 1,
                 "name": "Phase 1",
+                "test_annotation_file": self.phase_annotation_basename,
+            }
+        )
+        self.assertIsNone(msg)
+
+    def test_locked_challenge_phase_accepts_yaml_date_format(self):
+        phase_start = timezone.make_aware(
+            datetime(2019, 1, 19, 0, 0, 0), timezone.utc
+        )
+        phase_end = timezone.make_aware(
+            datetime(2019, 1, 20, 0, 0, 0), timezone.utc
+        )
+        self.phase.start_date = phase_start
+        self.phase.end_date = phase_end
+        self.phase.save()
+
+        msg = self.util._locked_challenge_phase_modified_message(
+            {
+                "id": 1,
+                "name": "Phase 1",
+                "start_date": "2019-01-19 00:00:00",
+                "end_date": "2019-01-20 00:00:00",
+                "test_annotation_file": self.phase_annotation_basename,
+            }
+        )
+        self.assertIsNone(msg)
+
+    def test_locked_challenge_phase_accepts_iso_date_format(self):
+        phase_start = timezone.make_aware(
+            datetime(2019, 1, 19, 0, 0, 0), timezone.utc
+        )
+        phase_end = timezone.make_aware(
+            datetime(2019, 1, 20, 0, 0, 0), timezone.utc
+        )
+        self.phase.start_date = phase_start
+        self.phase.end_date = phase_end
+        self.phase.save()
+
+        msg = self.util._locked_challenge_phase_modified_message(
+            {
+                "id": 1,
+                "name": "Phase 1",
+                "start_date": "2019-01-19T00:00:00Z",
+                "end_date": "2019-01-20T00:00:00Z",
+                "test_annotation_file": self.phase_annotation_basename,
+            }
+        )
+        self.assertIsNone(msg)
+
+    def test_locked_challenge_phase_accepts_description_trailing_newline(self):
+        self.phase.description = "<p>hello</p>"
+        self.phase.save()
+
+        msg = self.util._locked_challenge_phase_modified_message(
+            {
+                "id": 1,
+                "name": "Phase 1",
+                "description": "<p>hello</p>\n",
                 "test_annotation_file": self.phase_annotation_basename,
             }
         )


### PR DESCRIPTION
## Summary
- Compare approved challenge phase lock fields semantically instead of raw JSON strings
- Parse YAML date formats (`2019-01-19 00:00:00`) and ISO DB datetimes as the same instant
- Strip trailing whitespace from description HTML before lock comparison
- Add unit tests for YAML/ISO date equivalence and description newline handling

## Context
After #5084, approved challenges reject config zip updates when existing phase blocks differ from DB values. Host repos using standard EvalAI starter date formats were failing even when values were unchanged, because `_stable_json` compared `"2019-01-19 00:00:00"` to `"2019-01-19T00:00:00Z"`.

## Test plan
- [x] Pre-commit hooks pass locally
- [x] `python manage.py test tests.unit.challenges.test_challenge_config_utils.TestApprovedConfigLockMessageCoverage`
- [x] Push `staging-test-random` challenge branch after staging deploy and confirm Phase 5 update succeeds without changing YAML date formats