### PR TITLE
Update challenge configuration links to new ReadTheDocs paths.

### DIFF
--- a/docs/source/02-for-challenge-hosts/hosting-guide/host-challenge.md
+++ b/docs/source/02-for-challenge-hosts/hosting-guide/host-challenge.md
@@ -119,7 +119,7 @@ Please ensure the following fields are set to the following values:
 
 - `remote_evaluation : True`
 
-Refer to the [following documentation](https://evalai.readthedocs.io/en/latest/configuration.html) for details on challenge configuration.
+Refer to [Challenge configuration](../configuration/challenge-config.md) for details on challenge configuration.
 
 ### Step 3: Edit remote evaluation script
 

--- a/frontend/src/views/web/challenge-create.html
+++ b/frontend/src/views/web/challenge-create.html
@@ -60,7 +60,7 @@
         <div class="col s12 m9 offset-m2">
             <i class="fa fa-info-circle"></i>
             To know how to create a challenge using zip file configuration, please see our documentation
-            <a href="https://evalai.readthedocs.io/en/latest/configuration.html#challenge-configuration" class="highlight-link" target="_blank">here.</a>.
+            <a href="https://evalai.readthedocs.io/en/latest/02-for-challenge-hosts/configuration/challenge-config.html#challenge-configuration" class="highlight-link" target="_blank">here.</a>.
         </div>
     </div>
     <div ng-if="challengeCreate.isSyntaxErrorInYamlFile" class="row">


### PR DESCRIPTION
Point host-challenge docs and the challenge-create UI at the relocated challenge-config pages instead of removed configuration.html URLs.