### PR TITLE
Fix nodejs Docker xvfb install breaking Mesa GL dependencies.

### DIFF
--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -69,17 +69,11 @@ ENV NODE_ENV=development \
     CHROME_PATH=/usr/bin/google-chrome \
     DISPLAY=:99.0
 
-# Install only essential runtime dependencies (no build tools, no git)
-# Add retry logic and --fix-missing to handle transient network issues
+# Install only essential runtime dependencies (no build tools, no git).
+# xvfb is installed with Chrome/Chromium in arch-specific stages so Mesa GL deps resolve together.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends --fix-missing \
-    ca-certificates \
-    xvfb \
-    || (apt-get update && apt-get install -y --no-install-recommends --fix-missing \
-        ca-certificates \
-        xvfb) && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /var/cache/apt/*
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 WORKDIR /code
 
@@ -92,25 +86,21 @@ COPY --from=builder /code/bower_components /code/bower_components
 # AMD64-specific stage for Chrome
 FROM base AS amd64
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends --fix-missing wget gnupg procps && \
+    apt-get install -y --no-install-recommends wget gnupg procps && \
     wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list && \
     apt-get update && \
-    apt-get install -y --no-install-recommends --fix-missing google-chrome-stable libxss1 \
-    || (apt-get update && apt-get install -y --no-install-recommends --fix-missing google-chrome-stable libxss1) && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /var/cache/apt/* && \
-    # Clean Chrome unnecessary locale files only (preserve essential .pak files)
+    apt-get install -y --no-install-recommends \
+    google-chrome-stable libxss1 xvfb && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/* && \
     find /opt/google/chrome/locales -name "*.pak" ! -name "en-US.pak" -delete 2>/dev/null || true
 
 # ARM64-specific stage for Chromium
 FROM base AS arm64
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends --fix-missing chromium libxss1 procps \
-    || (apt-get update && apt-get install -y --no-install-recommends --fix-missing chromium libxss1 procps) && \
+    apt-get install -y --no-install-recommends chromium libxss1 procps xvfb && \
     ln -sf /usr/bin/chromium /usr/bin/google-chrome && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /var/cache/apt/*
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 # Final stage - automatically selects the right architecture
 FROM ${TARGETARCH:-amd64}

--- a/docker/prod/nodejs/Dockerfile
+++ b/docker/prod/nodejs/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update && \
     curl \
     wget \
     gnupg \
-    xvfb \
     || (apt-get update && apt-get install -y --no-install-recommends --fix-missing \
         python2 \
         python-is-python2 \
@@ -34,8 +33,7 @@ RUN apt-get update && \
         ca-certificates \
         curl \
         wget \
-        gnupg \
-        xvfb) && \
+        gnupg) && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -85,8 +83,7 @@ RUN bower install --allow-root
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list && \
     apt-get update && \
-    apt-get install -y --no-install-recommends --fix-missing google-chrome-stable libxss1 \
-    || (apt-get update && apt-get install -y --no-install-recommends --fix-missing google-chrome-stable libxss1) && \
+    apt-get install -y --no-install-recommends google-chrome-stable libxss1 xvfb && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/* && \
     # Clean Chrome unnecessary files


### PR DESCRIPTION
Install xvfb alongside Chrome/Chromium so apt resolves libglapi-mesa with related Mesa packages instead of a broken partial install in the base stage.
