### PR TITLE
Security: Restrict public subscribe and team member endpoints

### DIFF
--- a/apps/web/urls.py
+++ b/apps/web/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     url(r"^contact/$", views.contact_us, name="contact_us"),
     url(r"^subscribe/$", views.subscribe, name="subscribe"),
     url(r"^team/$", views.our_team, name="our_team"),
+    url(r"^team/add/$", views.add_team_member, name="add_team_member"),
     url(
         r"^notify_users/$",
         views.notify_users_about_challenge,

--- a/apps/web/views.py
+++ b/apps/web/views.py
@@ -1,5 +1,6 @@
 import logging
 
+from accounts.authentication import ExpiringTokenAuthentication
 from base.utils import send_slack_notification
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -14,7 +15,6 @@ from rest_framework.decorators import (
 from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 from rest_framework_simplejwt.authentication import JWTAuthentication
-from accounts.authentication import ExpiringTokenAuthentication
 
 from .models import Subscribers, Team
 from .serializers import ContactSerializer, SubscribeSerializer, TeamSerializer
@@ -119,10 +119,9 @@ def subscribe(request):
         if serializer.is_valid():
             serializer.save()
             response_data = {
-                "message",
-                "You will be notified about our latest updates at {}.".format(
-                    email
-                ),
+                "message": (
+                    "You will be notified about our latest updates at {}."
+                ).format(email)
             }
             return Response(response_data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -146,8 +145,9 @@ def our_team(request):
 @permission_classes((permissions.IsAdminUser,))
 @authentication_classes((JWTAuthentication, ExpiringTokenAuthentication))
 def add_team_member(request):
-    request.data["team_type"] = request.data.get("team_type", Team.CONTRIBUTOR)
-    serializer = TeamSerializer(data=request.data)
+    data = request.data.copy()
+    data.setdefault("team_type", Team.CONTRIBUTOR)
+    serializer = TeamSerializer(data=data)
     if serializer.is_valid():
         serializer.save()
         response_data = {"message": "Successfully added the contributor."}

--- a/apps/web/views.py
+++ b/apps/web/views.py
@@ -7,11 +7,14 @@ from django.shortcuts import render
 from rest_framework import permissions, status
 from rest_framework.decorators import (
     api_view,
+    authentication_classes,
     permission_classes,
     throttle_classes,
 )
 from rest_framework.response import Response
-from rest_framework.throttling import AnonRateThrottle
+from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from accounts.authentication import ExpiringTokenAuthentication
 
 from .models import Subscribers, Team
 from .serializers import ContactSerializer, SubscribeSerializer, TeamSerializer
@@ -99,18 +102,11 @@ def contact_us(request):
         return Response(response_data, status=status.HTTP_200_OK)
 
 
-@api_view(["GET", "POST"])
+@api_view(["POST"])
 @throttle_classes([AnonRateThrottle])
 @permission_classes((permissions.AllowAny,))
 def subscribe(request):
-    if request.method == "GET":
-        subscribers = Subscribers.objects.all().order_by("-pk")
-        serializer = SubscribeSerializer(
-            subscribers, many=True, context={"request": request}
-        )
-        response_data = serializer.data
-        return Response(response_data, status=status.HTTP_200_OK)
-    elif request.method == "POST":
+    if request.method == "POST":
         email = request.data.get("email")
         # When user has already subscribed
         if Subscribers.objects.filter(email=email).exists():
@@ -132,7 +128,7 @@ def subscribe(request):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-@api_view(["GET", "POST"])
+@api_view(["GET"])
 @throttle_classes([AnonRateThrottle])
 @permission_classes((permissions.AllowAny,))
 def our_team(request):
@@ -143,15 +139,17 @@ def our_team(request):
         )
         response_data = serializer.data
         return Response(response_data, status=status.HTTP_200_OK)
-    elif request.method == "POST":
-        # team_type is set to Team.CONTRIBUTOR by default and can be overridden
-        # by the requester
-        request.data["team_type"] = request.data.get(
-            "team_type", Team.CONTRIBUTOR
-        )
-        serializer = TeamSerializer(data=request.data)
-        if serializer.is_valid():
-            serializer.save()
-            response_data = {"message", "Successfully added the contributor."}
-            return Response(response_data, status=status.HTTP_201_CREATED)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(["POST"])
+@throttle_classes([UserRateThrottle])
+@permission_classes((permissions.IsAdminUser,))
+@authentication_classes((JWTAuthentication, ExpiringTokenAuthentication))
+def add_team_member(request):
+    request.data["team_type"] = request.data.get("team_type", Team.CONTRIBUTOR)
+    serializer = TeamSerializer(data=request.data)
+    if serializer.is_valid():
+        serializer.save()
+        response_data = {"message": "Successfully added the contributor."}
+        return Response(response_data, status=status.HTTP_201_CREATED)
+    return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/tests/unit/web/test_views.py
+++ b/tests/unit/web/test_views.py
@@ -71,7 +71,14 @@ class CreateContactMessage(BaseAPITestCase):
 
 class CreateTeamMember(APITestCase):
     def setUp(self):
-        self.url = reverse_lazy("web:our_team")
+        self.url = reverse_lazy("web:add_team_member")
+        self.user = User.objects.create(
+            username="adminuser",
+            email="admin@test.com",
+            password="secret_password",
+            is_staff=True,
+            is_superuser=True,
+        )
         self.data = {
             "name": "Test User",
             "email": "test@user.com",
@@ -82,6 +89,7 @@ class CreateTeamMember(APITestCase):
 
     def test_create_team_member_default_team_type(self):
         # TODO add 'Header' and 'Background image' to testing
+        self.client.force_authenticate(user=self.user)
         response = self.client.post(self.url, self.data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Team.objects.all().count(), 1)
@@ -100,6 +108,7 @@ class CreateTeamMember(APITestCase):
     def test_create_team_member_custom_team_type(self):
         # TODO add 'Header' and 'Background image' to testing
         self.data["team_type"] = Team.CORE_TEAM
+        self.client.force_authenticate(user=self.user)
         response = self.client.post(self.url, self.data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Team.objects.all().count(), 1)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens publicly accessible web API endpoints that exposed data or allowed unauthenticated writes.

## Changes

- Remove unauthenticated `GET` on `/api/web/subscribe/` (was listing all subscriber emails).
- Restrict team member creation to admin-only `POST /api/web/team/add/`.
- Keep public read-only `GET /api/web/team/` for the Our Team page.

## Security impact

Stops email list disclosure and unauthorized modification of public team content.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://cvmlp.slack.com/archives/C0B4U4Y62E6/p1780499944391159?thread_ts=1780499944.391159&cid=C0B4U4Y62E6)

<div><a href="https://cursor.com/agents/bc-0d8e08ab-8313-5bbd-90fb-a593f1989812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d8e08ab-8313-5bbd-90fb-a593f1989812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated admin-only endpoint to create team members, protected by token-based authentication.

* **API Improvements**
  * Subscribe endpoint now accepts POST only.
  * Team listing endpoint now supports GET only.
  * General API behavior clarified for consistency.

* **Tests**
  * Updated tests to target the new team-member creation endpoint and authenticate as an admin user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->