### PR TITLE
Security: Allowlist staff challenge attribute updates

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -5410,7 +5410,6 @@ def update_challenge_attributes(request):
         "terms_and_conditions",
         "submission_guidelines",
         "evaluation_details",
-        "approved_by_admin",
         "ephemeral_storage",
         "ec2_storage",
         "workers",
@@ -5422,7 +5421,6 @@ def update_challenge_attributes(request):
         "evaluation_module_error",
         "end_date",
         "start_date",
-        "is_frozen",
         "max_concurrent_submission_evaluation",
         "sqs_retention_period",
     }

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -5403,10 +5403,39 @@ def update_challenge_attributes(request):
         }
         return Response(response_data, status=status.HTTP_404_NOT_FOUND)
 
-    # Update attributes based on the request data
+    allowed_fields = {
+        "title",
+        "short_description",
+        "description",
+        "terms_and_conditions",
+        "submission_guidelines",
+        "evaluation_details",
+        "approved_by_admin",
+        "ephemeral_storage",
+        "ec2_storage",
+        "workers",
+        "worker_cpu_cores",
+        "worker_memory",
+        "is_disabled",
+        "published",
+        "featured",
+        "evaluation_module_error",
+        "end_date",
+        "start_date",
+        "is_frozen",
+        "max_concurrent_submission_evaluation",
+        "sqs_retention_period",
+    }
+
     for key, value in request.data.items():
-        if key != "challenge_pk" and hasattr(challenge, key):
-            setattr(challenge, key, value)
+        if key == "challenge_pk":
+            continue
+        if key not in allowed_fields:
+            return Response(
+                {"error": f"Updating '{key}' is not allowed."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        setattr(challenge, key, value)
 
     try:
         challenge.save()

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -8054,13 +8054,31 @@ class TestUpdateChallengeAttributes(BaseAPITestClass):
                 "challenge_pk": self.challenge.pk,
                 "title": "Updated Title",
                 "description": "Updated Description",
-                "approved_by_admin": True,
                 "ephemeral_storage": 25,
             },
         )
 
         self.assertEqual(response.data, expected)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_update_challenge_attributes_rejects_sensitive_fields(self):
+        self.url = reverse_lazy("challenges:update_challenge_attributes")
+        self.user.is_staff = True
+        self.user.save()
+
+        for field in ("approved_by_admin", "is_frozen"):
+            with self.subTest(field=field):
+                response = self.client.post(
+                    self.url,
+                    {"challenge_pk": self.challenge.pk, field: True},
+                )
+                self.assertEqual(
+                    response.status_code, status.HTTP_400_BAD_REQUEST
+                )
+                self.assertEqual(
+                    response.data,
+                    {"error": f"Updating '{field}' is not allowed."},
+                )
 
     def test_update_challenge_attributes_when_not_a_staff(self):
         self.url = reverse_lazy("challenges:update_challenge_attributes")
@@ -8076,7 +8094,6 @@ class TestUpdateChallengeAttributes(BaseAPITestClass):
                 "challenge_pk": self.challenge.pk,
                 "title": "Updated Title",
                 "description": "Updated Description",
-                "approved_by_admin": True,
                 "ephemeral_storage": 25,
             },
         )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces unrestricted mass assignment in `update_challenge_attributes` with an explicit allowlist.

## Changes

- Only permit updating operational challenge fields (title, description, scaling, approval flags, etc.).
- Reject attempts to set sensitive fields such as `aws_secret_access_key`.

## Security impact

Reduces blast radius if a staff session is compromised or abused.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://cvmlp.slack.com/archives/C0B4U4Y62E6/p1780499944391159?thread_ts=1780499944.391159&cid=C0B4U4Y62E6)

<div><a href="https://cursor.com/agents/bc-0d8e08ab-8313-5bbd-90fb-a593f1989812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d8e08ab-8313-5bbd-90fb-a593f1989812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The challenge update API now strictly validates which fields can be changed and returns a clear error for unsupported fields instead of silently ignoring them.
* **Tests**
  * Added tests to ensure updates that attempt to change restricted/sensitive fields are rejected with an appropriate error, and adjusted non-staff update tests accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->