### PR TITLE
Fix code upload worker image build on Python 3.9

### DIFF
--- a/docker/prod/code-upload-worker/Dockerfile
+++ b/docker/prod/code-upload-worker/Dockerfile
@@ -20,10 +20,10 @@ COPY requirements/ /code/requirements/
 
 # Install Python dependencies with BuildKit cache mount
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir --no-compile -r requirements/code_upload_worker.txt && \
-    # Clean up pip cache and Python bytecode (directories first, then files)
-    rm -rf /root/.cache/pip && \
-    find /usr/local/lib/python3.9/site-packages -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true && \
+    pip install --no-cache-dir --no-compile -r requirements/code_upload_worker.txt
+
+# Best-effort bytecode cleanup; keep separate so pip failures fail the build.
+RUN find /usr/local/lib/python3.9/site-packages -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true && \
     find /usr/local/lib/python3.9/site-packages \( -name "*.pyc" -o -name "*.pyo" \) -delete 2>/dev/null || true
 
 # Stage 2: Minimal runtime stage (needs shell for install script, so can't use distroless)

--- a/requirements/code_upload_worker.txt
+++ b/requirements/code_upload_worker.txt
@@ -1,3 +1,3 @@
 kubernetes==12.0.1
 PyYaml==5.4.1
-requests==2.33.0
+requests==2.32.5


### PR DESCRIPTION
## Summary
- Pin `requests` to `2.32.5` in `requirements/code_upload_worker.txt` because `2.33.0` requires Python 3.10+ while the code upload worker image still runs on Python 3.9.21.
- Fix the code upload worker Dockerfile so dependency install failures fail the build instead of producing an empty runtime image.
- Split pip install from bytecode cleanup and drop `rm -rf /root/.cache/pip`, which fails against the BuildKit cache mount and was previously masked by trailing `|| true`.

## Context
After #5102 added PyYAML, production builds could still succeed while installing zero worker dependencies because:
1. `requests==2.33.0` is incompatible with Python 3.9, so `pip install` failed.
2. The old single `RUN` line used `|| true`, which masked both the pip failure and the cache-mount `rm` failure.

That left images with only base `pip/setuptools/wheel`, causing `ModuleNotFoundError: No module named 'yaml'` at runtime.

## Test plan
- [x] `DOCKER_BUILDKIT=1 docker build --no-cache -f docker/prod/code-upload-worker/Dockerfile .`
- [x] Build log shows `Successfully installed ... PyYaml-5.4.1 ... requests-2.32.5 ...`
- [x] `docker run --rm --entrypoint python <image> -c "import yaml, requests, kubernetes; print(yaml.__version__, requests.__version__)"` prints `5.4.1 2.32.5`
- [x] After merge/deploy, rebuild/push `evalai-production-code-upload-worker` and restart affected ECS code upload workers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build process for improved dependency installation efficiency with enhanced caching.
  * Updated Python package dependency version for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->