### PR TITLE
Run migrations before starting django on deploy.

### DIFF
--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -171,9 +171,11 @@ if [[ "\${DRY_RUN_DEPLOYMENT}" == "true" ]]; then
 fi
 
 docker compose -f "docker-compose-\${TARGET_ENVIRONMENT}.yml" pull django nodejs celery memcached
-docker compose -f "docker-compose-\${TARGET_ENVIRONMENT}.yml" up -d --force-recreate --remove-orphans django nodejs celery memcached
+# Run migrations before starting django. container-start.sh also calls migrate on
+# startup; running both concurrently races on CREATE TABLE (pg_type_typname_nsp_index).
 docker compose -f "docker-compose-\${TARGET_ENVIRONMENT}.yml" run --rm \
   django sh -c "python manage.py migrate --noinput && python manage.py refresh_worker_task_definitions --commit-id \${COMMIT_ID}"
+docker compose -f "docker-compose-\${TARGET_ENVIRONMENT}.yml" up -d --force-recreate --remove-orphans django nodejs celery memcached
 ENDSSH
 }
 


### PR DESCRIPTION
Starting Django and Docker Compose, running migrate concurrently races on CREATE TABLE for new apps (e.g., Scout), causing CI to fail even when the service container migrates successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment startup order so database migrations and worker task updates run before application containers start, reducing the chance of deployment-related startup issues.
  * Deployments now recreate services more reliably after the setup step, helping ensure the latest configuration is applied.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->