### PR TITLE
Add CodeRabbit configuration for public-repo review safeguards

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# EvalAI is a public repository. This file must be merged to master so CodeRabbit
+# uses it by default; PR branches that include this file also apply it to that PR.
+
+language: en-US
+
+reviews:
+  profile: chill
+  review_status: true
+  review_details: false
+  poem: false
+  prompt_for_ai_agents: false
+  instructions: |
+    EvalAI is a public open-source repository. Treat all review output as public.
+    Never expose sensitive data in inline comments, walkthroughs, summaries,
+    titles, labels, or suggested fixes.
+
+    Never quote, repeat, or include in output:
+    - API keys, tokens, passwords, secrets, or connection strings
+    - Email addresses, phone numbers, or other PII
+    - AWS credentials, SendGrid keys, Django secret keys, or auth tokens
+    - User IDs, participant IDs, challenge IDs, team IDs, submission IDs,
+      host IDs, primary keys, UUIDs used as identifiers, or database record IDs
+
+    When discussing issues involving sensitive values:
+    - Use placeholders such as [REDACTED] instead of real values
+    - Describe the problem without echoing the literal secret or identifier
+    - Do not suggest committing real credentials or production identifiers
+    - Prefer file and line references over pasting code that contains sensitive literals
+    - Do not include example payloads, logs, or API responses containing real IDs
+  path_filters:
+    - "!**/.env"
+    - "!**/.env.*"
+    - "!**/*.env"
+    - "!docker/**/*.env"
+    - "!**/secrets/**"
+    - "!**/*credentials*"
+    - "!**/*secret*"
+  path_instructions:
+    - path: "settings/**"
+      instructions: |
+        Django settings may reference secrets via environment variables. Flag hardcoded
+        credentials, but never repeat secret values or production identifiers in comments.
+    - path: "tests/**"
+      instructions: |
+        Test fixtures may contain fake passwords and emails. Do not quote those values
+        in review comments. Flag accidental use of real secrets, not test placeholders.
+    - path: "apps/**"
+      instructions: |
+        Avoid repeating database IDs, user identifiers, tokens, or serialized object
+        payloads in review comments. Reference fields and logic without echoing values.
+  auto_review:
+    enabled: true
+    drafts: true
+    base_branches:
+      - ".*"
+    ignore_usernames:
+      - "dependabot[bot]"
+      - "renovate[bot]"
+  tools:
+    gitleaks:
+      enabled: true
+    trufflehog:
+      enabled: true
+    presidio:
+      enabled: true
+
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,20 +1,74 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 #
-# EvalAI is a public repository. This file must be merged to master so CodeRabbit
-# uses it by default; PR branches that include this file also apply it to that PR.
+# Cloud-CV/EvalAI — CodeRabbit config (repository root).
+# Tuned for an active OSS project: backend Python/Django, frontend AngularJS/JavaScript.
+# Goal: high-signal reviews (bugs, security, logic) without re-flagging formatting
+# that pre-commit (black/flake8/isort) and eslint already handle.
+#
+# This is a public repository. Merge this file to master so CodeRabbit uses it by default;
+# PR branches that include this file also apply it to that PR.
 
 language: en-US
 
 reviews:
+  # followup: thorough feedback plus re-raises unresolved review comments on new commits.
   profile: followup
+
+  # Don't let CodeRabbit auto-block PRs with a "changes requested" gate;
+  # maintainers and CODEOWNERS stay the merge authority.
+  request_changes_workflow: false
+
+  high_level_summary: true
   review_status: true
   review_details: false
+  collapse_walkthrough: false
+  sequence_diagrams: true
   poem: false
   prompt_for_ai_agents: false
+  assess_linked_issues: true
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - "master"
+    ignore_usernames:
+      - "dependabot[bot]"
+      - "renovate[bot]"
+
+  path_filters:
+    # Secrets and env files (public repo)
+    - "!**/.env"
+    - "!**/.env.*"
+    - "!**/*.env"
+    - "!docker/**/*.env"
+    - "!**/secrets/**"
+    - "!**/*credentials*"
+    - "!**/*secret*"
+    # Generated / vendored / build artifacts
+    - "!**/migrations/**"
+    - "!**/*.lock"
+    - "!**/package-lock.json"
+    - "!**/yarn.lock"
+    - "!**/node_modules/**"
+    - "!**/dist/**"
+    - "!**/build/**"
+    - "!**/*.min.js"
+    - "!**/*.min.css"
+    - "!**/*.svg"
+    - "!**/static/**"
+    - "!docs/_build/**"
+
   instructions: |
     EvalAI is a public open-source repository. Treat all review output as public.
-    Never expose sensitive data in inline comments, walkthroughs, summaries,
-    titles, labels, or suggested fixes.
+
+    This repository already enforces formatting and linting via pre-commit
+    (black, flake8, isort) for Python and eslint for JavaScript.
+    Do NOT comment on code style, formatting, import ordering, line length,
+    or naming conventions — those are handled automatically.
+    Focus your review on: logic bugs, security issues (auth, injection,
+    unsafe deserialization), race conditions in the submission/worker flow,
+    API contract changes, missing error handling, and missing test coverage.
 
     Never quote, repeat, or include in output:
     - API keys, tokens, passwords, secrets, or connection strings
@@ -29,35 +83,32 @@ reviews:
     - Do not suggest committing real credentials or production identifiers
     - Prefer file and line references over pasting code that contains sensitive literals
     - Do not include example payloads, logs, or API responses containing real IDs
-  path_filters:
-    - "!**/.env"
-    - "!**/.env.*"
-    - "!**/*.env"
-    - "!docker/**/*.env"
-    - "!**/secrets/**"
-    - "!**/*credentials*"
-    - "!**/*secret*"
+
   path_instructions:
     - path: "settings/**"
       instructions: |
         Django settings may reference secrets via environment variables. Flag hardcoded
         credentials, but never repeat secret values or production identifiers in comments.
-    - path: "tests/**"
-      instructions: |
-        Test fixtures may contain fake passwords and emails. Do not quote those values
-        in review comments. Flag accidental use of real secrets, not test placeholders.
     - path: "apps/**"
       instructions: |
-        Avoid repeating database IDs, user identifiers, tokens, or serialized object
-        payloads in review comments. Reference fields and logic without echoing values.
-  auto_review:
-    enabled: true
-    drafts: true
-    base_branches:
-      - ".*"
-    ignore_usernames:
-      - "dependabot[bot]"
-      - "renovate[bot]"
+        Django backend. Pay attention to:
+        - Database query efficiency (N+1 queries, missing select_related/prefetch_related)
+        - Permission and authentication checks on DRF views/serializers
+        - Safe handling of user-submitted files and Docker image references
+        - Migrations that could be destructive or lock large tables
+        - Do not repeat database IDs, tokens, or serialized payloads in review comments
+    - path: "frontend/**"
+      instructions: |
+        AngularJS/JavaScript frontend. Pay attention to:
+        - Unsubscribed $scope listeners / potential memory leaks
+        - Unsafe ng-bind-html or unsanitized user content (XSS)
+        - Controller state and digest-cycle correctness
+    - path: "**/test_*.py"
+      instructions: |
+        Test code. Check that tests actually assert behavior, cover edge cases,
+        and are not silently passing. Do not quote fake fixture passwords or emails
+        in review comments. Light touch on style.
+
   tools:
     gitleaks:
       enabled: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,7 +6,7 @@
 language: en-US
 
 reviews:
-  profile: chill
+  profile: followup
   review_status: true
   review_details: false
   poem: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,8 +11,8 @@
 language: en-US
 
 reviews:
-  # followup: thorough feedback plus re-raises unresolved review comments on new commits.
-  profile: followup
+  # Valid values: chill | assertive. chill keeps volume sane for OSS contributors.
+  profile: chill
 
   # Don't let CodeRabbit auto-block PRs with a "changes requested" gate;
   # maintainers and CODEOWNERS stay the merge authority.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -29,9 +29,9 @@ reviews:
 
   auto_review:
     enabled: true
-    drafts: false
+    drafts: true
     base_branches:
-      - "master"
+      - ".*"
     ignore_usernames:
       - "dependabot[bot]"
       - "renovate[bot]"

--- a/.presidiocli
+++ b/.presidiocli
@@ -1,0 +1,13 @@
+language: en
+threshold: 0.35
+ignore: |
+  .git
+entities:
+  - CREDIT_CARD
+  - CRYPTO
+  - EMAIL_ADDRESS
+  - IBAN_CODE
+  - PHONE_NUMBER
+  - US_BANK_NUMBER
+  - US_ITIN
+  - US_SSN


### PR DESCRIPTION
## Summary
- Add `.coderabbit.yaml` to enable auto-reviews on all base branches and instruct CodeRabbit not to quote secrets, PII, or internal IDs in public review output.
- Exclude env/credential files from review via path filters.
- Enable Gitleaks, TruffleHog, and Presidio scanning for secrets and PII in changed files.
- Add `.presidiocli` to configure Presidio entity detection.

## Test plan
- [x] Merge PR and confirm CodeRabbit reports `Configuration used: Repository: .coderabbit.yaml` on the next review
- [x] Verify auto-review runs on a PR targeting `master`
- [x] Confirm review comments do not repeat secrets, emails, or internal IDs
- [x] Trigger `@coderabbitai review` on this PR to validate config is picked up from the feature branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added repository automation to improve high-signal automated reviews, enable auto-reviews across branches, draft auto-reviews, and chat auto-replies.
  * Expanded and tuned sensitive-data detection and security scanning with additional detectors and adjusted thresholds.
  * Introduced path-based filters and focused review guidance, plus rules to redact secrets/PII and ignore common bot/automation noise.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cloud-CV/EvalAI/pull/5097?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->