### PR TITLE
Relax post-approval YAML lock to structural config only

### DIFF
--- a/apps/challenges/challenge_config_utils.py
+++ b/apps/challenges/challenge_config_utils.py
@@ -2,7 +2,6 @@ import json
 import logging
 import re
 import zipfile
-from datetime import datetime
 from os.path import basename, isfile, join
 
 import requests
@@ -20,7 +19,6 @@ from challenges.models import (
     Leaderboard,
 )
 from django.core.files.base import ContentFile
-from django.utils import dateparse, timezone
 from rest_framework import status
 from yaml.scanner import ScannerError
 
@@ -38,59 +36,6 @@ from .utils import (
 )
 
 logger = logging.getLogger(__name__)
-
-_CHALLENGE_PHASE_APPROVED_LOCK_FIELDS = (
-    "name",
-    "description",
-    "leaderboard_public",
-    "start_date",
-    "end_date",
-    "is_public",
-    "codename",
-    "max_submissions_per_day",
-    "max_submissions_per_month",
-    "max_submissions",
-    "max_concurrent_submissions_allowed",
-    "submission_meta_attributes",
-    "default_submission_meta_attributes",
-    "submission_artifact_retention_policy",
-    "is_submission_public",
-    "annotations_uploaded_using_cli",
-    "is_restricted_to_select_one_submission",
-    "allowed_submission_file_types",
-    "allowed_email_ids",
-    "disable_logs",
-    "is_submission_paused",
-    "environment_image",
-    "is_partial_submission_evaluation_enabled",
-)
-
-_CHALLENGE_PHASE_DATE_LOCK_FIELDS = frozenset({"start_date", "end_date"})
-
-
-def _parse_lock_datetime(value):
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        dt = value
-    elif isinstance(value, str):
-        stripped = value.strip()
-        dt = dateparse.parse_datetime(stripped)
-        if dt is None:
-            dt = dateparse.parse_datetime(stripped.replace(" ", "T", 1))
-    else:
-        return value
-    if timezone.is_naive(dt):
-        dt = timezone.make_aware(dt, timezone.utc)
-    return dt.astimezone(timezone.utc).replace(microsecond=0)
-
-
-def _normalize_lock_field_value(field, value):
-    if field in _CHALLENGE_PHASE_DATE_LOCK_FIELDS:
-        return _parse_lock_datetime(value)
-    if field == "description" and isinstance(value, str):
-        return value.rstrip()
-    return value
 
 
 def write_file(output_path, mode, file_content):
@@ -406,10 +351,6 @@ error_message_dict = {
         "ERROR: Dataset split {} cannot be changed after the challenge is approved by an admin. "
         "Revert the dataset split block to match the approved configuration or contact support."
     ),
-    "locked_challenge_phase_modified": (
-        "ERROR: Challenge phase {} cannot be changed after the challenge is approved by an admin. "
-        "Revert the phase block to match the approved configuration or contact support."
-    ),
     "locked_challenge_phase_split_modified": (
         "ERROR: Challenge phase split (leaderboard_id: {}, challenge_phase_id: {}, dataset_split_id: {}) "
         "cannot be changed after the challenge is approved by an admin. Revert visibility / ordering "
@@ -514,13 +455,6 @@ class ValidateChallengeConfigUtil:
     def _stable_json(value):
         return json.dumps(value, sort_keys=True, default=str)
 
-    def _lock_field_values_equal(self, field, db_value, yaml_value):
-        norm_db = _normalize_lock_field_value(field, db_value)
-        norm_yaml = _normalize_lock_field_value(field, yaml_value)
-        if isinstance(norm_db, datetime) and isinstance(norm_yaml, datetime):
-            return norm_db == norm_yaml
-        return self._stable_json(norm_db) == self._stable_json(norm_yaml)
-
     def _locked_leaderboard_modified_message(self, data):
         lb = Leaderboard.objects.filter(
             config_id=int(data["id"]),
@@ -552,32 +486,6 @@ class ValidateChallengeConfigUtil:
             return self.error_messages_dict[
                 "locked_dataset_split_modified"
             ].format(split["id"])
-        return None
-
-    def _locked_challenge_phase_modified_message(self, data):
-        phase = ChallengePhase.objects.filter(
-            challenge_id=self.current_challenge.pk,
-            config_id=int(data["id"]),
-        ).first()
-        if phase is None:
-            return None
-        for field in _CHALLENGE_PHASE_APPROVED_LOCK_FIELDS:
-            if field not in data:
-                continue
-            if not self._lock_field_values_equal(
-                field, getattr(phase, field), data.get(field)
-            ):
-                return self.error_messages_dict[
-                    "locked_challenge_phase_modified"
-                ].format(data["id"])
-        yaml_ann = data.get("test_annotation_file")
-        db_ann_name = None
-        if phase.test_annotation:
-            db_ann_name = basename(phase.test_annotation.name)
-        if yaml_ann != db_ann_name:
-            return self.error_messages_dict[
-                "locked_challenge_phase_modified"
-            ].format(data["id"])
         return None
 
     def _locked_challenge_phase_split_modified_message(self, data):
@@ -1070,16 +978,6 @@ class ValidateChallengeConfigUtil:
                 ].format(data["id"], serializer_error)
                 self.error_messages.append(message)
             else:
-                if (
-                    self._approved_config_locked()
-                    and current_phase_config_ids
-                    and int(data["id"]) in current_phase_config_ids
-                ):
-                    locked_msg = self._locked_challenge_phase_modified_message(
-                        data
-                    )
-                    if locked_msg:
-                        self.error_messages.append(locked_msg)
                 self.phase_ids.append(data["id"])
 
         for current_challenge_phase_id in current_phase_config_ids:

--- a/tests/unit/challenges/test_challenge_config_utils.py
+++ b/tests/unit/challenges/test_challenge_config_utils.py
@@ -1551,8 +1551,8 @@ class TestValidateChallengeConfigUtil(unittest.TestCase):
 @override_settings(MEDIA_ROOT="/tmp/evalai-lock-coverage")
 class TestApprovedConfigLockMessageCoverage(TestCase):
     """
-    Cover _locked_* helpers and _stable_json for Codecov on post-approval
-    immutability checks (real ORM queries, no mocks of the methods under test).
+    Cover structural _locked_* helpers and _stable_json for Codecov on
+    post-approval immutability checks (leaderboard, dataset split, phase split).
     """
 
     @staticmethod
@@ -1625,9 +1625,6 @@ class TestApprovedConfigLockMessageCoverage(TestCase):
             is_leaderboard_order_descending=True,
         )
         self.phase.refresh_from_db()
-        self.phase_annotation_basename = basename(
-            self.phase.test_annotation.name
-        )
         self.util = self._bare_util(self.challenge)
 
     def test_stable_json(self):
@@ -1689,90 +1686,6 @@ class TestApprovedConfigLockMessageCoverage(TestCase):
             }
         )
         self.assertIsNone(msg)
-
-    def test_locked_challenge_phase_detects_name_change(self):
-        msg = self.util._locked_challenge_phase_modified_message(
-            {"id": 1, "name": "Renamed"}
-        )
-        self.assertIsNotNone(msg)
-
-    def test_locked_challenge_phase_none_when_consistent(self):
-        msg = self.util._locked_challenge_phase_modified_message(
-            {
-                "id": 1,
-                "name": "Phase 1",
-                "test_annotation_file": self.phase_annotation_basename,
-            }
-        )
-        self.assertIsNone(msg)
-
-    def test_locked_challenge_phase_accepts_yaml_date_format(self):
-        phase_start = timezone.make_aware(
-            datetime(2019, 1, 19, 0, 0, 0), timezone.utc
-        )
-        phase_end = timezone.make_aware(
-            datetime(2019, 1, 20, 0, 0, 0), timezone.utc
-        )
-        self.phase.start_date = phase_start
-        self.phase.end_date = phase_end
-        self.phase.save()
-
-        msg = self.util._locked_challenge_phase_modified_message(
-            {
-                "id": 1,
-                "name": "Phase 1",
-                "start_date": "2019-01-19 00:00:00",
-                "end_date": "2019-01-20 00:00:00",
-                "test_annotation_file": self.phase_annotation_basename,
-            }
-        )
-        self.assertIsNone(msg)
-
-    def test_locked_challenge_phase_accepts_iso_date_format(self):
-        phase_start = timezone.make_aware(
-            datetime(2019, 1, 19, 0, 0, 0), timezone.utc
-        )
-        phase_end = timezone.make_aware(
-            datetime(2019, 1, 20, 0, 0, 0), timezone.utc
-        )
-        self.phase.start_date = phase_start
-        self.phase.end_date = phase_end
-        self.phase.save()
-
-        msg = self.util._locked_challenge_phase_modified_message(
-            {
-                "id": 1,
-                "name": "Phase 1",
-                "start_date": "2019-01-19T00:00:00Z",
-                "end_date": "2019-01-20T00:00:00Z",
-                "test_annotation_file": self.phase_annotation_basename,
-            }
-        )
-        self.assertIsNone(msg)
-
-    def test_locked_challenge_phase_accepts_description_trailing_newline(self):
-        self.phase.description = "<p>hello</p>"
-        self.phase.save()
-
-        msg = self.util._locked_challenge_phase_modified_message(
-            {
-                "id": 1,
-                "name": "Phase 1",
-                "description": "<p>hello</p>\n",
-                "test_annotation_file": self.phase_annotation_basename,
-            }
-        )
-        self.assertIsNone(msg)
-
-    def test_locked_challenge_phase_detects_annotation_reference_change(self):
-        msg = self.util._locked_challenge_phase_modified_message(
-            {
-                "id": 1,
-                "name": "Phase 1",
-                "test_annotation_file": "nonexistent_annotation.txt",
-            }
-        )
-        self.assertIsNotNone(msg)
 
     def test_locked_challenge_phase_split_visibility_change(self):
         msg = self.util._locked_challenge_phase_split_modified_message(
@@ -2022,7 +1935,9 @@ class TestApprovedValidateMethodsRealLockIntegration(TestCase):
     @mockpatch(
         "challenges.challenge_config_utils.ChallengePhaseCreateSerializer"
     )
-    def test_validate_challenge_phases_real_lock_error(self, mock_cps):
+    def test_validate_challenge_phases_allows_changes_when_approved(
+        self, mock_cps
+    ):
         mock_cps.return_value.is_valid.return_value = True
         self.phase.refresh_from_db()
         self.util.yaml_file_data = {
@@ -2032,6 +1947,7 @@ class TestApprovedValidateMethodsRealLockIntegration(TestCase):
                     "codename": "pv1",
                     "name": "Renamed Phase",
                     "description": self.phase_desc_html,
+                    "allowed_submission_file_types": ".json",
                     "start_date": self.phase.start_date,
                     "end_date": self.phase.end_date,
                     "max_submissions": 100,
@@ -2041,9 +1957,7 @@ class TestApprovedValidateMethodsRealLockIntegration(TestCase):
             ]
         }
         self.util.validate_challenge_phases([1])
-        self.assertTrue(
-            any("approved by an admin" in m for m in self.util.error_messages)
-        )
+        self.assertEqual(self.util.error_messages, [])
 
     @mockpatch(
         "challenges.challenge_config_utils.ZipChallengePhaseSplitSerializer"

--- a/tests/unit/challenges/test_challenge_config_utils.py
+++ b/tests/unit/challenges/test_challenge_config_utils.py
@@ -4,8 +4,8 @@ import tempfile
 import unittest
 import uuid
 import zipfile
-from datetime import datetime, timedelta
-from os.path import basename, join
+from datetime import timedelta
+from os.path import join
 from unittest.mock import Mock
 from unittest.mock import patch as mockpatch
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After admin approval, GitHub Actions challenge config sync was blocking updates to **all** existing challenge phase fields (description, submission format, limits, etc.). This change keeps post-approval immutability only for evaluation **structure**:

- **Still locked** (unchanged): leaderboards, dataset splits, challenge phase splits
- **Now editable** via YAML/GitHub Actions: challenge phase fields (description, `allowed_submission_file_types`, `submission_meta_attributes`, dates, limits, etc.)

This addresses host workflows (e.g. updating overview/test-set links and submission format after approval) without allowing changes to leaderboard schema or split wiring.

## Changes

- Removed `_CHALLENGE_PHASE_APPROVED_LOCK_FIELDS` and `_locked_challenge_phase_modified_message()` from `challenge_config_utils.py`
- Removed the approved-phase check inside `validate_challenge_phases()`
- Left `_locked_leaderboard_modified_message`, `_locked_dataset_split_modified_message`, and `_locked_challenge_phase_split_modified_message` unchanged
- Updated unit tests to reflect the new policy

## Test plan

- [ ] `pytest tests/unit/challenges/test_challenge_config_utils.py::TestApprovedConfigLockMessageCoverage -q`
- [ ] `pytest tests/unit/challenges/test_challenge_config_utils.py::TestApprovedValidateMethodsRealLockIntegration -q`
- [ ] Push to an approved challenge's `challenge` branch with phase description / `allowed_submission_file_types` changes and confirm GitHub Actions passes
- [ ] Confirm leaderboard schema or phase-split visibility changes still fail validation after approval
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://cvmlp.slack.com/archives/C0B4U4Y62E6/p1782507016951829?thread_ts=1782507016.951829&cid=C0B4U4Y62E6)

<div><a href="https://cursor.com/agents/bc-fb5c971d-546b-5143-b5d5-af7f4b8d874a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb5c971d-546b-5143-b5d5-af7f4b8d874a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Approved challenge phases can now be edited without triggering validation errors for direct phase-field changes.
  * YAML validation no longer locks challenge phase fields after admin approval, while existing approval-related protections for other change types remain enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->