### PR TITLE
Fix worker Docker builds for dnspython and py3.9 numpy pin

### DIFF
--- a/docker/dev/worker_py3_7/Dockerfile
+++ b/docker/dev/worker_py3_7/Dockerfile
@@ -49,7 +49,9 @@ WORKDIR /code
 COPY requirements/ /code/requirements/
 
 # PyJWT>=2.10 requires Python 3.9+; pin a 3.7-compatible release for worker builds.
-RUN sed -i 's/^PyJWT==.*/PyJWT==2.8.0/' /code/requirements/common.txt
+# dnspython>=2.4 requires Python 3.8+; pin a 3.7-compatible release for worker builds.
+RUN sed -i 's/^PyJWT==.*/PyJWT==2.8.0/' /code/requirements/common.txt && \
+    sed -i 's/^dnspython==.*/dnspython==2.3.0/' /code/requirements/common.txt
 
 # Install Python dependencies with BuildKit cache mount
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/docker/prod/worker_py3_7/Dockerfile
+++ b/docker/prod/worker_py3_7/Dockerfile
@@ -65,7 +65,9 @@ WORKDIR /code
 COPY requirements/ /code/requirements/
 
 # PyJWT>=2.10 requires Python 3.9+; pin a 3.7-compatible release for worker builds.
-RUN sed -i 's/^PyJWT==.*/PyJWT==2.8.0/' /code/requirements/common.txt
+# dnspython>=2.4 requires Python 3.8+; pin a 3.7-compatible release for worker builds.
+RUN sed -i 's/^PyJWT==.*/PyJWT==2.8.0/' /code/requirements/common.txt && \
+    sed -i 's/^dnspython==.*/dnspython==2.3.0/' /code/requirements/common.txt
 
 # Install Python dependencies with BuildKit cache mount
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/docker/prod/worker_py3_9/Dockerfile
+++ b/docker/prod/worker_py3_9/Dockerfile
@@ -70,7 +70,7 @@ COPY requirements/ /code/requirements/
 # Note: BuildKit cache mount persists outside container, but we clean internal cache for final image size
 # Install prerequisite packages first (needed for compiling native extensions)
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir --no-compile -U cffi service_identity cython==0.29.36 numpy==1.18.1 && \
+    pip install --no-cache-dir --no-compile -U cffi service_identity cython==0.29.36 && \
     pip install --no-cache-dir --no-compile -r requirements/prod.txt && \
     pip install --no-cache-dir --no-compile -r requirements/worker_py3_9.txt
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Docker image build failures for `worker_py3_7`, `remote-worker`, and `worker_py3_9` during staging/production packaging.

## Problem

1. **`dnspython==2.6.1` on Python 3.7 workers** — `dnspython` 2.4+ requires Python 3.8+. The `worker_py3_7` and `remote-worker` images (both built from the py3.7 Dockerfile) fail with:
   ```
   ERROR: No matching distribution found for dnspython==2.6.1
   ```
   Available versions on Python 3.7 stop at 2.3.0.

2. **`numpy==1.18.1` pre-install on prod `worker_py3_9`** — The production py3.9 worker Dockerfile pre-installs `numpy==1.18.1` before `worker_py3_9.txt`, which pins `numpy==1.26.4` and pulls in `scipy==1.11.4` / `scikit-learn==1.4.2`. The stale numpy pin causes `metadata-generation-failed` during pip resolution. The dev py3.9 Dockerfile does not pre-install numpy and avoids this issue.

## Solution

- Override `dnspython` to `2.3.0` in py3.7 worker Docker builds, following the same `sed` pattern already used for `PyJWT` version overrides.
- Remove the `numpy==1.18.1` pre-install from the prod `worker_py3_9` Dockerfile; `cython==0.29.36` remains as the compile prerequisite.

## Notes

- Django/celery (Python 3.9) continue to use `dnspython==2.6.1` from `requirements/common.txt` for the CVE-2023-29483 fix.
- Python 3.7 workers only need `dnspython` transitively via `prod.txt`; they do not run account email validation, but the dependency must install cleanly.
- `dns.resolver.resolve()` used in the Django app is available in dnspython 2.3.0.

## Testing

- [ ] CI worker image builds (`worker_py3_7`, `worker_py3_8`, `worker_py3_9`)
- [ ] Staging/production `docker compose build` succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28aace1a-e5f1-4c2c-bec3-905bbb00942d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28aace1a-e5f1-4c2c-bec3-905bbb00942d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python worker build reliability by updating dependency version handling for compatibility.
  * Ensured older Python environments continue to install supported versions of key packages.
  * Removed an overly strict early version pin so package resolution can use the most appropriate compatible release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->