### PR TITLE
Fix #4413: Allow adding missing submission metadata

### DIFF
--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -2259,6 +2259,21 @@
             return false;
         };
 
+        vm.getSubmissionMetadataForEdit = function(submission) {
+            if (submission.submission_metadata != null) {
+                return JSON.parse(JSON.stringify(submission.submission_metadata));
+            }
+
+            var phaseId = submission.challenge_phase || vm.phaseId;
+            var phaseAttributes = vm.submissionMetaAttributes.find(function(element) {
+                return element["phaseId"] == phaseId;
+            });
+            if (phaseAttributes && phaseAttributes.attributes != null) {
+                return JSON.parse(JSON.stringify(phaseAttributes.attributes));
+            }
+            return null;
+        };
+
         vm.showMdDialog = function (ev, submissionId) {
             for (var i = 0; i < vm.submissionResult.count; i++) {
                 if (vm.submissionResult.results[i].id === submissionId) {
@@ -2271,9 +2286,7 @@
             vm.project_url = vm.submissionMetaData.project_url;
             vm.publication_url = vm.submissionMetaData.publication_url;
             vm.submissionId = submissionId;
-            if (vm.submissionMetaData.submission_metadata != null) {
-                vm.currentSubmissionMetaData = JSON.parse(JSON.stringify(vm.submissionMetaData.submission_metadata));
-            }
+            vm.currentSubmissionMetaData = vm.getSubmissionMetadataForEdit(vm.submissionMetaData);
             $mdDialog.show({
                 scope: $scope,
                 preserveScope: true,

--- a/frontend/tests/controllers-test/challengeCtrlMetadata.test.js
+++ b/frontend/tests/controllers-test/challengeCtrlMetadata.test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+describe('ChallengeCtrl submission metadata editing', function() {
+    beforeEach(angular.mock.module('evalai'));
+
+    var $controller, $mdDialog, $rootScope, $scope, utilities, vm;
+
+    beforeEach(inject(function(
+        _$controller_,
+        _$mdDialog_,
+        _$rootScope_,
+        _utilities_
+    ) {
+        $controller = _$controller_;
+        $mdDialog = _$mdDialog_;
+        $rootScope = _$rootScope_;
+        utilities = _utilities_;
+
+        spyOn(utilities, 'getData').and.returnValue(null);
+        spyOn(utilities, 'sendRequest').and.callFake(function() {});
+        spyOn($mdDialog, 'show');
+
+        $scope = $rootScope.$new();
+        vm = $controller('ChallengeCtrl', { $scope: $scope });
+    }));
+
+    it('loads phase metadata attributes when submission has no metadata', function() {
+        var submissionId = 1;
+        var phaseAttributes = [
+            {
+                name: 'TextAttribute',
+                type: 'text',
+                value: null,
+                description: 'Sample'
+            }
+        ];
+        vm.submissionResult = {
+            count: 1,
+            results: [
+                {
+                    id: submissionId,
+                    challenge_phase: 2,
+                    method_name: 'method name',
+                    method_description: 'method description',
+                    project_url: 'project url',
+                    publication_url: 'publication url',
+                    submission_metadata: null
+                }
+            ]
+        };
+        vm.submissionMetaAttributes = [
+            {
+                phaseId: 2,
+                attributes: phaseAttributes
+            }
+        ];
+
+        vm.showMdDialog(new Event('click'), submissionId);
+
+        expect(vm.currentSubmissionMetaData).toEqual(phaseAttributes);
+        expect(vm.currentSubmissionMetaData).not.toBe(phaseAttributes);
+        expect($mdDialog.show).toHaveBeenCalled();
+    });
+
+    it('keeps saved submission metadata when present', function() {
+        var submissionId = 1;
+        var savedMetadata = [
+            {
+                name: 'TextAttribute',
+                type: 'text',
+                value: 'saved value',
+                description: 'Sample'
+            }
+        ];
+        vm.submissionResult = {
+            count: 1,
+            results: [
+                {
+                    id: submissionId,
+                    challenge_phase: 2,
+                    method_name: 'method name',
+                    method_description: 'method description',
+                    project_url: 'project url',
+                    publication_url: 'publication url',
+                    submission_metadata: savedMetadata
+                }
+            ]
+        };
+        vm.submissionMetaAttributes = [
+            {
+                phaseId: 2,
+                attributes: [
+                    {
+                        name: 'TextAttribute',
+                        type: 'text',
+                        value: null,
+                        description: 'Sample'
+                    }
+                ]
+            }
+        ];
+
+        vm.showMdDialog(new Event('click'), submissionId);
+
+        expect(vm.currentSubmissionMetaData).toEqual(savedMetadata);
+        expect(vm.currentSubmissionMetaData).not.toBe(savedMetadata);
+    });
+});


### PR DESCRIPTION
Fixes #4413.

Summary:
- Load the current phase metadata schema when a submission has no saved `submission_metadata`.
- Preserve saved submission metadata when it already exists.
- Add controller coverage for both editing paths.

Validation:
- `git diff --check`
- `node --check frontend/src/js/controllers/challengeCtrl.js`
- `node --check frontend/tests/controllers-test/challengeCtrlMetadata.test.js`
- `docker compose run nodejs bash -c "gulp dev && karma start --single-run --reporters=brief --client.jasmine.grep="ChallengeCtrl submission metadata editing""` (602 passed)