### PR TITLE
Fix CI deployment by using placeholder env file during image build

### DIFF
--- a/scripts/deployment/push.sh
+++ b/scripts/deployment/push.sh
@@ -33,11 +33,18 @@ build_and_push_images() {
         "./docker/prod/nodejs/nginx_${deployment_environment_name}.conf"
     echo "Pulled SSL certificates and nginx configuration successfully."
 
-    echo "Pulling environment variables file..."
-    aws s3 cp \
-        "s3://cloudcv-secrets/evalai/${deployment_environment_name}/docker_${deployment_environment_name}.env" \
-        "./docker/prod/docker_${deployment_environment_name}.env"
-    echo "Environment variables file downloaded successfully."
+    # Real secrets are pulled on the deployment instance (deploy.sh auto_deploy).
+    # CI only needs a placeholder so docker compose config/build can resolve env_file.
+    local environment_file_path="./docker/prod/docker_${deployment_environment_name}.env"
+    local environment_file_example_path="./docker/prod/docker_${deployment_environment_name}.env.example"
+    if [[ ! -f "${environment_file_path}" ]]; then
+        if [[ ! -f "${environment_file_example_path}" ]]; then
+            echo "Missing placeholder env file: ${environment_file_example_path}"
+            exit 1
+        fi
+        cp "${environment_file_example_path}" "${environment_file_path}"
+        echo "Using placeholder environment file for image build (secrets are fetched on the deployment instance)."
+    fi
 
     if [[ "${dry_run_deployment}" == "true" ]]; then
         echo "Dry-run mode enabled. Validating Docker Compose configuration only."


### PR DESCRIPTION
## Summary
- Stop downloading `docker_*.env` from S3 in `push.sh` during CI image builds, which fails with 403 because the GitHub OIDC role cannot read that object.
- Copy the checked-in `docker_*.env.example` as a placeholder so `docker compose config` / `build` can resolve `env_file` paths without real secrets.
- Real environment secrets continue to be fetched on the deployment instance in `deploy.sh auto_deploy` before `docker compose pull` / `up`.

## Test plan
- [ ] Merge and run the staging/production deployment workflow on `master`
- [ ] Confirm `push.sh` completes image build and ECR push without S3 403 on the env file
- [ ] Confirm `deploy.sh auto_deploy` still downloads `docker_*.env` from S3 on the instance and services start with correct configuration


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment image build/push setup to use a local environment file placeholder instead of downloading one during the process.
  * If the expected environment file is missing, the workflow now creates it from a template and stops early when no template is available.
  * Dry-run checks and the Docker build/push steps continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->