### PR TITLE
Backend: Add password reset rate limiting to prevent email flooding

### DIFF
--- a/apps/accounts/throttles.py
+++ b/apps/accounts/throttles.py
@@ -3,14 +3,18 @@ from django.core.cache import caches
 from rest_framework.throttling import SimpleRateThrottle
 
 
-class ResendEmailThrottle(SimpleRateThrottle):
+class _ThrottlingCacheMixin:
+    """Use a dedicated cache backend in dev/test for reliable throttle tests."""
+
+    if (settings.DEBUG is True) or (settings.TEST is True):
+        cache = caches["throttling"]
+
+
+class ResendEmailThrottle(_ThrottlingCacheMixin, SimpleRateThrottle):
     """
     Used to limit the requests to /accounts/user/resend_email_verification/
     to 3/hour.
     """
-
-    if (settings.DEBUG is True) or (settings.TEST is True):
-        cache = caches["throttling"]
 
     scope = "resend_email"
 
@@ -21,3 +25,31 @@ class ResendEmailThrottle(SimpleRateThrottle):
         else:
             ident = self.get_ident(request)
         return self.cache_format % {"scope": self.scope, "ident": ident}
+
+
+class PasswordResetEmailThrottle(_ThrottlingCacheMixin, SimpleRateThrottle):
+    """
+    Limit password reset requests to 3/hour per target email address.
+    """
+
+    scope = "password_reset_email"
+
+    def get_cache_key(self, request, view):
+        email = (request.data.get("email") or "").strip().lower()
+        if not email:
+            return None
+        return self.cache_format % {"scope": self.scope, "ident": email}
+
+
+class PasswordResetIPThrottle(_ThrottlingCacheMixin, SimpleRateThrottle):
+    """
+    Limit password reset requests to 10/hour per client IP address.
+    """
+
+    scope = "password_reset_ip"
+
+    def get_cache_key(self, request, view):
+        return self.cache_format % {
+            "scope": self.scope,
+            "ident": self.get_ident(request),
+        }

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -44,7 +44,7 @@ class SafePasswordResetView(PasswordResetView):
     """Password reset view that returns a generic response to prevent
     email enumeration."""
 
-    throttle_classes = [PasswordResetEmailThrottle, PasswordResetIPThrottle]
+    throttle_classes = (PasswordResetEmailThrottle, PasswordResetIPThrottle)
 
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -25,7 +25,11 @@ from .authentication import ExpiringTokenAuthentication
 from .models import JwtToken
 from .permissions import HasVerifiedEmail
 from .serializers import JwtTokenSerializer, UpdateEmailSerializer
-from .throttles import ResendEmailThrottle
+from .throttles import (
+    PasswordResetEmailThrottle,
+    PasswordResetIPThrottle,
+    ResendEmailThrottle,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +43,8 @@ PASSWORD_RESET_GENERIC_MESSAGE = (
 class SafePasswordResetView(PasswordResetView):
     """Password reset view that returns a generic response to prevent
     email enumeration."""
+
+    throttle_classes = [PasswordResetEmailThrottle, PasswordResetIPThrottle]
 
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)

--- a/settings/common.py
+++ b/settings/common.py
@@ -183,6 +183,8 @@ REST_FRAMEWORK = {
         "anon": "100/minute",
         "user": "60/minute",
         "resend_email": "3/hour",
+        "password_reset_email": "3/hour",
+        "password_reset_ip": "10/hour",
     },
     "DEFAULT_RENDERER_CLASSES": ("rest_framework.renderers.JSONRenderer",),
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",

--- a/tests/unit/accounts/test_throttles.py
+++ b/tests/unit/accounts/test_throttles.py
@@ -1,6 +1,10 @@
 from unittest.mock import MagicMock
 
-from accounts.throttles import ResendEmailThrottle
+from accounts.throttles import (
+    PasswordResetEmailThrottle,
+    PasswordResetIPThrottle,
+    ResendEmailThrottle,
+)
 from django.test import TestCase
 
 
@@ -28,3 +32,36 @@ class TestResendEmailThrottle(TestCase):
 
         self.assertIn("throttle_resend_email", cache_key)
         self.assertIn("1", cache_key)
+
+
+class TestPasswordResetEmailThrottle(TestCase):
+    def test_get_cache_key_normalizes_email(self):
+        throttle = PasswordResetEmailThrottle()
+        request = MagicMock()
+        request.data = {"email": "  User@Example.COM  "}
+
+        cache_key = throttle.get_cache_key(request, MagicMock())
+
+        self.assertIn("throttle_password_reset_email", cache_key)
+        self.assertIn("user@example.com", cache_key)
+
+    def test_get_cache_key_returns_none_without_email(self):
+        throttle = PasswordResetEmailThrottle()
+        request = MagicMock()
+        request.data = {}
+
+        cache_key = throttle.get_cache_key(request, MagicMock())
+
+        self.assertIsNone(cache_key)
+
+
+class TestPasswordResetIPThrottle(TestCase):
+    def test_get_cache_key_uses_client_ip(self):
+        throttle = PasswordResetIPThrottle()
+        request = MagicMock()
+        request.META = {"REMOTE_ADDR": "10.0.0.1"}
+
+        cache_key = throttle.get_cache_key(request, MagicMock())
+
+        self.assertIn("throttle_password_reset_ip", cache_key)
+        self.assertIn("10.0.0.1", cache_key)

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -5,6 +5,7 @@ from accounts.models import JwtToken
 from accounts.views import PASSWORD_RESET_GENERIC_MESSAGE
 from allauth.account.models import EmailAddress
 from django.contrib.auth.models import User
+from django.core.cache import caches
 from django.db import IntegrityError
 from django.urls import reverse_lazy
 from rest_framework import status
@@ -365,6 +366,10 @@ class PasswordResetViewTest(APITestCase):
             primary=True,
             verified=True,
         )
+        caches["throttling"].clear()
+
+    def tearDown(self):
+        caches["throttling"].clear()
 
     @patch("django.contrib.auth.forms.PasswordResetForm.save")
     def test_password_reset_verified_active_user_success(self, mock_save):
@@ -464,7 +469,9 @@ class PasswordResetViewTest(APITestCase):
         self.assertEqual(mock_save.call_count, 3)
 
     @patch("django.contrib.auth.forms.PasswordResetForm.save")
-    def test_password_reset_email_throttle_is_case_insensitive(self, mock_save):
+    def test_password_reset_email_throttle_is_case_insensitive(
+        self, mock_save
+    ):
         emails = [
             "verified@example.com",
             "VERIFIED@EXAMPLE.COM",

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -443,3 +443,42 @@ class PasswordResetViewTest(APITestCase):
             response.data["detail"], PASSWORD_RESET_GENERIC_MESSAGE
         )
         mock_save.assert_not_called()
+
+    @patch("django.contrib.auth.forms.PasswordResetForm.save")
+    def test_password_reset_throttles_by_email(self, mock_save):
+        for _ in range(3):
+            response = self.client.post(
+                self.url,
+                {"email": self.verified_user.email},
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.client.post(
+            self.url,
+            {"email": self.verified_user.email},
+            format="json",
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_429_TOO_MANY_REQUESTS
+        )
+        self.assertEqual(mock_save.call_count, 3)
+
+    @patch("django.contrib.auth.forms.PasswordResetForm.save")
+    def test_password_reset_email_throttle_is_case_insensitive(self, mock_save):
+        emails = [
+            "verified@example.com",
+            "VERIFIED@EXAMPLE.COM",
+            "Verified@Example.com",
+        ]
+        for email in emails:
+            response = self.client.post(
+                self.url, {"email": email}, format="json"
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.client.post(
+            self.url, {"email": self.verified_user.email}, format="json"
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_429_TOO_MANY_REQUESTS
+        )
+        self.assertEqual(mock_save.call_count, 3)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the victim mailbox flooding vulnerability reported on `/auth/reset-password` by adding dedicated rate limits on the password reset API endpoint.

## Changes

- Add `PasswordResetEmailThrottle` (3/hour per target email) and `PasswordResetIPThrottle` (10/hour per client IP) in `apps/accounts/throttles.py`
- Apply both throttles on `SafePasswordResetView`, replacing the generic 100/min IP limit for this endpoint
- Add throttle rates to `REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]`
- Add unit tests for cache key generation and endpoint throttling behavior

## Why this approach

- **Per-email limit** stops an attacker from flooding a single victim's inbox regardless of how many requests they send
- **Per-IP limit** caps abuse across many target addresses from one source
- Matches the existing `ResendEmailThrottle` pattern (3/hour) already used for email verification resends

## Testing

- Added `TestPasswordResetEmailThrottle`, `TestPasswordResetIPThrottle`, and `PasswordResetViewTest.test_password_reset_throttles_by_email`
- Backend tests should be run via `./scripts/run-all-tests.sh` or the Django container pytest command in `AGENTS.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://cvmlp.slack.com/archives/C0B4U4Y62E6/p1783014231329239?thread_ts=1783014231.329239&cid=C0B4U4Y62E6)

<div><a href="https://cursor.com/agents/bc-a8218f2e-94f9-5579-9fb4-f5f12289d887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8218f2e-94f9-5579-9fb4-f5f12289d887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rate limiting for password reset requests, with separate limits for email address and client IP to reduce abuse.
  * Password reset throttling is now enforced using configured per-hour caps for email and IP.

* **Bug Fixes**
  * Email-based throttling now normalizes inputs so capitalization and extra spaces don’t bypass limits.
  * Requests with no email provided are no longer counted toward the email-based limit.

* **Tests**
  * Added unit coverage for password reset throttling, including normalization behavior and correct 429 responses after the limit is reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->