### PR TITLE
Add PyYAML to code upload worker requirements.

### DIFF
--- a/requirements/code_upload_worker.txt
+++ b/requirements/code_upload_worker.txt
@@ -1,3 +1,3 @@
 kubernetes==12.0.1
-PyYaml==5.1
+PyYaml==5.4.1
 requests==2.33.0

--- a/requirements/code_upload_worker.txt
+++ b/requirements/code_upload_worker.txt
@@ -1,2 +1,3 @@
 kubernetes==12.0.1
+PyYaml==5.1
 requests==2.33.0


### PR DESCRIPTION
The worker imports YAML for Kubernetes manifests, but the worker image only installs code_upload_worker.txt, causing a ModuleNotFoundError at runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added PyYAML 5.4.1 to project dependencies to provide consistent YAML parsing support and improve stability. No other dependency changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->