### PR TITLE
Frontend: Simplify paid-plan transition announcement banner.

### DIFF
--- a/frontend/src/views/web/partials/main-header.html
+++ b/frontend/src/views/web/partials/main-header.html
@@ -1,8 +1,7 @@
 <div class="announcement-banner">
     <div style="max-width: 960px; margin: 0 auto;">
-        🚨 <strong>Update:</strong> EvalAI is transitioning to a paid plan for hosting challenges and is sunsetting
-        support for code-upload and static code-upload challenges. If you are planning to host a new challenge, please get in touch at
-        <a href="mailto:team@eval.ai" style="color: inherit; text-decoration: underline;">team@eval.ai</a>. 🚨
+        EvalAI is transitioning to a paid plan for hosting challenges. If you are planning to host a new challenge, please get in touch at
+        <a href="mailto:team@eval.ai" style="color: inherit; text-decoration: underline;">team@eval.ai</a>.
     </div>
 </div>
 <div ng-if="isAuth && emailBounced" style="


### PR DESCRIPTION
Remove alert emojis and sunsetting copy while keeping the hosting transition message and team@eval.ai contact link.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated announcement banner text to reflect EvalAI's paid plan transition for hosting challenges, directing prospective hosts to contact the support team. Removed previous messaging regarding sunsetting support for specific challenge types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->