### PR TITLE
Include challenge names in max team member error messages.

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -669,10 +669,14 @@ def add_participant_team_to_challenge(
             member_count = get_participant_team_member_count(participant_team)
             response_data = {
                 "error": (
-                    "This challenge limits teams to {} member(s). Your team "
-                    "has {} member(s). Please remove members before "
+                    "The challenge {} limits teams to {} member(s). Your "
+                    "team has {} member(s). Please remove members before "
                     "participating."
-                ).format(challenge.max_team_members, member_count)
+                ).format(
+                    challenge.title,
+                    challenge.max_team_members,
+                    member_count,
+                )
             }
             return Response(
                 response_data, status=status.HTTP_406_NOT_ACCEPTABLE

--- a/apps/participants/utils.py
+++ b/apps/participants/utils.py
@@ -97,6 +97,20 @@ def get_effective_max_team_members_for_team(participant_team):
     return min(limits)
 
 
+def get_team_capacity_blocking_challenge_titles(participant_team):
+    """
+    Returns titles of joined challenges whose max_team_members limit the team
+    has reached or exceeded.
+    """
+    member_count = get_participant_team_member_count(participant_team)
+    return list(
+        get_list_of_challenges_for_participant_team([participant_team])
+        .exclude(max_team_members__isnull=True)
+        .filter(max_team_members__lte=member_count)
+        .values_list("title", flat=True)
+    )
+
+
 def team_can_add_member(participant_team):
     """Returns whether the team can invite or accept another member."""
     limit = get_effective_max_team_members_for_team(participant_team)

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -47,6 +47,7 @@ from .utils import (
     get_list_of_challenges_for_participant_team,
     get_list_of_challenges_participated_by_a_user,
     get_participant_team_of_user_for_a_challenge,
+    get_team_capacity_blocking_challenge_titles,
     has_user_participated_in_challenge,
     is_user_creator_of_participant_team,
     is_user_part_of_participant_team,
@@ -345,12 +346,15 @@ def invite_participant_to_team(request, pk):
             max_team_members = get_effective_max_team_members_for_team(
                 participant_team
             )
+            challenge_names = ", ".join(
+                get_team_capacity_blocking_challenge_titles(participant_team)
+            )
             response_data = {
                 "error": (
                     "This team has reached the maximum of {} member(s) "
-                    "allowed for the challenge(s) it has joined. Please "
-                    "remove members or contact the challenge host."
-                ).format(max_team_members)
+                    "allowed for {}. Please remove members or contact the "
+                    "challenge host."
+                ).format(max_team_members, challenge_names)
             }
             return Response(
                 response_data, status=status.HTTP_406_NOT_ACCEPTABLE

--- a/apps/participants/views.py
+++ b/apps/participants/views.py
@@ -351,10 +351,11 @@ def invite_participant_to_team(request, pk):
             )
             response_data = {
                 "error": (
-                    "This team has reached the maximum of {} member(s) "
-                    "allowed for {}. Please remove members or contact the "
+                    "This team has reached the team-member limit for "
+                    "{}. The strictest limit across joined challenges is "
+                    "{} member(s). Please remove members or contact the "
                     "challenge host."
-                ).format(max_team_members, challenge_names)
+                ).format(challenge_names, max_team_members)
             }
             return Response(
                 response_data, status=status.HTTP_406_NOT_ACCEPTABLE

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -1514,6 +1514,7 @@ class MapChallengeAndParticipantTeam(
         response = self.client.post(self.url, {})
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
         self.assertIn("limits teams to 1 member(s)", response.data["error"])
+        self.assertIn("Some Test Challenge", response.data["error"])
         self.assertIn("Your team has 2 member(s)", response.data["error"])
         self.assertFalse(
             self.challenge2.participant_teams.filter(

--- a/tests/unit/participants/test_utils.py
+++ b/tests/unit/participants/test_utils.py
@@ -11,6 +11,7 @@ from participants.utils import (
     get_effective_max_team_members_for_team,
     get_participant_team_id_of_user_for_a_challenge,
     get_participant_team_member_count,
+    get_team_capacity_blocking_challenge_titles,
     has_participant_team_participated_in_challenge,
     has_participated_in_require_complete_profile_challenge,
     team_can_add_member,
@@ -324,6 +325,25 @@ class TestMaxTeamMembersUtils(TestCase):
         challenge_b.participant_teams.add(self.participant_team)
         self.assertEqual(
             get_effective_max_team_members_for_team(self.participant_team), 3
+        )
+
+    def test_get_team_capacity_blocking_challenge_titles(self):
+        challenge_at_capacity = Challenge.objects.create(
+            title="At Capacity Challenge",
+            creator=self.host_team,
+            max_team_members=2,
+        )
+        challenge_below_capacity = Challenge.objects.create(
+            title="Below Capacity Challenge",
+            creator=self.host_team,
+            max_team_members=5,
+        )
+        challenge_at_capacity.participant_teams.add(self.participant_team)
+        challenge_below_capacity.participant_teams.add(self.participant_team)
+
+        self.assertEqual(
+            get_team_capacity_blocking_challenge_titles(self.participant_team),
+            ["At Capacity Challenge"],
         )
 
     def test_team_can_add_member_when_below_limit(self):

--- a/tests/unit/participants/test_views.py
+++ b/tests/unit/participants/test_views.py
@@ -497,7 +497,10 @@ class InviteParticipantToTeamTest(BaseAPITestClass):
         challenge.participant_teams.add(self.participant_team)
         response = self.client.post(self.url, self.data)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
-        self.assertIn("maximum of 1 member(s)", response.data["error"])
+        self.assertIn(
+            "strictest limit across joined challenges is 1 member(s)",
+            response.data["error"],
+        )
         self.assertIn("Max Team Members Challenge", response.data["error"])
         self.assertFalse(
             Participant.objects.filter(
@@ -524,7 +527,10 @@ class InviteParticipantToTeamTest(BaseAPITestClass):
         response = self.client.post(self.url, self.data)
 
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
-        self.assertIn("maximum of 1 member(s)", response.data["error"])
+        self.assertIn(
+            "strictest limit across joined challenges is 1 member(s)",
+            response.data["error"],
+        )
         self.assertIn("Max Team Members Challenge", response.data["error"])
         self.assertFalse(
             Participant.objects.filter(
@@ -612,8 +618,12 @@ class InviteParticipantToTeamTest(BaseAPITestClass):
         challenge_b.participant_teams.add(self.participant_team)
         response = self.client.post(self.url, self.data)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
-        self.assertIn("maximum of 1 member(s)", response.data["error"])
+        self.assertIn(
+            "strictest limit across joined challenges is 1 member(s)",
+            response.data["error"],
+        )
         self.assertIn("Challenge B", response.data["error"])
+        self.assertNotIn("Challenge A", response.data["error"])
         self.assertFalse(
             Participant.objects.filter(
                 team=self.participant_team, user=self.invite_user

--- a/tests/unit/participants/test_views.py
+++ b/tests/unit/participants/test_views.py
@@ -498,6 +498,7 @@ class InviteParticipantToTeamTest(BaseAPITestClass):
         response = self.client.post(self.url, self.data)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
         self.assertIn("maximum of 1 member(s)", response.data["error"])
+        self.assertIn("Max Team Members Challenge", response.data["error"])
         self.assertFalse(
             Participant.objects.filter(
                 team=self.participant_team, user=self.invite_user
@@ -524,6 +525,7 @@ class InviteParticipantToTeamTest(BaseAPITestClass):
 
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
         self.assertIn("maximum of 1 member(s)", response.data["error"])
+        self.assertIn("Max Team Members Challenge", response.data["error"])
         self.assertFalse(
             Participant.objects.filter(
                 team=self.participant_team, user=self.invite_user
@@ -575,6 +577,7 @@ class InviteParticipantToTeamTest(BaseAPITestClass):
         response = self.client.post(self.url, self.data)
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
         self.assertIn("maximum of 1 member(s)", response.data["error"])
+        self.assertIn("Challenge B", response.data["error"])
         self.assertFalse(
             Participant.objects.filter(
                 team=self.participant_team, user=self.invite_user


### PR DESCRIPTION
Show which joined challenge(s) block invites or registration when a team reaches its member limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Team invitations now include the specific challenge title(s) in capacity-related error messages, and when multiple joined challenges apply the message highlights the strictest blocking challenge.

* **Tests**
  * Added and updated tests to assert capacity-blocking error messages list the correct challenge title(s) across invite, capacity-limit, and stale-snapshot scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->