### PR TITLE
Security: Fail production startup when SECRET_KEY is insecure

### DIFF
--- a/settings/prod.py
+++ b/settings/prod.py
@@ -7,7 +7,10 @@ from sentry_sdk.integrations.django import DjangoIntegration
 from .common import *  # noqa: ignore=F405  # pylint: disable=wildcard-import,unused-wildcard-import
 
 _INSECURE_SECRET_KEYS = {"", "random_secret_key", "some-secret-key"}
-if SECRET_KEY in _INSECURE_SECRET_KEYS:  # noqa: ignore=F405
+if (
+    not SECRET_KEY  # noqa: F405
+    or str(SECRET_KEY).strip() in _INSECURE_SECRET_KEYS  # noqa: F405
+):
     raise ImproperlyConfigured(
         "SECRET_KEY must be set to a unique value in production."
     )

--- a/settings/prod.py
+++ b/settings/prod.py
@@ -1,9 +1,16 @@
 import os
 
 import sentry_sdk
+from django.core.exceptions import ImproperlyConfigured
 from sentry_sdk.integrations.django import DjangoIntegration
 
 from .common import *  # noqa: ignore=F405  # pylint: disable=wildcard-import,unused-wildcard-import
+
+_INSECURE_SECRET_KEYS = {"", "random_secret_key", "some-secret-key"}
+if SECRET_KEY in _INSECURE_SECRET_KEYS:  # noqa: ignore=F405
+    raise ImproperlyConfigured(
+        "SECRET_KEY must be set to a unique value in production."
+    )
 
 
 def _sentry_before_send(event, hint):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prevents production deployments from starting with known-insecure Django secret keys.

## Changes

- Raise `ImproperlyConfigured` in `settings/prod.py` when `SECRET_KEY` is empty or matches known placeholders (`random_secret_key`, `some-secret-key`).

## Security impact

Avoids session, CSRF, and JWT signing with predictable secrets in production.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://cvmlp.slack.com/archives/C0B4U4Y62E6/p1780499944391159?thread_ts=1780499944.391159&cid=C0B4U4Y62E6)

<div><a href="https://cursor.com/agents/bc-0d8e08ab-8313-5bbd-90fb-a593f1989812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d8e08ab-8313-5bbd-90fb-a593f1989812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Production now validates the application secret on startup and will refuse to run if the secret is blank or matches common insecure/placeholder values, preventing deployments with unsafe configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->