### PR TITLE
Show JWT issue/expiry metadata in JwtToken admin

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -8,6 +8,10 @@ from import_export import resources
 from import_export.admin import ExportMixin
 from rest_framework.authtoken.admin import TokenAdmin
 from rest_framework.authtoken.models import Token
+from rest_framework_simplejwt.token_blacklist.models import (
+    BlacklistedToken,
+    OutstandingToken,
+)
 
 from .models import JwtToken, Profile
 
@@ -77,14 +81,72 @@ admin.site.unregister(Token)
 admin.site.register(Token, TokenAdmin)
 
 
+def _get_outstanding_token_for_jwt(jwt_token):
+    if jwt_token.refresh_token:
+        outstanding_token = OutstandingToken.objects.filter(
+            token=jwt_token.refresh_token
+        ).first()
+        if outstanding_token is not None:
+            return outstanding_token
+
+    return (
+        OutstandingToken.objects.filter(user=jwt_token.user)
+        .order_by("-created_at")
+        .first()
+    )
+
+
 @admin.register(JwtToken)
 class JwtTokenAdmin(ImportExportTimeStampedAdmin):
+    exclude = ()
     list_display = (
         "user",
-        "access_token",
+        "created_at",
+        "modified_at",
+        "jwt_issued_at",
+        "jwt_expires_at",
+        "is_blacklisted",
     )
     list_filter = ("user",)
-    search_fields = ("user__username",)
+    search_fields = ("user__username", "user__email")
+    readonly_fields = (
+        "user",
+        "access_token",
+        "refresh_token",
+        "created_at",
+        "modified_at",
+        "jwt_issued_at",
+        "jwt_expires_at",
+        "is_blacklisted",
+    )
+
+    def jwt_issued_at(self, obj):
+        outstanding_token = _get_outstanding_token_for_jwt(obj)
+        if outstanding_token is None:
+            return "-"
+        return outstanding_token.created_at
+
+    jwt_issued_at.short_description = "JWT issued at"
+    jwt_issued_at.admin_order_field = "modified_at"
+
+    def jwt_expires_at(self, obj):
+        outstanding_token = _get_outstanding_token_for_jwt(obj)
+        if outstanding_token is None:
+            return "-"
+        return outstanding_token.expires_at
+
+    jwt_expires_at.short_description = "JWT expires at"
+
+    def is_blacklisted(self, obj):
+        outstanding_token = _get_outstanding_token_for_jwt(obj)
+        if outstanding_token is None:
+            return None
+        return BlacklistedToken.objects.filter(
+            token=outstanding_token
+        ).exists()
+
+    is_blacklisted.short_description = "Blacklisted"
+    is_blacklisted.boolean = True
 
 
 admin.site.unregister(JwtToken)

--- a/tests/unit/accounts/test_admin.py
+++ b/tests/unit/accounts/test_admin.py
@@ -1,0 +1,92 @@
+from accounts.admin import JwtTokenAdmin, _get_outstanding_token_for_jwt
+from accounts.models import JwtToken
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse_lazy
+from rest_framework.test import APIClient, APITestCase
+from rest_framework_simplejwt.token_blacklist.models import (
+    BlacklistedToken,
+    OutstandingToken,
+)
+
+
+class BaseAPITestClass(APITestCase):
+    def setUp(self):
+        self.client = APIClient(enforce_csrf_checks=True)
+        self.user = User.objects.create(
+            username="user",
+            email="user@test.com",
+            password="password",
+        )
+        self.client.force_authenticate(user=self.user)
+
+
+class JwtTokenAdminTest(BaseAPITestClass):
+    def setUp(self):
+        super().setUp()
+        self.admin = JwtTokenAdmin(JwtToken, AdminSite())
+        self.get_auth_token_url = reverse_lazy("accounts:get_auth_token")
+
+    def test_get_outstanding_token_matches_refresh_token(self):
+        response = self.client.get(self.get_auth_token_url, {})
+        self.assertEqual(response.status_code, 200)
+
+        jwt_token = JwtToken.objects.get(user=self.user)
+        outstanding_token = _get_outstanding_token_for_jwt(jwt_token)
+
+        self.assertIsNotNone(outstanding_token)
+        self.assertEqual(outstanding_token.token, jwt_token.refresh_token)
+        self.assertEqual(
+            outstanding_token.expires_at, response.data["expires_at"]
+        )
+
+    def test_admin_displays_jwt_metadata(self):
+        response = self.client.get(self.get_auth_token_url, {})
+        self.assertEqual(response.status_code, 200)
+
+        jwt_token = JwtToken.objects.get(user=self.user)
+        outstanding_token = OutstandingToken.objects.filter(
+            user=self.user
+        ).latest("created_at")
+
+        self.assertEqual(
+            self.admin.jwt_issued_at(jwt_token), outstanding_token.created_at
+        )
+        self.assertEqual(
+            self.admin.jwt_expires_at(jwt_token), outstanding_token.expires_at
+        )
+        self.assertFalse(self.admin.is_blacklisted(jwt_token))
+
+    def test_admin_marks_blacklisted_refresh_token(self):
+        self.client.get(self.get_auth_token_url, {})
+        jwt_token = JwtToken.objects.get(user=self.user)
+        outstanding_token = OutstandingToken.objects.get(
+            token=jwt_token.refresh_token
+        )
+
+        BlacklistedToken.objects.create(token=outstanding_token)
+
+        self.assertTrue(self.admin.is_blacklisted(jwt_token))
+
+    def test_admin_returns_dash_when_no_outstanding_token(self):
+        jwt_token = JwtToken.objects.create(
+            user=self.user,
+            access_token="access",
+            refresh_token="refresh",
+        )
+
+        self.assertEqual(self.admin.jwt_issued_at(jwt_token), "-")
+        self.assertEqual(self.admin.jwt_expires_at(jwt_token), "-")
+        self.assertIsNone(self.admin.is_blacklisted(jwt_token))
+
+
+class JwtTokenAdminRegistrationTest(TestCase):
+    def test_jwt_token_admin_list_display_includes_expiry_fields(self):
+        list_display = JwtTokenAdmin(JwtToken, AdminSite()).list_display
+
+        self.assertIn("created_at", list_display)
+        self.assertIn("modified_at", list_display)
+        self.assertIn("jwt_issued_at", list_display)
+        self.assertIn("jwt_expires_at", list_display)
+        self.assertIn("is_blacklisted", list_display)

--- a/tests/unit/accounts/test_admin.py
+++ b/tests/unit/accounts/test_admin.py
@@ -1,5 +1,6 @@
 from accounts.admin import JwtTokenAdmin, _get_outstanding_token_for_jwt
 from accounts.models import JwtToken
+from allauth.account.models import EmailAddress
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -18,6 +19,9 @@ class BaseAPITestClass(APITestCase):
             username="user",
             email="user@test.com",
             password="password",
+        )
+        EmailAddress.objects.create(
+            user=self.user, email="user@test.com", primary=True, verified=True
         )
         self.client.force_authenticate(user=self.user)
 


### PR DESCRIPTION
## Summary
- Extend `JwtToken` Django admin to show `created_at`, `modified_at`, JWT issue/expiry timestamps, and blacklist status.
- Resolve expiry from `OutstandingToken` (matched to the stored `refresh_token`, with a fallback to the latest token for the user), which is the same source used by `GET /api/accounts/user/get_auth_token`.
- Add unit tests covering metadata display, blacklist detection, and missing-token handling.

## Why
Operators debugging static code-upload cron/worker auth failures previously had to use shell/API access to learn when a JWT expires or was revoked. This surfaces that information directly in admin.

## Test plan
- [ ] Run `pytest tests/unit/accounts/test_admin.py -q`
- [ ] Open Django admin → Accounts → Jwt tokens and verify list/detail columns for an active user
- [ ] Refresh a user's auth token in the UI and confirm `modified_at`, `jwt_issued_at`, and `jwt_expires_at` update; blacklisted old tokens show `Blacklisted = True` when applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced JWT admin view showing user, creation/modified timestamps, token issuance and expiration times, and blacklist status.
  * Read-only display of token fields and expanded admin search to include user email.

* **Tests**
  * Added unit tests covering admin metadata display, blacklist behavior, and admin registration/listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->