### PR TITLE
Security: Codify clickjacking protection headers in nginx and Django

### DIFF
--- a/docker/prod/nodejs/nginx_production.conf
+++ b/docker/prod/nodejs/nginx_production.conf
@@ -38,6 +38,15 @@ server {
   gzip_comp_level   9;
   root /code/frontend;
 
+  # Security headers (codified from production deployment)
+  add_header X-Frame-Options "DENY" always;
+  add_header Content-Security-Policy "frame-ancestors 'none'" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header X-XSS-Protection "1; mode=block" always;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+  add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+
   location / {
     try_files $uri $uri/ /index.html =404;
   }

--- a/docker/prod/nodejs/nginx_staging.conf
+++ b/docker/prod/nodejs/nginx_staging.conf
@@ -38,6 +38,15 @@ server {
   gzip_comp_level   9;
   root /code/frontend;
 
+  # Security headers (codified from production deployment)
+  add_header X-Frame-Options "DENY" always;
+  add_header Content-Security-Policy "frame-ancestors 'none'" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header X-XSS-Protection "1; mode=block" always;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+  add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+
   location / {
     try_files $uri $uri/ /index.html =404;
   }

--- a/settings/common.py
+++ b/settings/common.py
@@ -94,6 +94,8 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
+X_FRAME_OPTIONS = "DENY"
+
 ROOT_URLCONF = "evalai.urls"
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Codifies the anti-clickjacking and related security headers that are already deployed on production/staging `eval.ai` into the repository, so protection does not depend on out-of-band server configuration.

This addresses the reported clickjacking concern on `/auth/login` by ensuring `X-Frame-Options: DENY` and `Content-Security-Policy: frame-ancestors 'none'` are set in version-controlled nginx configs for both production and staging.

## Changes

- **`docker/prod/nodejs/nginx_production.conf`** — Add security response headers to the HTTPS server block:
  - `X-Frame-Options: DENY`
  - `Content-Security-Policy: frame-ancestors 'none'`
  - `X-Content-Type-Options: nosniff`
  - `X-XSS-Protection: 1; mode=block`
  - `Strict-Transport-Security: max-age=31536000; includeSubDomains`
  - `Referrer-Policy: strict-origin-when-cross-origin`
  - `Permissions-Policy: camera=(), microphone=(), geolocation=()`
- **`docker/prod/nodejs/nginx_staging.conf`** — Same headers as production.
- **`settings/common.py`** — Set `X_FRAME_OPTIONS = "DENY"` so Django API responses align with nginx (avoids conflicting `SAMEORIGIN` from the default).

## Context

Live production already returns these headers (verified via `curl -sI https://eval.ai/auth/login`), but they were not present in the committed nginx configs. This PR makes the deployment reproducible and documents the intended security posture in code.

## Testing

- [ ] Deploy to staging and verify headers with `curl -sI https://staging.eval.ai/auth/login`
- [ ] Confirm the clickjacking PoC iframe is blocked in a browser
- [ ] Confirm login and normal navigation still work

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://cvmlp.slack.com/archives/C0B4U4Y62E6/p1783096932913709?thread_ts=1783096932.913709&cid=C0B4U4Y62E6)

<div><a href="https://cursor.com/agents/bc-bd77ffa5-f224-5ece-b3c0-8d9e3e59aa57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd77ffa5-f224-5ece-b3c0-8d9e3e59aa57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added stronger browser security protections across production and staging, including framing restrictions, content security, clickjacking protection, transport security, and safer referrer and permissions policies.
  * Updated app-wide settings to deny iframe embedding by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->