### PR TITLE
Security: Sanitize mathjaxBind content to prevent stored XSS

### DIFF
--- a/frontend/src/js/directives/directives.js
+++ b/frontend/src/js/directives/directives.js
@@ -340,14 +340,12 @@ function dashboardFooterController($scope) {
 (function() {
     'use strict';
 
-    angular.module('evalai').directive("mathjaxBind", ['$compile', '$timeout', function($compile, $timeout) {
+    angular.module('evalai').directive("mathjaxBind", ['$sanitize', '$timeout', function($sanitize, $timeout) {
       return {
         restrict: "A",
         link: function(scope, element, attrs) {
           scope.$watch(attrs.mathjaxBind, function(texExpression) {
-            var template = angular.element('<div>').html(texExpression).contents();
-            var compiledTemplate = $compile(template)(scope);
-            element.empty().append(compiledTemplate);
+            element.html($sanitize(texExpression || ''));
             $timeout(function() {
                 /* eslint-disable no-undef */
                 MathJax.Hub.Queue(["Typeset", MathJax.Hub, element[0]]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes stored XSS in the `mathjaxBind` Angular directive used for challenge HTML content.

## Changes

- Replace `$compile` of user HTML with `$sanitize` and direct DOM insertion.
- Continue running MathJax typesetting on sanitized content.

## Security impact

Prevents challenge hosts (or attackers with write access) from injecting executable Angular templates into participant browsers.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://cvmlp.slack.com/archives/C0B4U4Y62E6/p1780499944391159?thread_ts=1780499944.391159&cid=C0B4U4Y62E6)

<div><a href="https://cursor.com/agents/bc-0d8e08ab-8313-5bbd-90fb-a593f1989812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d8e08ab-8313-5bbd-90fb-a593f1989812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of mathematical expressions by updating the equation processing method to ensure proper display and typesetting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->