### PR TITLE
Fix Lambda invoke ValidationException for misconfigured autoscale ARN

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -930,11 +930,8 @@ def trigger_eks_node_autoscale(
 
     function_name = _resolve_eks_node_autoscale_lambda_function_name()
     if not function_name:
-        if (
-            not EKS_NODE_AUTOSCALE_LAMBDA_ARN
-            and not os.environ.get(
-                "EKS_NODE_AUTOSCALE_LAMBDA_FUNCTION_NAME", ""
-            )
+        if not EKS_NODE_AUTOSCALE_LAMBDA_ARN and not os.environ.get(
+            "EKS_NODE_AUTOSCALE_LAMBDA_FUNCTION_NAME", ""
         ):
             logger.info(
                 "EKS_NODE_AUTOSCALE_LAMBDA_ARN not configured. "

--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import random
+import re
 import string
 import uuid
 from http import HTTPStatus
@@ -93,6 +94,42 @@ EVENTBRIDGE_SCHEDULER_ROLE_ARN = os.environ.get(
 EKS_NODE_AUTOSCALE_LAMBDA_ARN = os.environ.get(
     "EKS_NODE_AUTOSCALE_LAMBDA_ARN", ""
 )
+IAM_ROLE_ARN_PATTERN = re.compile(r"^arn:aws[a-zA-Z-]*:iam:")
+
+
+def _resolve_eks_node_autoscale_lambda_function_name():
+    """
+    Return a valid Lambda FunctionName for Invoke, or empty string if
+    misconfigured.
+
+    EKS_NODE_AUTOSCALE_LAMBDA_FUNCTION_NAME takes precedence when set.
+    EKS_NODE_AUTOSCALE_LAMBDA_ARN may be a full/partial Lambda ARN or a
+    plain function name. IAM role ARNs are rejected with a clear log message.
+    """
+    function_name = os.environ.get(
+        "EKS_NODE_AUTOSCALE_LAMBDA_FUNCTION_NAME", ""
+    )
+    if function_name:
+        return function_name
+
+    lambda_arn_or_name = EKS_NODE_AUTOSCALE_LAMBDA_ARN
+    if not lambda_arn_or_name:
+        return ""
+
+    if IAM_ROLE_ARN_PATTERN.match(lambda_arn_or_name):
+        logger.error(
+            "EKS_NODE_AUTOSCALE_LAMBDA_ARN is set to an IAM role ARN (%s), "
+            "not a Lambda function ARN or name. Configure "
+            "EKS_NODE_AUTOSCALE_LAMBDA_ARN with the Lambda function ARN "
+            "(e.g. arn:aws:lambda:us-east-1:ACCOUNT_ID:function:"
+            "auto_scale_eks_nodes_lambda) or set "
+            "EKS_NODE_AUTOSCALE_LAMBDA_FUNCTION_NAME instead.",
+            lambda_arn_or_name,
+        )
+        return ""
+
+    return lambda_arn_or_name
+
 
 COMMON_SETTINGS_DICT = {
     "EXECUTION_ROLE_ARN": os.environ.get(
@@ -891,12 +928,19 @@ def trigger_eks_node_autoscale(
             if was_pending == is_pending:
                 return
 
-    if not EKS_NODE_AUTOSCALE_LAMBDA_ARN:
-        logger.info(
-            "EKS_NODE_AUTOSCALE_LAMBDA_ARN not configured. "
-            "Skipping autoscale invoke for challenge %s.",
-            challenge_pk,
-        )
+    function_name = _resolve_eks_node_autoscale_lambda_function_name()
+    if not function_name:
+        if (
+            not EKS_NODE_AUTOSCALE_LAMBDA_ARN
+            and not os.environ.get(
+                "EKS_NODE_AUTOSCALE_LAMBDA_FUNCTION_NAME", ""
+            )
+        ):
+            logger.info(
+                "EKS_NODE_AUTOSCALE_LAMBDA_ARN not configured. "
+                "Skipping autoscale invoke for challenge %s.",
+                challenge_pk,
+            )
         return
 
     payload = {
@@ -913,7 +957,7 @@ def trigger_eks_node_autoscale(
     try:
         lambda_client = get_boto3_client("lambda", aws_keys)
         lambda_client.invoke(
-            FunctionName=EKS_NODE_AUTOSCALE_LAMBDA_ARN,
+            FunctionName=function_name,
             InvocationType="Event",
             Payload=json.dumps(payload).encode("utf-8"),
         )

--- a/tests/unit/challenges/test_aws_utils.py
+++ b/tests/unit/challenges/test_aws_utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 import unittest
 from http import HTTPStatus
 from unittest import TestCase, mock
@@ -5498,6 +5499,69 @@ class TestTriggerEksNodeAutoscale:
             previous_submission_status="submitting",
         )
         mock_get_boto3_client.assert_not_called()
+
+    @patch("challenges.aws_utils.settings")
+    @patch(
+        "challenges.aws_utils.EKS_NODE_AUTOSCALE_LAMBDA_ARN",
+        "arn:aws:iam::937891341272:role/evalai-lambda-execution-role",
+    )
+    @patch("challenges.aws_utils.get_boto3_client")
+    def test_skip_when_lambda_arn_is_iam_role(
+        self, mock_get_boto3_client, mock_settings
+    ):
+        mock_settings.DEBUG = False
+        mock_settings.TEST = False
+
+        trigger_eks_node_autoscale(11, "submission_created")
+
+        mock_get_boto3_client.assert_not_called()
+
+    @patch("challenges.aws_utils.settings")
+    @patch(
+        "challenges.aws_utils.EKS_NODE_AUTOSCALE_LAMBDA_ARN",
+        "arn:aws:iam::937891341272:role/evalai-lambda-execution-role",
+    )
+    @patch.dict(
+        os.environ,
+        {"EKS_NODE_AUTOSCALE_LAMBDA_FUNCTION_NAME": "auto_scale_eks_nodes_lambda"},
+        clear=False,
+    )
+    @patch("challenges.aws_utils.get_boto3_client")
+    def test_uses_function_name_env_var_over_misconfigured_arn(
+        self, mock_get_boto3_client, mock_settings
+    ):
+        mock_settings.DEBUG = False
+        mock_settings.TEST = False
+        mock_lambda_client = MagicMock()
+        mock_get_boto3_client.return_value = mock_lambda_client
+
+        trigger_eks_node_autoscale(11, "submission_created")
+
+        mock_get_boto3_client.assert_called_once()
+        kwargs = mock_lambda_client.invoke.call_args.kwargs
+        assert kwargs["FunctionName"] == "auto_scale_eks_nodes_lambda"
+
+    @patch("challenges.aws_utils.settings")
+    @patch("challenges.aws_utils.EKS_NODE_AUTOSCALE_LAMBDA_ARN", "")
+    @patch.dict(
+        os.environ,
+        {"EKS_NODE_AUTOSCALE_LAMBDA_FUNCTION_NAME": "auto_scale_eks_nodes_lambda"},
+        clear=False,
+    )
+    @patch("challenges.aws_utils.get_boto3_client")
+    def test_uses_function_name_env_var_when_arn_empty(
+        self, mock_get_boto3_client, mock_settings
+    ):
+        mock_settings.DEBUG = False
+        mock_settings.TEST = False
+        mock_lambda_client = MagicMock()
+        mock_get_boto3_client.return_value = mock_lambda_client
+
+        trigger_eks_node_autoscale(11, "submission_created")
+
+        mock_get_boto3_client.assert_called_once()
+        kwargs = mock_lambda_client.invoke.call_args.kwargs
+        assert kwargs["FunctionName"] == "auto_scale_eks_nodes_lambda"
 
 
 class TestWorkerImageHelpers(TestCase):

--- a/tests/unit/challenges/test_aws_utils.py
+++ b/tests/unit/challenges/test_aws_utils.py
@@ -5523,7 +5523,9 @@ class TestTriggerEksNodeAutoscale:
     )
     @patch.dict(
         os.environ,
-        {"EKS_NODE_AUTOSCALE_LAMBDA_FUNCTION_NAME": "auto_scale_eks_nodes_lambda"},
+        {
+            "EKS_NODE_AUTOSCALE_LAMBDA_FUNCTION_NAME": "auto_scale_eks_nodes_lambda"
+        },
         clear=False,
     )
     @patch("challenges.aws_utils.get_boto3_client")
@@ -5545,7 +5547,9 @@ class TestTriggerEksNodeAutoscale:
     @patch("challenges.aws_utils.EKS_NODE_AUTOSCALE_LAMBDA_ARN", "")
     @patch.dict(
         os.environ,
-        {"EKS_NODE_AUTOSCALE_LAMBDA_FUNCTION_NAME": "auto_scale_eks_nodes_lambda"},
+        {
+            "EKS_NODE_AUTOSCALE_LAMBDA_FUNCTION_NAME": "auto_scale_eks_nodes_lambda"
+        },
         clear=False,
     )
     @patch("challenges.aws_utils.get_boto3_client")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`trigger_eks_node_autoscale` was passing `EKS_NODE_AUTOSCALE_LAMBDA_ARN` directly to `lambda:Invoke` as `FunctionName`. In production this env var was set to an IAM role ARN (`arn:aws:iam::937891341272:role/evalai-lambda-execution-role`) instead of a Lambda function ARN/name, causing:

```
ClientError: An error occurred (ValidationException) when calling the Invoke operation:
Value 'arn:aws:iam::937891341272:role/evalai-lambda-execution-role' at 'functionName'
failed to satisfy constraint...
```

## Solution

- Add `_resolve_eks_node_autoscale_lambda_function_name()` to validate the configured value before invoking Lambda.
- Reject IAM role ARNs with a clear error log instead of calling AWS and raising `ValidationException`.
- Support `EKS_NODE_AUTOSCALE_LAMBDA_FUNCTION_NAME` as an alternative env var (takes precedence when set), so deployments can supply just the function name.

## Deployment note

Production should set one of:

- `EKS_NODE_AUTOSCALE_LAMBDA_ARN` to the Lambda function ARN (e.g. `arn:aws:lambda:us-east-1:937891341272:function:auto_scale_eks_nodes_lambda`), **or**
- `EKS_NODE_AUTOSCALE_LAMBDA_FUNCTION_NAME` to the function name (e.g. `auto_scale_eks_nodes_lambda`).

Do **not** set `EKS_NODE_AUTOSCALE_LAMBDA_ARN` to the Lambda execution role ARN.

## Tests

Added unit tests covering:
- Skipping invoke when ARN is an IAM role
- Using `EKS_NODE_AUTOSCALE_LAMBDA_FUNCTION_NAME` when ARN is misconfigured
- Using `EKS_NODE_AUTOSCALE_LAMBDA_FUNCTION_NAME` when ARN is empty
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7e41dae-e5ab-41fd-93db-4f0268baee4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7e41dae-e5ab-41fd-93db-4f0268baee4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved EKS node autoscaling Lambda configuration by supporting multiple environment variable formats (function name or ARN) and prioritizing the explicit function-name setting.

* **Bug Fixes**
  * Better validation to ignore misconfigured IAM role ARNs and ensure the correct Lambda is invoked based on the provided configuration.
  * Updated “not configured” handling to trigger only when neither required setting is set.

* **Tests**
  * Added unit tests covering valid/invalid configuration combinations for EKS node autoscaling Lambda invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->