### PR TITLE
Fix submission worker Celery queue for S3 retention tagging

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -161,7 +161,6 @@ COMMON_SETTINGS_DICT = {
     "EMAIL_PORT": settings.EMAIL_PORT,
     "EMAIL_USE_TLS": settings.EMAIL_USE_TLS,
     "MEMCACHED_LOCATION": os.environ.get("MEMCACHED_LOCATION", None),
-    "CELERY_QUEUE_NAME": os.environ.get("CELERY_QUEUE_NAME"),
     "RDS_DB_NAME": settings.DATABASES["default"]["NAME"],
     "RDS_HOSTNAME": settings.DATABASES["default"]["HOST"],
     "RDS_PASSWORD": settings.DATABASES["default"]["PASSWORD"],
@@ -312,6 +311,17 @@ def build_task_definition_dict(
     """
     from .utils import get_aws_credentials_for_challenge
 
+    celery_queue_name = os.environ.get("CELERY_QUEUE_NAME")
+    if not celery_queue_name:
+        message = (
+            "CELERY_QUEUE_NAME environment variable must be set to build "
+            "worker task definitions."
+        )
+        return None, {
+            "Error": message,
+            "ResponseMetadata": {"HTTPStatusCode": HTTPStatus.BAD_REQUEST},
+        }
+
     container_name = f"worker_{queue_name}"
     code_upload_container_name = f"code_upload_worker_{queue_name}"
     worker_cpu_cores = (
@@ -329,6 +339,10 @@ def build_task_definition_dict(
     updated_settings = image_settings or get_image_settings_for_challenge(
         challenge
     )
+    updated_settings = {
+        **updated_settings,
+        "CELERY_QUEUE_NAME": celery_queue_name,
+    }
     challenge_aws_keys = get_aws_credentials_for_challenge(challenge.pk)
 
     if challenge.is_docker_based:

--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -161,6 +161,7 @@ COMMON_SETTINGS_DICT = {
     "EMAIL_PORT": settings.EMAIL_PORT,
     "EMAIL_USE_TLS": settings.EMAIL_USE_TLS,
     "MEMCACHED_LOCATION": os.environ.get("MEMCACHED_LOCATION", None),
+    "CELERY_QUEUE_NAME": os.environ.get("CELERY_QUEUE_NAME"),
     "RDS_DB_NAME": settings.DATABASES["default"]["NAME"],
     "RDS_HOSTNAME": settings.DATABASES["default"]["HOST"],
     "RDS_PASSWORD": settings.DATABASES["default"]["PASSWORD"],

--- a/apps/challenges/task_definitions.py
+++ b/apps/challenges/task_definitions.py
@@ -38,6 +38,10 @@ task_definition = """
                   "value": "{queue_name}"
                 }},
                 {{
+                  "name": "CELERY_QUEUE_NAME",
+                  "value": "{CELERY_QUEUE_NAME}"
+                }},
+                {{
                   "name": "DJANGO_SERVER",
                   "value": "{DJANGO_SERVER}"
                 }},
@@ -278,6 +282,10 @@ container_definition_submission_worker = """
         {{
             "name": "CHALLENGE_QUEUE",
             "value": "{queue_name}"
+        }},
+        {{
+            "name": "CELERY_QUEUE_NAME",
+            "value": "{CELERY_QUEUE_NAME}"
         }},
         {{
             "name": "DJANGO_SERVER",

--- a/apps/jobs/s3_retention.py
+++ b/apps/jobs/s3_retention.py
@@ -127,6 +127,17 @@ def should_tag_submission_artifacts(submission):
     return True
 
 
+def get_celery_queue_for_retention_tagging():
+    """Return the Celery queue name when async tagging is available."""
+    celery_queue = os.environ.get("CELERY_QUEUE_NAME")
+    if celery_queue:
+        return celery_queue
+
+    from evalai.celery import app
+
+    return app.conf.task_default_queue or None
+
+
 def enqueue_submission_artifact_retention_tagging(
     submission, artifact_paths=None
 ):
@@ -140,11 +151,17 @@ def enqueue_submission_artifact_retention_tagging(
     if not artifact_paths or not should_tag_submission_artifacts(submission):
         return
 
-    from jobs.tasks import tag_submission_artifact_retention_tags
+    celery_queue = get_celery_queue_for_retention_tagging()
+    if celery_queue:
+        from jobs.tasks import tag_submission_artifact_retention_tags
 
-    tag_submission_artifact_retention_tags.delay(
-        submission.pk, list(artifact_paths)
-    )
+        tag_submission_artifact_retention_tags.apply_async(
+            (submission.pk, list(artifact_paths)),
+            queue=celery_queue,
+        )
+        return
+
+    tag_submission_artifacts_for_retention(submission, artifact_paths)
 
 
 def tag_submission_artifacts_for_retention(submission, artifact_paths=None):

--- a/apps/jobs/s3_retention.py
+++ b/apps/jobs/s3_retention.py
@@ -155,11 +155,18 @@ def enqueue_submission_artifact_retention_tagging(
     if celery_queue:
         from jobs.tasks import tag_submission_artifact_retention_tags
 
-        tag_submission_artifact_retention_tags.apply_async(
-            (submission.pk, list(artifact_paths)),
-            queue=celery_queue,
-        )
-        return
+        try:
+            tag_submission_artifact_retention_tags.apply_async(
+                (submission.pk, list(artifact_paths)),
+                queue=celery_queue,
+            )
+            return
+        except Exception:
+            logger.exception(
+                "Failed to enqueue retention tagging, falling back to sync: "
+                "submission_id=%s",
+                submission.pk,
+            )
 
     tag_submission_artifacts_for_retention(submission, artifact_paths)
 

--- a/evalai/celery.py
+++ b/evalai/celery.py
@@ -6,12 +6,13 @@ from django.conf import settings
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
 app = Celery(broker=settings.CELERY_BROKER_URL)
+app.config_from_object("django.conf:settings")
+
 if settings.DEBUG:
     app.conf.task_default_queue = "celery_dev"
-else:
-    app.conf.task_default_queue = os.environ.get("CELERY_QUEUE_NAME")
+elif os.environ.get("CELERY_QUEUE_NAME"):
+    app.conf.task_default_queue = os.environ["CELERY_QUEUE_NAME"]
 
-app.config_from_object("django.conf:settings")
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
 if __name__ == "__main__":

--- a/evalai/celery.py
+++ b/evalai/celery.py
@@ -8,10 +8,11 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 app = Celery(broker=settings.CELERY_BROKER_URL)
 app.config_from_object("django.conf:settings")
 
+celery_queue_name = os.environ.get("CELERY_QUEUE_NAME")
 if settings.DEBUG:
     app.conf.task_default_queue = "celery_dev"
-elif os.environ.get("CELERY_QUEUE_NAME"):
-    app.conf.task_default_queue = os.environ["CELERY_QUEUE_NAME"]
+elif celery_queue_name:
+    app.conf.task_default_queue = celery_queue_name
 
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 

--- a/tests/unit/challenges/test_aws_utils.py
+++ b/tests/unit/challenges/test_aws_utils.py
@@ -6163,6 +6163,7 @@ class TestWorkerImageHelpers(TestCase):
             )
         )
 
+    @patch.dict("os.environ", {"CELERY_QUEUE_NAME": "evalai-celery"}, clear=False)
     @patch("challenges.aws_utils.JwtToken.objects.get")
     @patch("challenges.models.ChallengeEvaluationCluster.objects.get")
     @patch("challenges.utils.get_aws_credentials_for_challenge")
@@ -6192,6 +6193,7 @@ class TestWorkerImageHelpers(TestCase):
         self.assertEqual(task_def, {"family": "queue"})
         mock_task_definition.format.assert_called_once()
 
+    @patch.dict("os.environ", {"CELERY_QUEUE_NAME": "evalai-celery"}, clear=False)
     @patch("challenges.aws_utils.JwtToken.objects.get")
     @patch("challenges.models.ChallengeEvaluationCluster.objects.get")
     @patch("challenges.utils.get_aws_credentials_for_challenge")
@@ -6229,6 +6231,7 @@ class TestWorkerImageHelpers(TestCase):
         self.assertIsNone(error)
         self.assertEqual(task_def, {"family": "queue"})
 
+    @patch.dict("os.environ", {"CELERY_QUEUE_NAME": "evalai-celery"}, clear=False)
     @patch("challenges.aws_utils.JwtToken.objects.get")
     @patch("challenges.models.ChallengeEvaluationCluster.objects.get")
     @patch("challenges.utils.get_aws_credentials_for_challenge")
@@ -6271,6 +6274,21 @@ class TestWorkerImageHelpers(TestCase):
             task_def, error = build_task_definition_dict(challenge, "queue")
         self.assertIsNone(error)
         self.assertEqual(task_def, {"family": "queue"})
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_build_task_definition_dict_requires_celery_queue_name(self):
+        challenge = MagicMock(
+            pk=1,
+            is_docker_based=False,
+            worker_cpu_cores=1024,
+            worker_memory=2048,
+            ephemeral_storage=21,
+        )
+
+        task_def, error = build_task_definition_dict(challenge, "queue")
+
+        self.assertIsNone(task_def)
+        self.assertIn("CELERY_QUEUE_NAME", error["Error"])
 
     @patch("challenges.aws_utils.get_boto3_client")
     @patch("challenges.aws_utils.refresh_task_definition_for_challenge")

--- a/tests/unit/challenges/test_aws_utils.py
+++ b/tests/unit/challenges/test_aws_utils.py
@@ -3689,6 +3689,12 @@ class TestSetupEC2(TestCase):
         )
 
 
+@pytest.fixture
+def celery_queue_env(monkeypatch):
+    monkeypatch.setenv("CELERY_QUEUE_NAME", "evalai-celery")
+
+
+@pytest.mark.usefixtures("celery_queue_env")
 class TestRegisterTaskDefByChallengePk:
     @patch("challenges.aws_utils.JwtToken.objects.get")
     @patch("challenges.models.ChallengeEvaluationCluster.objects.get")
@@ -6163,7 +6169,9 @@ class TestWorkerImageHelpers(TestCase):
             )
         )
 
-    @patch.dict("os.environ", {"CELERY_QUEUE_NAME": "evalai-celery"}, clear=False)
+    @patch.dict(
+        "os.environ", {"CELERY_QUEUE_NAME": "evalai-celery"}, clear=False
+    )
     @patch("challenges.aws_utils.JwtToken.objects.get")
     @patch("challenges.models.ChallengeEvaluationCluster.objects.get")
     @patch("challenges.utils.get_aws_credentials_for_challenge")
@@ -6193,7 +6201,9 @@ class TestWorkerImageHelpers(TestCase):
         self.assertEqual(task_def, {"family": "queue"})
         mock_task_definition.format.assert_called_once()
 
-    @patch.dict("os.environ", {"CELERY_QUEUE_NAME": "evalai-celery"}, clear=False)
+    @patch.dict(
+        "os.environ", {"CELERY_QUEUE_NAME": "evalai-celery"}, clear=False
+    )
     @patch("challenges.aws_utils.JwtToken.objects.get")
     @patch("challenges.models.ChallengeEvaluationCluster.objects.get")
     @patch("challenges.utils.get_aws_credentials_for_challenge")
@@ -6231,7 +6241,9 @@ class TestWorkerImageHelpers(TestCase):
         self.assertIsNone(error)
         self.assertEqual(task_def, {"family": "queue"})
 
-    @patch.dict("os.environ", {"CELERY_QUEUE_NAME": "evalai-celery"}, clear=False)
+    @patch.dict(
+        "os.environ", {"CELERY_QUEUE_NAME": "evalai-celery"}, clear=False
+    )
     @patch("challenges.aws_utils.JwtToken.objects.get")
     @patch("challenges.models.ChallengeEvaluationCluster.objects.get")
     @patch("challenges.utils.get_aws_credentials_for_challenge")

--- a/tests/unit/jobs/test_s3_retention.py
+++ b/tests/unit/jobs/test_s3_retention.py
@@ -135,7 +135,9 @@ class S3RetentionTestCase(TestCase):
 
         mock_client.assert_not_called()
 
-    @patch.dict("os.environ", {"CELERY_QUEUE_NAME": "evalai-celery"}, clear=False)
+    @patch.dict(
+        "os.environ", {"CELERY_QUEUE_NAME": "evalai-celery"}, clear=False
+    )
     @patch("jobs.tasks.tag_submission_artifact_retention_tags.apply_async")
     def test_enqueue_submission_artifact_retention_tagging_uses_celery(
         self, mock_apply_async
@@ -178,7 +180,9 @@ class S3RetentionTestCase(TestCase):
             [self.submission.input_file.name],
         )
 
-    @patch.dict("os.environ", {"CELERY_QUEUE_NAME": "evalai-celery"}, clear=False)
+    @patch.dict(
+        "os.environ", {"CELERY_QUEUE_NAME": "evalai-celery"}, clear=False
+    )
     def test_get_celery_queue_for_retention_tagging_prefers_env(self):
         self.assertEqual(
             "evalai-celery", get_celery_queue_for_retention_tagging()

--- a/tests/unit/jobs/test_s3_retention.py
+++ b/tests/unit/jobs/test_s3_retention.py
@@ -193,3 +193,37 @@ class S3RetentionTestCase(TestCase):
         self.assertEqual(
             "celery_dev", get_celery_queue_for_retention_tagging()
         )
+
+    @patch.dict("os.environ", {"CELERY_QUEUE_NAME": ""}, clear=True)
+    @patch("evalai.celery.app")
+    def test_get_celery_queue_for_retention_tagging_empty_env_falls_back(
+        self, mock_app
+    ):
+        mock_app.conf.task_default_queue = "celery_dev"
+        self.assertEqual(
+            "celery_dev", get_celery_queue_for_retention_tagging()
+        )
+
+    @patch("jobs.s3_retention.tag_submission_artifacts_for_retention")
+    @patch("jobs.tasks.tag_submission_artifact_retention_tags.apply_async")
+    def test_enqueue_submission_artifact_retention_tagging_falls_back_on_broker_error(
+        self, mock_apply_async, mock_tag_sync
+    ):
+        mock_apply_async.side_effect = Exception("broker unavailable")
+        with self.settings(TEST=False, DEBUG=False):
+            with patch(
+                "jobs.s3_retention.should_tag_submission_artifacts",
+                return_value=True,
+            ), patch(
+                "jobs.s3_retention.get_celery_queue_for_retention_tagging",
+                return_value="evalai-celery",
+            ):
+                enqueue_submission_artifact_retention_tagging(
+                    self.submission,
+                    [self.submission.input_file.name],
+                )
+
+        mock_tag_sync.assert_called_once_with(
+            self.submission,
+            [self.submission.input_file.name],
+        )

--- a/tests/unit/jobs/test_s3_retention.py
+++ b/tests/unit/jobs/test_s3_retention.py
@@ -11,6 +11,8 @@ from jobs.models import Submission
 from jobs.s3_retention import (
     backfill_submission_artifact_tags,
     build_submission_artifact_s3_tags,
+    enqueue_submission_artifact_retention_tagging,
+    get_celery_queue_for_retention_tagging,
     get_submission_artifact_s3_key,
     tag_submission_artifacts_for_retention,
 )
@@ -132,3 +134,62 @@ class S3RetentionTestCase(TestCase):
             )
 
         mock_client.assert_not_called()
+
+    @patch.dict("os.environ", {"CELERY_QUEUE_NAME": "evalai-celery"}, clear=False)
+    @patch("jobs.tasks.tag_submission_artifact_retention_tags.apply_async")
+    def test_enqueue_submission_artifact_retention_tagging_uses_celery(
+        self, mock_apply_async
+    ):
+        with self.settings(TEST=False, DEBUG=False):
+            with patch(
+                "jobs.s3_retention.should_tag_submission_artifacts",
+                return_value=True,
+            ):
+                enqueue_submission_artifact_retention_tagging(
+                    self.submission,
+                    [self.submission.input_file.name],
+                )
+
+        mock_apply_async.assert_called_once_with(
+            (self.submission.pk, [self.submission.input_file.name]),
+            queue="evalai-celery",
+        )
+
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("jobs.s3_retention.tag_submission_artifacts_for_retention")
+    def test_enqueue_submission_artifact_retention_tagging_falls_back_to_sync(
+        self, mock_tag_sync
+    ):
+        with self.settings(TEST=False, DEBUG=False):
+            with patch(
+                "jobs.s3_retention.should_tag_submission_artifacts",
+                return_value=True,
+            ), patch(
+                "jobs.s3_retention.get_celery_queue_for_retention_tagging",
+                return_value=None,
+            ):
+                enqueue_submission_artifact_retention_tagging(
+                    self.submission,
+                    [self.submission.input_file.name],
+                )
+
+        mock_tag_sync.assert_called_once_with(
+            self.submission,
+            [self.submission.input_file.name],
+        )
+
+    @patch.dict("os.environ", {"CELERY_QUEUE_NAME": "evalai-celery"}, clear=False)
+    def test_get_celery_queue_for_retention_tagging_prefers_env(self):
+        self.assertEqual(
+            "evalai-celery", get_celery_queue_for_retention_tagging()
+        )
+
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("evalai.celery.app")
+    def test_get_celery_queue_for_retention_tagging_uses_app_default(
+        self, mock_app
+    ):
+        mock_app.conf.task_default_queue = "celery_dev"
+        self.assertEqual(
+            "celery_dev", get_celery_queue_for_retention_tagging()
+        )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the production `AttributeError: 'NoneType' object has no attribute 'pop'` raised when submission workers call `enqueue_submission_artifact_retention_tagging()` after evaluation completes.

The S3 retention feature enqueues `tag_submission_artifact_retention_tags` via Celery, but ECS submission worker task definitions never set `CELERY_QUEUE_NAME`. That left `task_default_queue` as `None`, causing Celery 4.3's `expand_destination()` to crash when routing the task.

## Changes

1. **ECS task definitions** — Pass `CELERY_QUEUE_NAME` into submission worker containers (`task_definition` and `container_definition_submission_worker`), injected at build time with validation so unset values are never rendered as the literal string `"None"`.
2. **`evalai/celery.py`** — Configure `task_default_queue` after `config_from_object()` and only when `CELERY_QUEUE_NAME` is set (or in DEBUG).
3. **`enqueue_submission_artifact_retention_tagging()`** — Use `apply_async()` with an explicit queue when available; fall back to synchronous tagging when no queue is configured or Celery dispatch fails.
4. **Tests** — Unit coverage for Celery enqueue, sync fallback, queue resolution, missing env validation, and broker failure fallback.

## Deployment notes

- **Immediate relief:** Existing workers tag artifacts synchronously until their ECS task definitions are refreshed.
- **Long-term:** Run `refresh_worker_task_definitions` (or redeploy workers) so running containers receive `CELERY_QUEUE_NAME` and resume async tagging via Celery.

## Testing

- Added/updated unit tests in `tests/unit/jobs/test_s3_retention.py` and `tests/unit/challenges/test_aws_utils.py`.
- Full backend suite not run in this cloud agent environment (Docker unavailable); please verify in CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11703ec9-191f-40a3-aa61-d5e9e95344b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11703ec9-191f-40a3-aa61-d5e9e95344b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ECS worker task definitions now receive `CELERY_QUEUE_NAME`, and requests fail with a clear error if it isn’t set.
  * Retention-tagging tasks can now be enqueued onto the configured Celery queue when available.

* **Bug Fixes**
  * Default queue selection no longer overwrites existing configuration when `CELERY_QUEUE_NAME` is unset/empty.
  * Retention-tagging falls back to synchronous tagging when no queue is configured or async enqueueing fails.

* **Tests**
  * Added unit coverage for queue resolution, fallback behavior, and `CELERY_QUEUE_NAME` requirements for ECS task definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->