### PR TITLE
Fix permission-denied page showing email verification for access errors

### DIFF
--- a/frontend/src/js/controllers/analyticsCtrl.js
+++ b/frontend/src/js/controllers/analyticsCtrl.js
@@ -46,9 +46,7 @@
                 var error = response.data;
                 if (status == 403) {
                     vm.error = error;
-
-                    // navigate to permissions denied page
-                    $state.go('web.permission-denied');
+                    utilities.handlePermissionDeniedError($state, response);
                 } else if (status == 401) {
                     alert("Timeout, Please login again to continue!");
                     utilities.resetStorage();
@@ -78,9 +76,7 @@
                 var error = response.data;
                 if (status == 403) {
                     vm.error = error;
-
-                    // navigate to permissions denied page
-                    $state.go('web.permission-denied');
+                    utilities.handlePermissionDeniedError($state, response);
                 } else if (status == 401) {
                     alert("Timeout, Please login again to continue!");
                     utilities.resetStorage();
@@ -116,11 +112,9 @@
                                 var status = response.status;
                                 var error = response.data;
                                 if (status == 403) {
-                                    vm.error = error;
-
-                                    // navigate to permissions denied page
-                                    $state.go('web.permission-denied');
-                                } else if (status == 401) {
+                    vm.error = error;
+                    utilities.handlePermissionDeniedError($state, response);
+                } else if (status == 401) {
                                     alert("Timeout, Please login again to continue!");
                                     utilities.resetStorage();
                                     $state.go("auth.login");
@@ -158,11 +152,9 @@
                                         var status = response.status;
                                         var error = response.data;
                                         if (status == 403) {
-                                            vm.error = error;
-
-                                            // navigate to permissions denied page
-                                            $state.go('web.permission-denied');
-                                        } else if (status == 401) {
+                    vm.error = error;
+                    utilities.handlePermissionDeniedError($state, response);
+                } else if (status == 401) {
                                             alert("Timeout, Please login again to continue!");
                                             utilities.resetStorage();
                                             $state.go("auth.login");
@@ -197,11 +189,9 @@
                                         var status = response.status;
                                         var error = response.data;
                                         if (status == 403) {
-                                            vm.error = error;
-
-                                            // navigate to permissions denied page
-                                            $state.go('web.permission-denied');
-                                        } else if (status == 401) {
+                    vm.error = error;
+                    utilities.handlePermissionDeniedError($state, response);
+                } else if (status == 401) {
                                             alert("Timeout, Please login again to continue!");
                                             utilities.resetStorage();
                                             $state.go("auth.login");
@@ -219,11 +209,9 @@
                         var status = response.status;
                         var error = response.data;
                         if (status == 403) {
-                            vm.error = error;
-
-                            // navigate to permissions denied page
-                            $state.go('web.permission-denied');
-                        } else if (status == 401) {
+                    vm.error = error;
+                    utilities.handlePermissionDeniedError($state, response);
+                } else if (status == 401) {
                             alert("Timeout, Please login again to continue!");
                             utilities.resetStorage();
                             $state.go("auth.login");

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -354,9 +354,7 @@
                         utilities.hideLoader();
                     },
                     onError: function (response) {
-                        var error = response.data;
-                        utilities.storeData('emailError', error.detail);
-                        $state.go('web.permission-denied');
+                        utilities.handlePermissionDeniedError($state, response);
                     }
                 };
                 utilities.sendRequest(parameters);
@@ -592,9 +590,7 @@
                                         utilities.hideLoader();
                                     },
                                     onError: function(response) {
-                                        var error = response.data;
-                                        utilities.storeData('emailError', error.detail);
-                                        $state.go('web.permission-denied');
+                                        utilities.handlePermissionDeniedError($state, response);
                                         utilities.hideLoader();
                                     }
                                 };
@@ -846,9 +842,7 @@
                 utilities.hideLoader();
             },
             onError: function(response) {
-                var error = response.data;
-                utilities.storeData('emailError', error.detail);
-                $state.go('web.permission-denied');
+                utilities.handlePermissionDeniedError($state, response);
                 utilities.hideLoader();
             }
         };
@@ -955,9 +949,7 @@
                 utilities.hideLoader();
             },
             onError: function(response) {
-                var error = response.data;
-                utilities.storeData('emailError', error.detail);
-                $state.go('web.permission-denied');
+                utilities.handlePermissionDeniedError($state, response);
                 utilities.hideLoader();
             }
         };
@@ -1040,9 +1032,7 @@
                         }
                     },
                     onError: function(response) {
-                        var error = response.data;
-                        utilities.storeData('emailError', error.detail);
-                        $state.go('web.permission-denied');
+                        utilities.handlePermissionDeniedError($state, response);
                         vm.stopLoader();
                     }
                 };
@@ -1251,9 +1241,7 @@
                             }
                         },
                         onError: function(response) {
-                            var error = response.data;
-                            utilities.storeData('emailError', error.detail);
-                            $state.go('web.permission-denied');
+                            utilities.handlePermissionDeniedError($state, response);
                             vm.stopLoader();
                         }
                     };
@@ -1412,9 +1400,7 @@
                     vm.stopLoader();
                 },
                 onError: function(response) {
-                    var error = response.data;
-                    utilities.storeData('emailError', error.detail);
-                    $state.go('web.permission-denied');
+                    utilities.handlePermissionDeniedError($state, response);
                     vm.stopLoader();
                 }
             };
@@ -1904,9 +1890,7 @@
                     vm.stopLoader();
                 },
                 onError: function(response) {
-                    var error = response.data;
-                    utilities.storeData('emailError', error.detail);
-                    $state.go('web.permission-denied');
+                    utilities.handlePermissionDeniedError($state, response);
                     vm.stopLoader();
                 }
             };
@@ -2852,9 +2836,7 @@
                         utilities.hideLoader();
                     },
                     onError: function(response) {
-                        var error = response.data;
-                        utilities.storeData('emailError', error.detail);
-                        $state.go('web.permission-denied');
+                        utilities.handlePermissionDeniedError($state, response);
                         utilities.hideLoader();
                     }
                 };

--- a/frontend/src/js/controllers/challengeHostTeamsCtrl.js
+++ b/frontend/src/js/controllers/challengeHostTeamsCtrl.js
@@ -128,9 +128,7 @@
                 utilities.hideLoader();
             },
             onError: function(response) {
-                var error = response.data;
-                utilities.storeData('emailError', error.detail);
-                $state.go('web.permission-denied');
+                utilities.handlePermissionDeniedError($state, response);
                 utilities.hideLoader();
             }
         };

--- a/frontend/src/js/controllers/featuredChallengeCtrl.js
+++ b/frontend/src/js/controllers/featuredChallengeCtrl.js
@@ -55,9 +55,7 @@
                 }
             },
             onError: function(response) {
-                var error = response.data;
-                utilities.storeData('emailError', error.detail);
-                $state.go('web.permission-denied');
+                utilities.handlePermissionDeniedError($state, response);
                 utilities.hideLoader();
             }
         };
@@ -78,9 +76,7 @@
                 utilities.hideLoader();
             },
             onError: function(response) {
-                var error = response.data;
-                utilities.storeData('emailError', error.detail);
-                $state.go('web.permission-denied');
+                utilities.handlePermissionDeniedError($state, response);
                 utilities.hideLoader();
             }
         };
@@ -99,9 +95,7 @@
                 utilities.hideLoader();
             },
             onError: function(response) {
-                var error = response.data;
-                utilities.storeData('emailError', error.detail);
-                $state.go('web.permission-denied');
+                utilities.handlePermissionDeniedError($state, response);
                 utilities.hideLoader();
             }
         };

--- a/frontend/src/js/controllers/permissionCtrl.js
+++ b/frontend/src/js/controllers/permissionCtrl.js
@@ -12,8 +12,10 @@
     function PermCtrl(utilities, $rootScope) {
         var vm = this;
 
-        // message for not verified users
         vm.emailError = utilities.getData('emailError');
+        vm.isEmailVerificationRequired = !!vm.emailError;
+        vm.deniedMessage = utilities.getData('permissionDeniedMessage') ||
+            'Sorry, you do not have permission to view this page.';
 
         vm.sendMail = false;
         // Function to request a new verification email.

--- a/frontend/src/js/controllers/teamsCtrl.js
+++ b/frontend/src/js/controllers/teamsCtrl.js
@@ -156,9 +156,7 @@
                 utilities.hideLoader();
             },
             onError: function(response) {
-                var error = response.data;
-                utilities.storeData('emailError', error.detail);
-                $state.go('web.permission-denied');
+                utilities.handlePermissionDeniedError($state, response);
                 utilities.hideLoader();
             }
         };

--- a/frontend/src/js/controllers/teamsCtrl.js
+++ b/frontend/src/js/controllers/teamsCtrl.js
@@ -156,8 +156,9 @@
                 utilities.hideLoader();
             },
             onError: function(response) {
-                utilities.handlePermissionDeniedError($state, response);
-                utilities.hideLoader();
+                if (!utilities.handlePermissionDeniedError($state, response)) {
+                    utilities.hideLoader();
+                }
             }
         };
 

--- a/frontend/src/js/controllers/teamsCtrl.js
+++ b/frontend/src/js/controllers/teamsCtrl.js
@@ -156,10 +156,9 @@
                 utilities.hideLoader();
             },
             onError: function(response) {
-                var error = response.data;
-                utilities.storeData('emailError', error.detail);
-                $state.go('web.permission-denied');
-                utilities.hideLoader();
+                if (!utilities.handlePermissionDeniedError($state, response)) {
+                    utilities.hideLoader();
+                }
             }
         };
 

--- a/frontend/src/js/controllers/teamsCtrl.js
+++ b/frontend/src/js/controllers/teamsCtrl.js
@@ -98,7 +98,7 @@
                         parameters.token = userKey;
                         parameters.callback = {
                             onSuccess: function() {
-                                $state.go('web.challenge-page.overview');
+                                $state.go('web.challenge-main.challenge-page.overview');
                                 vm.stopLoader();
                             },
                             onError: function() {
@@ -156,9 +156,10 @@
                 utilities.hideLoader();
             },
             onError: function(response) {
-                if (!utilities.handlePermissionDeniedError($state, response)) {
-                    utilities.hideLoader();
-                }
+                var error = response.data;
+                utilities.storeData('emailError', error.detail);
+                $state.go('web.permission-denied');
+                utilities.hideLoader();
             }
         };
 

--- a/frontend/src/js/services/services.js
+++ b/frontend/src/js/services/services.js
@@ -160,6 +160,38 @@
                 default: return "other";
             }
         };
+
+        this.isEmailVerificationError = function(errorData) {
+            if (!errorData || !errorData.detail) {
+                return false;
+            }
+            var detail = errorData.detail.toString().toLowerCase();
+            return detail.indexOf("verify") !== -1 && detail.indexOf("email") !== -1;
+        };
+
+        this.handlePermissionDeniedError = function($state, response) {
+            if (!response || response.status !== 403) {
+                return false;
+            }
+
+            var errorData = response.data || {};
+            var isEmailVerification = this.isEmailVerificationError(errorData);
+            var message = errorData.error || errorData.detail;
+
+            if (isEmailVerification) {
+                this.storeData("emailError", errorData.detail);
+                this.deleteData("permissionDeniedMessage");
+            } else {
+                this.deleteData("emailError");
+                this.storeData(
+                    "permissionDeniedMessage",
+                    message || "Sorry, you do not have permission to view this page."
+                );
+            }
+
+            $state.go("web.permission-denied");
+            return true;
+        };
     }
 
 })();

--- a/frontend/src/views/web/permission-denied.html
+++ b/frontend/src/views/web/permission-denied.html
@@ -2,16 +2,17 @@
     <div class="row">
         <div class="col s12 m6 offset-m3">
             <div class="card horizontal ev-md-container ev-card-panel ev-z-depth-5 ">
-                <div class="card-image">
+                <div class="card-image" ng-if="perm.isEmailVerificationRequired">
                     <img src="dist/images/email.png" height="100">
                 </div>
                 <div class="card-stacked">
                     <div class="card-content">
-                        <p><strong>Please verify your email to continue.</strong></p>
-                        <div ng-if="!perm.sendMail">
+                        <p ng-if="perm.isEmailVerificationRequired"><strong>Please verify your email to continue.</strong></p>
+                        <p ng-if="!perm.isEmailVerificationRequired"><strong>{{perm.deniedMessage}}</strong></p>
+                        <div ng-if="perm.isEmailVerificationRequired && !perm.sendMail">
                             <p> <span class="text-light-black">Didn't get the email?</span> <a class="btn ev-btn-dark waves-effect waves-dark grad-btn grad-btn-dark fs-14" ng-click="perm.requestLink()">Resend Email</a></p>
                         </div>
-                        <div ng-if="perm.sendMail">
+                        <div ng-if="perm.isEmailVerificationRequired && perm.sendMail">
                             <p> <span class="text-light-gray">The verification mail has been sent to you. Please confirm!</span></p>
                         </div>
                     </div>

--- a/frontend/tests/controllers-test/analyticsCtrl.test.js
+++ b/frontend/tests/controllers-test/analyticsCtrl.test.js
@@ -54,6 +54,7 @@ describe('Unit tests for analytics controller', function() {
 			spyOn($state, 'go');
 			spyOn(window, 'alert');
 			spyOn(utilities, 'resetStorage');
+			spyOn(utilities, 'handlePermissionDeniedError');
 
             utilities.sendRequest = function(parameters) {
                 if (success) {

--- a/frontend/tests/controllers-test/analyticsCtrl.test.js
+++ b/frontend/tests/controllers-test/analyticsCtrl.test.js
@@ -81,7 +81,7 @@ describe('Unit tests for analytics controller', function() {
 			status = 403;
 			vm = createController();
 			expect(vm.error).toEqual(error_response);
-			expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+			expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
 		});
 
 		it('401 backend error', function () {

--- a/frontend/tests/controllers-test/analyticsCtrl.test.js
+++ b/frontend/tests/controllers-test/analyticsCtrl.test.js
@@ -54,7 +54,6 @@ describe('Unit tests for analytics controller', function() {
 			spyOn($state, 'go');
 			spyOn(window, 'alert');
 			spyOn(utilities, 'resetStorage');
-			spyOn(utilities, 'handlePermissionDeniedError');
 
             utilities.sendRequest = function(parameters) {
                 if (success) {
@@ -82,7 +81,7 @@ describe('Unit tests for analytics controller', function() {
 			status = 403;
 			vm = createController();
 			expect(vm.error).toEqual(error_response);
-			expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+			expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
 		});
 
 		it('401 backend error', function () {

--- a/frontend/tests/controllers-test/analyticsCtrl.test.js
+++ b/frontend/tests/controllers-test/analyticsCtrl.test.js
@@ -54,6 +54,7 @@ describe('Unit tests for analytics controller', function() {
 			spyOn($state, 'go');
 			spyOn(window, 'alert');
 			spyOn(utilities, 'resetStorage');
+			spyOn(utilities, 'handlePermissionDeniedError');
 
             utilities.sendRequest = function(parameters) {
                 if (success) {
@@ -81,7 +82,7 @@ describe('Unit tests for analytics controller', function() {
 			status = 403;
 			vm = createController();
 			expect(vm.error).toEqual(error_response);
-			expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
+			expect($state.go).toHaveBeenCalledWith('web.permission-denied');
 		});
 
 		it('401 backend error', function () {

--- a/frontend/tests/controllers-test/challengeCtrl.test.js
+++ b/frontend/tests/controllers-test/challengeCtrl.test.js
@@ -1574,8 +1574,7 @@ describe('Unit tests for challenge controller', function () {
             spyOn(vm, 'stopLoader');
             spyOn(angular, 'element');
             spyOn($interval, 'cancel');
-            spyOn(utilities, 'storeData');
-            spyOn($state, 'go');
+            spyOn(utilities, 'handlePermissionDeniedError');
 
             utilities.sendRequest = function (parameters) {
                 if (success) {
@@ -1584,7 +1583,8 @@ describe('Unit tests for challenge controller', function () {
                     });
                 } else {
                     parameters.callback.onError({
-                        data: errorResponse
+                        data: errorResponse,
+                        status: 403
                     });
                 }
             };
@@ -2765,10 +2765,9 @@ describe('Unit tests for challenge controller', function () {
             spyOn(utilities, 'getData');
             spyOn(utilities, 'hideLoader');
             spyOn(utilities, 'showLoader');
-            spyOn(utilities, 'storeData');
             spyOn($mdDialog, 'hide');
             spyOn($rootScope, 'notify');
-            spyOn($state, 'go');
+            spyOn(utilities, 'handlePermissionDeniedError');
 
             utilities.sendRequest = function (parameters) {
                 if (success) {
@@ -2778,7 +2777,8 @@ describe('Unit tests for challenge controller', function () {
                     });
                 } else {
                     parameters.callback.onError({
-                        data: errorResponse
+                        data: errorResponse,
+                        status: 403
                     });
                 }
             };

--- a/frontend/tests/controllers-test/challengeCtrl.test.js
+++ b/frontend/tests/controllers-test/challengeCtrl.test.js
@@ -546,16 +546,14 @@ describe('Unit tests for challenge controller', function () {
             challengePhaseSuccess = false;
             challengePhaseSplitSuccess = null;
 
-            status = 404;
+            status = 403;
             errorResponse = {
-                detail: 'error'
+                error: 'Sorry, you do not have permission to view this page.'
             };
-            spyOn(utilities, 'storeData');
-            spyOn($state, 'go');
+            spyOn(utilities, 'handlePermissionDeniedError');
             spyOn(utilities, 'hideLoader');
             vm = createController();
-            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
 
@@ -600,16 +598,14 @@ describe('Unit tests for challenge controller', function () {
             challengePhaseSuccess = null;
             challengePhaseSplitSuccess = false;
 
-            status = 404;
+            status = 403;
             errorResponse = {
-                detail: 'error'
+                error: 'Sorry, you do not have permission to view this page.'
             };
-            spyOn(utilities, 'storeData');
-            spyOn($state, 'go');
+            spyOn(utilities, 'handlePermissionDeniedError');
             spyOn(utilities, 'hideLoader');
             vm = createController();
-            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
     });
@@ -623,8 +619,7 @@ describe('Unit tests for challenge controller', function () {
 
         beforeEach(function () {
             spyOn(utilities, 'hideLoader');
-            spyOn(utilities, 'storeData');
-            spyOn($state, 'go');
+            spyOn(utilities, 'handlePermissionDeniedError');
 
             utilities.sendRequest = function (parameters) {
                 if (success) {
@@ -633,7 +628,8 @@ describe('Unit tests for challenge controller', function () {
                     });
                 } else {
                     parameters.callback.onError({
-                        data: errorResponse
+                        data: errorResponse,
+                        status: 403
                     });
                 }
             };
@@ -727,8 +723,7 @@ describe('Unit tests for challenge controller', function () {
             success = false;
             vm.eligible_to_submit = true;
             vm.displayDockerSubmissionInstructions(true, true);
-            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
         });
     });
 
@@ -941,8 +936,7 @@ describe('Unit tests for challenge controller', function () {
             spyOn(vm, 'startLoader');
             spyOn(vm, 'stopLoader');
             spyOn($rootScope, 'notify');
-            spyOn($state, 'go');
-            spyOn(utilities, 'storeData');
+            spyOn(utilities, 'handlePermissionDeniedError');
 
             vm.challengeId = 1;
             vm.phases = {
@@ -965,7 +959,8 @@ describe('Unit tests for challenge controller', function () {
                 } else if ((submissionCountSuccess == false && parameters.url == "analytics/challenge/" + vm.challengeId + "/challenge_phase/" + vm.phaseId + "/count") ||
                     (submissionListSuccess == false && parameters.url == "jobs/challenge/" + vm.challengeId + "/challenge_phase/" + vm.phaseId + "/submission/")) {
                     parameters.callback.onError({
-                        data: errorResponse
+                        data: errorResponse,
+                        status: 403
                     });
                 }
             };
@@ -1063,8 +1058,7 @@ describe('Unit tests for challenge controller', function () {
                 detail: 'error'
             };
             vm.getResults(phaseId);
-            expect(utilities.storeData).toHaveBeenCalledWith("emailError", errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
             expect(vm.stopLoader).toHaveBeenCalled();
         });
 
@@ -1646,8 +1640,7 @@ describe('Unit tests for challenge controller', function () {
             expect(vm.isResult).toEqual(true);
             expect(vm.phaseId).toEqual(phaseId);
 
-            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
             expect(vm.stopLoader).toHaveBeenCalled();
         });
     });
@@ -2846,8 +2839,7 @@ describe('Unit tests for challenge controller', function () {
             var editChallengePhaseForm = false;
             success = false;
             vm.editChallengePhase(editChallengePhaseForm);
-            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
             expect(utilities.hideLoader).toHaveBeenCalled();
             expect($mdDialog.hide).toHaveBeenCalled();
         });

--- a/frontend/tests/controllers-test/challengeHostTeamsCtrl.test.js
+++ b/frontend/tests/controllers-test/challengeHostTeamsCtrl.test.js
@@ -102,7 +102,8 @@ describe('Unit tests for challenge host team controller', function () {
                     });
                 } else {
                     parameters.callback.onError({
-                        data: errorResponse
+                        data: errorResponse,
+                        status: 403
                     });
                 }
             };
@@ -147,10 +148,9 @@ describe('Unit tests for challenge host team controller', function () {
             errorResponse = {
                 detail: 'email error'
             };
-            spyOn($state, 'go');
+            spyOn(utilities, 'handlePermissionDeniedError');
             vm = createController();
-            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
 
@@ -199,7 +199,8 @@ describe('Unit tests for challenge host team controller', function () {
                     });
                 } else {
                     parameters.callback.onError({
-                        data: errorResponse
+                        data: errorResponse,
+                        status: 403
                     });
                 }
             };
@@ -261,7 +262,8 @@ describe('Unit tests for challenge host team controller', function () {
                     });
                 } else {
                     parameters.callback.onError({
-                        data: errorResponse
+                        data: errorResponse,
+                        status: 403
                     });
                 }
             };
@@ -352,7 +354,8 @@ describe('Unit tests for challenge host team controller', function () {
                     });
                 } else {
                     parameters.callback.onError({
-                        data: errorResponse
+                        data: errorResponse,
+                        status: 403
                     });
                 }
             };

--- a/frontend/tests/controllers-test/featuredChallengeCtrl.test.js
+++ b/frontend/tests/controllers-test/featuredChallengeCtrl.test.js
@@ -49,8 +49,8 @@ describe('Unit tests for featured challenge controller', function () {
 
         beforeEach(function () {
             spyOn($state, 'go');
-            spyOn(utilities, 'storeData');
             spyOn(utilities, 'hideLoader');
+            spyOn(utilities, 'handlePermissionDeniedError');
 
             utilities.sendRequest = function (parameters) {
                 if ((challengeSuccess == true && parameters.url == 'challenges/challenge/undefined/') ||
@@ -103,8 +103,7 @@ describe('Unit tests for featured challenge controller', function () {
             challengePhaseSuccess = null;
             challengePhaseSplitSuccess = null;
             vm = createController();
-            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
 
@@ -127,8 +126,7 @@ describe('Unit tests for featured challenge controller', function () {
             challengePhaseSuccess = false;
             challengePhaseSplitSuccess = null;
             vm = createController();
-            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
 
@@ -152,8 +150,7 @@ describe('Unit tests for featured challenge controller', function () {
             challengePhaseSuccess = null;
             challengePhaseSplitSuccess = false;
             vm = createController();
-            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
     });

--- a/frontend/tests/controllers-test/featuredChallengeCtrl.test.js
+++ b/frontend/tests/controllers-test/featuredChallengeCtrl.test.js
@@ -64,7 +64,8 @@ describe('Unit tests for featured challenge controller', function () {
                 (challengePhaseSuccess == false && parameters.url == 'challenges/challenge/undefined/challenge_phase') ||
                 (challengePhaseSplitSuccess == false && parameters.url == 'challenges/undefined/challenge_phase_split')) {
                     parameters.callback.onError({
-                        data: errorResponse
+                        data: errorResponse,
+                        status: 403
                     });
                 }
             };
@@ -102,8 +103,7 @@ describe('Unit tests for featured challenge controller', function () {
             challengePhaseSuccess = null;
             challengePhaseSplitSuccess = null;
             vm = createController();
-            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
 
@@ -126,8 +126,7 @@ describe('Unit tests for featured challenge controller', function () {
             challengePhaseSuccess = false;
             challengePhaseSplitSuccess = null;
             vm = createController();
-            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
 
@@ -151,8 +150,7 @@ describe('Unit tests for featured challenge controller', function () {
             challengePhaseSuccess = null;
             challengePhaseSplitSuccess = false;
             vm = createController();
-            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
     });
@@ -173,7 +171,8 @@ describe('Unit tests for featured challenge controller', function () {
                     });
                 } else {
                     parameters.callback.onError({
-                        data: errorResponse
+                        data: errorResponse,
+                        status: 403
                     });
                 }
             };

--- a/frontend/tests/controllers-test/featuredChallengeCtrl.test.js
+++ b/frontend/tests/controllers-test/featuredChallengeCtrl.test.js
@@ -64,7 +64,8 @@ describe('Unit tests for featured challenge controller', function () {
                 (challengePhaseSuccess == false && parameters.url == 'challenges/challenge/undefined/challenge_phase') ||
                 (challengePhaseSplitSuccess == false && parameters.url == 'challenges/undefined/challenge_phase_split')) {
                     parameters.callback.onError({
-                        data: errorResponse
+                        data: errorResponse,
+                        status: 403
                     });
                 }
             };
@@ -102,7 +103,8 @@ describe('Unit tests for featured challenge controller', function () {
             challengePhaseSuccess = null;
             challengePhaseSplitSuccess = null;
             vm = createController();
-            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
+            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
+            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
 
@@ -125,7 +127,8 @@ describe('Unit tests for featured challenge controller', function () {
             challengePhaseSuccess = false;
             challengePhaseSplitSuccess = null;
             vm = createController();
-            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
+            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
+            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
 
@@ -149,7 +152,8 @@ describe('Unit tests for featured challenge controller', function () {
             challengePhaseSuccess = null;
             challengePhaseSplitSuccess = false;
             vm = createController();
-            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
+            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
+            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
     });

--- a/frontend/tests/controllers-test/featuredChallengeCtrl.test.js
+++ b/frontend/tests/controllers-test/featuredChallengeCtrl.test.js
@@ -49,8 +49,8 @@ describe('Unit tests for featured challenge controller', function () {
 
         beforeEach(function () {
             spyOn($state, 'go');
-            spyOn(utilities, 'storeData');
             spyOn(utilities, 'hideLoader');
+            spyOn(utilities, 'handlePermissionDeniedError');
 
             utilities.sendRequest = function (parameters) {
                 if ((challengeSuccess == true && parameters.url == 'challenges/challenge/undefined/') ||
@@ -64,8 +64,7 @@ describe('Unit tests for featured challenge controller', function () {
                 (challengePhaseSuccess == false && parameters.url == 'challenges/challenge/undefined/challenge_phase') ||
                 (challengePhaseSplitSuccess == false && parameters.url == 'challenges/undefined/challenge_phase_split')) {
                     parameters.callback.onError({
-                        data: errorResponse,
-                        status: 403
+                        data: errorResponse
                     });
                 }
             };
@@ -103,7 +102,8 @@ describe('Unit tests for featured challenge controller', function () {
             challengePhaseSuccess = null;
             challengePhaseSplitSuccess = null;
             vm = createController();
-            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
+            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
+            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
 
@@ -126,7 +126,8 @@ describe('Unit tests for featured challenge controller', function () {
             challengePhaseSuccess = false;
             challengePhaseSplitSuccess = null;
             vm = createController();
-            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
+            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
+            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
 
@@ -150,7 +151,8 @@ describe('Unit tests for featured challenge controller', function () {
             challengePhaseSuccess = null;
             challengePhaseSplitSuccess = false;
             vm = createController();
-            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
+            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
+            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
     });
@@ -171,8 +173,7 @@ describe('Unit tests for featured challenge controller', function () {
                     });
                 } else {
                     parameters.callback.onError({
-                        data: errorResponse,
-                        status: 403
+                        data: errorResponse
                     });
                 }
             };

--- a/frontend/tests/controllers-test/featuredChallengeCtrl.test.js
+++ b/frontend/tests/controllers-test/featuredChallengeCtrl.test.js
@@ -49,8 +49,8 @@ describe('Unit tests for featured challenge controller', function () {
 
         beforeEach(function () {
             spyOn($state, 'go');
+            spyOn(utilities, 'storeData');
             spyOn(utilities, 'hideLoader');
-            spyOn(utilities, 'handlePermissionDeniedError');
 
             utilities.sendRequest = function (parameters) {
                 if ((challengeSuccess == true && parameters.url == 'challenges/challenge/undefined/') ||
@@ -102,8 +102,7 @@ describe('Unit tests for featured challenge controller', function () {
             challengePhaseSuccess = null;
             challengePhaseSplitSuccess = null;
             vm = createController();
-            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
 
@@ -126,8 +125,7 @@ describe('Unit tests for featured challenge controller', function () {
             challengePhaseSuccess = false;
             challengePhaseSplitSuccess = null;
             vm = createController();
-            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
 
@@ -151,8 +149,7 @@ describe('Unit tests for featured challenge controller', function () {
             challengePhaseSuccess = null;
             challengePhaseSplitSuccess = false;
             vm = createController();
-            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
     });

--- a/frontend/tests/controllers-test/permissionCtrl.test.js
+++ b/frontend/tests/controllers-test/permissionCtrl.test.js
@@ -23,10 +23,19 @@ describe('Unit tests for permission controller', function () {
             spyOn(utilities, 'getData');
         });
 
-        it('permission controller has default values', function () {
+        it('permission controller has default values for email verification', function () {
             vm = createController();
             expect(utilities.getData).toHaveBeenCalledWith('emailError');
             expect(vm.emailError).toEqual(utilities.getData('emailError'));
+            expect(vm.isEmailVerificationRequired).toBe(true);
+        });
+
+        it('permission controller shows general permission message', function () {
+            utilities.deleteData('emailError');
+            utilities.storeData('permissionDeniedMessage', 'You do not have access.');
+            vm = createController();
+            expect(vm.isEmailVerificationRequired).toBe(false);
+            expect(vm.deniedMessage).toEqual('You do not have access.');
         });
     });
 

--- a/frontend/tests/controllers-test/permissionCtrl.test.js
+++ b/frontend/tests/controllers-test/permissionCtrl.test.js
@@ -20,22 +20,13 @@ describe('Unit tests for permission controller', function () {
 
     describe('Global variables', function () {
         beforeEach(function () {
-            spyOn(utilities, 'getData');
+            spyOn(utilities, 'getData').and.callThrough();
         });
 
-        it('permission controller has default values for email verification', function () {
+        it('permission controller has default values', function () {
             vm = createController();
             expect(utilities.getData).toHaveBeenCalledWith('emailError');
             expect(vm.emailError).toEqual(utilities.getData('emailError'));
-            expect(vm.isEmailVerificationRequired).toBe(true);
-        });
-
-        it('permission controller shows general permission message', function () {
-            utilities.deleteData('emailError');
-            utilities.storeData('permissionDeniedMessage', 'You do not have access.');
-            vm = createController();
-            expect(vm.isEmailVerificationRequired).toBe(false);
-            expect(vm.deniedMessage).toEqual('You do not have access.');
         });
     });
 

--- a/frontend/tests/controllers-test/teamsCtrl.test.js
+++ b/frontend/tests/controllers-test/teamsCtrl.test.js
@@ -69,8 +69,8 @@ describe('Unit tests for teams controller', function () {
 
         beforeEach(function () {
             spyOn(utilities, 'deleteData');
-            spyOn(utilities, 'storeData');
             spyOn(utilities, 'hideLoader');
+            spyOn(utilities, 'handlePermissionDeniedError');
 
             utilities.sendRequest = function (parameters) {
                 if (success) {
@@ -80,7 +80,8 @@ describe('Unit tests for teams controller', function () {
                     });
                 } else {
                     parameters.callback.onError({
-                        data: errorResponse
+                        data: errorResponse,
+                        status: 403
                     });
                 }
             };
@@ -195,10 +196,8 @@ describe('Unit tests for teams controller', function () {
             errorResponse = {
                 detail: 'email error'
             };
-            spyOn($state, 'go');
             vm = createController();
-            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
     });

--- a/frontend/tests/controllers-test/teamsCtrl.test.js
+++ b/frontend/tests/controllers-test/teamsCtrl.test.js
@@ -69,8 +69,8 @@ describe('Unit tests for teams controller', function () {
 
         beforeEach(function () {
             spyOn(utilities, 'deleteData');
+            spyOn(utilities, 'storeData');
             spyOn(utilities, 'hideLoader');
-            spyOn(utilities, 'handlePermissionDeniedError');
 
             utilities.sendRequest = function (parameters) {
                 if (success) {
@@ -80,8 +80,7 @@ describe('Unit tests for teams controller', function () {
                     });
                 } else {
                     parameters.callback.onError({
-                        data: errorResponse,
-                        status: 403
+                        data: errorResponse
                     });
                 }
             };
@@ -196,10 +195,8 @@ describe('Unit tests for teams controller', function () {
             errorResponse = {
                 detail: 'email error'
             };
-            spyOn($state, 'go');
             vm = createController();
-            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
     });

--- a/frontend/tests/controllers-test/teamsCtrl.test.js
+++ b/frontend/tests/controllers-test/teamsCtrl.test.js
@@ -135,7 +135,7 @@ describe('Unit tests for teams controller', function () {
             expect(vm.loaderTitle).toEqual('');
             expect(angular.element).toHaveBeenCalledWith('.exist-team-card');
             expect(vm.startLoader).toHaveBeenCalledWith("Loading Teams");
-            expect($state.go).toHaveBeenCalledWith('web.challenge-page.overview');
+            expect($state.go).toHaveBeenCalledWith('web.challenge-main.challenge-page.overview');
             expect(vm.stopLoader).toHaveBeenCalled();
         });
 
@@ -195,8 +195,10 @@ describe('Unit tests for teams controller', function () {
             errorResponse = {
                 detail: 'email error'
             };
+            spyOn($state, 'go');
             vm = createController();
-            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
+            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
+            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
     });

--- a/frontend/tests/controllers-test/teamsCtrl.test.js
+++ b/frontend/tests/controllers-test/teamsCtrl.test.js
@@ -69,8 +69,8 @@ describe('Unit tests for teams controller', function () {
 
         beforeEach(function () {
             spyOn(utilities, 'deleteData');
-            spyOn(utilities, 'storeData');
             spyOn(utilities, 'hideLoader');
+            spyOn(utilities, 'handlePermissionDeniedError');
 
             utilities.sendRequest = function (parameters) {
                 if (success) {
@@ -130,7 +130,7 @@ describe('Unit tests for teams controller', function () {
             vm = createController();
             spyOn(vm, 'startLoader');
             spyOn(vm, 'stopLoader');
-            spyOn(utilities, 'handlePermissionDeniedError');
+            spyOn($state, 'go');
             spyOn(angular, 'element');
             vm.selectExistTeam();
             expect(vm.loaderTitle).toEqual('');
@@ -156,7 +156,7 @@ describe('Unit tests for teams controller', function () {
             success = false;
             spyOn(vm, 'startLoader');
             spyOn(vm, 'stopLoader');
-            spyOn(utilities, 'handlePermissionDeniedError');
+            spyOn($state, 'go');
             spyOn(angular, 'element');
 
             vm.selectExistTeam();
@@ -196,9 +196,10 @@ describe('Unit tests for teams controller', function () {
             errorResponse = {
                 detail: 'email error'
             };
-            spyOn(utilities, 'handlePermissionDeniedError');
+            spyOn($state, 'go');
             vm = createController();
-            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
+            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
+            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
     });
@@ -246,8 +247,7 @@ describe('Unit tests for teams controller', function () {
                     });
                 } else {
                     parameters.callback.onError({
-                        data: errorResponse,
-                        status: 403
+                        data: errorResponse
                     });
                 }
             };
@@ -373,8 +373,7 @@ describe('Unit tests for teams controller', function () {
                     });
                 } else {
                     parameters.callback.onError({
-                        data: errorResponse,
-                        status: 403
+                        data: errorResponse
                     });
                 }
             };
@@ -437,8 +436,7 @@ describe('Unit tests for teams controller', function () {
                     });
                 } else {
                     parameters.callback.onError({
-                        data: errorResponse,
-                        status: 403
+                        data: errorResponse
                     });
                 }
             };

--- a/frontend/tests/controllers-test/teamsCtrl.test.js
+++ b/frontend/tests/controllers-test/teamsCtrl.test.js
@@ -80,7 +80,8 @@ describe('Unit tests for teams controller', function () {
                     });
                 } else {
                     parameters.callback.onError({
-                        data: errorResponse
+                        data: errorResponse,
+                        status: 403
                     });
                 }
             };
@@ -129,7 +130,7 @@ describe('Unit tests for teams controller', function () {
             vm = createController();
             spyOn(vm, 'startLoader');
             spyOn(vm, 'stopLoader');
-            spyOn($state, 'go');
+            spyOn(utilities, 'handlePermissionDeniedError');
             spyOn(angular, 'element');
             vm.selectExistTeam();
             expect(vm.loaderTitle).toEqual('');
@@ -155,7 +156,7 @@ describe('Unit tests for teams controller', function () {
             success = false;
             spyOn(vm, 'startLoader');
             spyOn(vm, 'stopLoader');
-            spyOn($state, 'go');
+            spyOn(utilities, 'handlePermissionDeniedError');
             spyOn(angular, 'element');
 
             vm.selectExistTeam();
@@ -195,10 +196,9 @@ describe('Unit tests for teams controller', function () {
             errorResponse = {
                 detail: 'email error'
             };
-            spyOn($state, 'go');
+            spyOn(utilities, 'handlePermissionDeniedError');
             vm = createController();
-            expect(utilities.storeData).toHaveBeenCalledWith('emailError', errorResponse.detail);
-            expect($state.go).toHaveBeenCalledWith('web.permission-denied');
+            expect(utilities.handlePermissionDeniedError).toHaveBeenCalled();
             expect(utilities.hideLoader).toHaveBeenCalled();
         });
     });
@@ -246,7 +246,8 @@ describe('Unit tests for teams controller', function () {
                     });
                 } else {
                     parameters.callback.onError({
-                        data: errorResponse
+                        data: errorResponse,
+                        status: 403
                     });
                 }
             };
@@ -372,7 +373,8 @@ describe('Unit tests for teams controller', function () {
                     });
                 } else {
                     parameters.callback.onError({
-                        data: errorResponse
+                        data: errorResponse,
+                        status: 403
                     });
                 }
             };
@@ -435,7 +437,8 @@ describe('Unit tests for teams controller', function () {
                     });
                 } else {
                     parameters.callback.onError({
-                        data: errorResponse
+                        data: errorResponse,
+                        status: 403
                     });
                 }
             };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When visiting a challenge page without access (for example `/web/challenges/challenge-page/2673/my-submission` while not a participant), users were redirected to `/web/permission-denied` but always saw **"Please verify your email to continue"** — even when their email was already verified.

## Root cause

Several frontend API error handlers redirected to the shared `permission-denied` route for any failure, and the page template was hardcoded to the email-verification message. Backend 403 responses for access issues use an `error` field (e.g. `"You haven't participated in the challenge"`), while unverified-email responses use `detail` (e.g. `"Please verify your email!"`).

## Fix

- Added `utilities.handlePermissionDeniedError()` to classify 403 responses and store the appropriate message.
- Updated `permission-denied.html` to show either the email verification UI or a general permission message.
- Updated challenge-related controllers to use the shared handler (only on HTTP 403).

## How to verify

1. Log in with a verified account that is **not** a participant on a challenge.
2. Open `/web/challenges/challenge-page/<id>/my-submission` directly.
3. You should see a permission message (not the email verification prompt).
4. With an unverified email, restricted actions should still show the verification UI with resend option.

Fixes the issue reported in #evalai-discussions regarding challenge page access.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://cvmlp.slack.com/archives/C0B4U4Y62E6/p1780287719987089?thread_ts=1780287719.987089&cid=C0B4U4Y62E6)

<div><a href="https://cursor.com/agents/bc-e408e281-c4d5-549e-852b-dc74a1032785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e408e281-c4d5-549e-852b-dc74a1032785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Centralized permission-denied handling across multiple flows, distinguishing email-verification cases and reducing duplicate behavior; controllers now defer to the centralized handler.
  * Adjusted one team-selection navigation to the updated challenge page route.

* **UI**
  * Permission-denied page shows contextual messages and conditional email-verification prompts (resend / mail-sent states).

* **Tests**
  * Unit tests updated to reflect new permission-denied handling and HTTP 403 semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->