### PR TITLE
Exempt all-host participant teams from max_team_members limits.

### DIFF
--- a/apps/participants/utils.py
+++ b/apps/participants/utils.py
@@ -98,7 +98,8 @@ def is_participant_team_exempt_from_max_members_for_challenge(
 
     host_user_ids = set(
         ChallengeHost.objects.filter(
-            team_name_id=challenge.creator_id
+            team_name_id=challenge.creator_id,
+            status__in=[ChallengeHost.ACCEPTED, ChallengeHost.SELF],
         ).values_list("user_id", flat=True)
     )
     return all(user_id in host_user_ids for user_id in member_user_ids)

--- a/apps/participants/utils.py
+++ b/apps/participants/utils.py
@@ -1,5 +1,6 @@
 from base.utils import get_model_object
 from challenges.models import Challenge
+from hosts.models import ChallengeHost
 
 from .models import Participant, ParticipantTeam
 
@@ -80,6 +81,29 @@ def get_participant_team_member_count(participant_team):
     return Participant.objects.filter(team=participant_team).count()
 
 
+def is_participant_team_exempt_from_max_members_for_challenge(
+    participant_team, challenge
+):
+    """
+    Returns True when every member of the participant team is a host of the
+    challenge's organizing team (baseline/testing team exemption).
+    """
+    member_user_ids = list(
+        Participant.objects.filter(team=participant_team).values_list(
+            "user_id", flat=True
+        )
+    )
+    if not member_user_ids:
+        return False
+
+    host_user_ids = set(
+        ChallengeHost.objects.filter(
+            team_name_id=challenge.creator_id
+        ).values_list("user_id", flat=True)
+    )
+    return all(user_id in host_user_ids for user_id in member_user_ids)
+
+
 def get_effective_max_team_members_for_team(participant_team):
     """
     Returns the strictest max_team_members limit among challenges the team
@@ -88,9 +112,13 @@ def get_effective_max_team_members_for_team(participant_team):
     challenges = get_list_of_challenges_for_participant_team(
         [participant_team]
     )
-    limits = challenges.exclude(max_team_members__isnull=True).values_list(
-        "max_team_members", flat=True
-    )
+    limits = []
+    for challenge in challenges.exclude(max_team_members__isnull=True):
+        if is_participant_team_exempt_from_max_members_for_challenge(
+            participant_team, challenge
+        ):
+            continue
+        limits.append(challenge.max_team_members)
     limits = list(limits)
     if not limits:
         return None
@@ -108,6 +136,10 @@ def team_can_add_member(participant_team):
 def team_exceeds_challenge_max_members(participant_team, challenge):
     """Returns whether the team exceeds a challenge's max team member limit."""
     if challenge.max_team_members is None:
+        return False
+    if is_participant_team_exempt_from_max_members_for_challenge(
+        participant_team, challenge
+    ):
         return False
     return (
         get_participant_team_member_count(participant_team)

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -1521,6 +1521,41 @@ class MapChallengeAndParticipantTeam(
             ).exists()
         )
 
+    def test_participation_allowed_for_host_participant_team_despite_max_members(
+        self,
+    ):
+        """Hosts participating on an all-host team bypass max_team_members."""
+        self.challenge2.max_team_members = 1
+        self.challenge2.save()
+        host_participant_team = ParticipantTeam.objects.create(
+            team_name="Host Participant Team", created_by=self.user2
+        )
+        Participant.objects.create(
+            user=self.user2,
+            status=Participant.SELF,
+            team=host_participant_team,
+        )
+        Participant.objects.create(
+            user=self.user3,
+            status=Participant.ACCEPTED,
+            team=host_participant_team,
+        )
+        self.client.force_authenticate(user=self.user2)
+        self.url = reverse_lazy(
+            "challenges:add_participant_team_to_challenge",
+            kwargs={
+                "challenge_pk": self.challenge2.pk,
+                "participant_team_pk": host_participant_team.pk,
+            },
+        )
+        response = self.client.post(self.url, {})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(
+            self.challenge2.participant_teams.filter(
+                pk=host_participant_team.pk
+            ).exists()
+        )
+
     def test_participation_allowed_when_team_within_max_team_members(
         self,
     ):

--- a/tests/unit/participants/test_utils.py
+++ b/tests/unit/participants/test_utils.py
@@ -423,6 +423,29 @@ class TestMaxTeamMembersUtils(TestCase):
             )
         )
 
+    def test_team_with_denied_host_not_exempt_from_organizer_challenge(self):
+        ChallengeHost.objects.create(
+            user=self.user,
+            team_name=self.host_team,
+            status=ChallengeHost.ACCEPTED,
+        )
+        ChallengeHost.objects.create(
+            user=self.other_user,
+            team_name=self.host_team,
+            status=ChallengeHost.DENIED,
+        )
+        challenge = Challenge.objects.create(
+            title="host challenge",
+            creator=self.host_team,
+            max_team_members=1,
+        )
+
+        self.assertFalse(
+            is_participant_team_exempt_from_max_members_for_challenge(
+                self.participant_team, challenge
+            )
+        )
+
     def test_host_challenge_exempt_but_other_challenge_still_limits(self):
         ChallengeHost.objects.create(
             user=self.user,

--- a/tests/unit/participants/test_utils.py
+++ b/tests/unit/participants/test_utils.py
@@ -13,6 +13,7 @@ from participants.utils import (
     get_participant_team_member_count,
     has_participant_team_participated_in_challenge,
     has_participated_in_require_complete_profile_challenge,
+    is_participant_team_exempt_from_max_members_for_challenge,
     team_can_add_member,
     team_exceeds_challenge_max_members,
 )
@@ -365,3 +366,92 @@ class TestMaxTeamMembersUtils(TestCase):
                 self.participant_team, challenge
             )
         )
+
+    def test_host_only_team_exempt_from_own_challenge_limit(self):
+        ChallengeHost.objects.create(
+            user=self.user,
+            team_name=self.host_team,
+            status=ChallengeHost.ACCEPTED,
+        )
+        ChallengeHost.objects.create(
+            user=self.other_user,
+            team_name=self.host_team,
+            status=ChallengeHost.ACCEPTED,
+        )
+        challenge = Challenge.objects.create(
+            title="host challenge",
+            creator=self.host_team,
+            max_team_members=1,
+        )
+        challenge.participant_teams.add(self.participant_team)
+
+        self.assertTrue(
+            is_participant_team_exempt_from_max_members_for_challenge(
+                self.participant_team, challenge
+            )
+        )
+        self.assertFalse(
+            team_exceeds_challenge_max_members(
+                self.participant_team, challenge
+            )
+        )
+        self.assertTrue(team_can_add_member(self.participant_team))
+        self.assertIsNone(
+            get_effective_max_team_members_for_team(self.participant_team)
+        )
+
+    def test_mixed_team_not_exempt_from_organizer_challenge(self):
+        ChallengeHost.objects.create(
+            user=self.user,
+            team_name=self.host_team,
+            status=ChallengeHost.ACCEPTED,
+        )
+        challenge = Challenge.objects.create(
+            title="host challenge",
+            creator=self.host_team,
+            max_team_members=1,
+        )
+
+        self.assertFalse(
+            is_participant_team_exempt_from_max_members_for_challenge(
+                self.participant_team, challenge
+            )
+        )
+        self.assertTrue(
+            team_exceeds_challenge_max_members(
+                self.participant_team, challenge
+            )
+        )
+
+    def test_host_challenge_exempt_but_other_challenge_still_limits(self):
+        ChallengeHost.objects.create(
+            user=self.user,
+            team_name=self.host_team,
+            status=ChallengeHost.ACCEPTED,
+        )
+        ChallengeHost.objects.create(
+            user=self.other_user,
+            team_name=self.host_team,
+            status=ChallengeHost.ACCEPTED,
+        )
+        host_challenge = Challenge.objects.create(
+            title="host challenge",
+            creator=self.host_team,
+            max_team_members=1,
+        )
+        other_host_team = ChallengeHostTeam.objects.create(
+            team_name="other_host_team",
+            created_by=self.other_user,
+        )
+        other_challenge = Challenge.objects.create(
+            title="other challenge",
+            creator=other_host_team,
+            max_team_members=2,
+        )
+        host_challenge.participant_teams.add(self.participant_team)
+        other_challenge.participant_teams.add(self.participant_team)
+
+        self.assertEqual(
+            get_effective_max_team_members_for_team(self.participant_team), 2
+        )
+        self.assertFalse(team_can_add_member(self.participant_team))

--- a/tests/unit/participants/test_views.py
+++ b/tests/unit/participants/test_views.py
@@ -530,6 +530,42 @@ class InviteParticipantToTeamTest(BaseAPITestClass):
             ).exists()
         )
 
+    def test_invite_allowed_for_host_only_team_at_own_challenge(self):
+        """Hosts can grow their baseline team beyond max_team_members."""
+        ChallengeHost.objects.create(
+            user=self.user1,
+            team_name=self.challenge_host_team,
+            status=ChallengeHost.ACCEPTED,
+        )
+        host_participant_team = ParticipantTeam.objects.create(
+            team_name="Host Baseline Team", created_by=self.user1
+        )
+        Participant.objects.create(
+            user=self.user1,
+            status=Participant.SELF,
+            team=host_participant_team,
+        )
+        challenge = Challenge.objects.create(
+            title="Host Own Challenge",
+            creator=self.challenge_host_team,
+            max_team_members=1,
+            start_date=timezone.now() - timedelta(days=1),
+            end_date=timezone.now() + timedelta(days=10),
+        )
+        challenge.participant_teams.add(host_participant_team)
+        url = reverse_lazy(
+            "participants:invite_participant_to_team",
+            kwargs={"pk": host_participant_team.pk},
+        )
+        self.client.force_authenticate(user=self.user1)
+        response = self.client.post(url, self.data)
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertTrue(
+            Participant.objects.filter(
+                team=host_participant_team, user=self.invite_user
+            ).exists()
+        )
+
     def test_invite_allowed_when_team_below_max_members_for_participated_challenge(
         self,
     ):


### PR DESCRIPTION
Host-only teams bypass per-challenge member caps on join and invite so organizers can use baseline/testing teams without hitting competitor limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Challenge hosts on an all-host team can register or be invited to their own challenge even if the team exceeds that challenge's max-member limit.
* **Bug Fixes**
  * Effective team-size checks now ignore host-exempt challenges and respect the strictest applicable limits across joined challenges.
* **Tests**
  * Added unit tests covering host exemptions, mixed/denied host states, and related registration/invite flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->