### PR TITLE
fix: clear submission type marker after submission

### DIFF
--- a/apps/challenges/models.py
+++ b/apps/challenges/models.py
@@ -5,6 +5,7 @@ from base.utils import RandomFileName, get_slug, is_model_field_changed
 from django.contrib.auth.models import User
 from django.contrib.postgres.fields import ArrayField, JSONField
 from django.core import serializers
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import signals
 from django.db.models.signals import pre_save
@@ -358,6 +359,17 @@ class Challenge(TimeStampedModel):
             return True
         return False
 
+    def save(self, *args, **kwargs):
+        if (
+            self.start_date
+            and self.end_date
+            and self.start_date >= self.end_date
+        ):
+            raise ValidationError(
+                "Challenge start date must be before end date."
+            )
+        super(Challenge, self).save(*args, **kwargs)
+
 
 @receiver(signals.post_save, sender="challenges.Challenge")
 def create_eks_cluster_or_ec2_for_challenge(
@@ -591,6 +603,48 @@ class ChallengePhase(TimeStampedModel):
         return False
 
     def save(self, *args, **kwargs):
+        challenge = self.challenge
+        if challenge:
+            if (
+                self.start_date
+                and challenge.start_date
+                and self.start_date < challenge.start_date
+            ):
+                raise ValidationError(
+                    "Phase start date must be on or after challenge start date."
+                )
+            if (
+                self.start_date
+                and challenge.end_date
+                and self.start_date >= challenge.end_date
+            ):
+                raise ValidationError(
+                    "Phase start date must be before challenge end date."
+                )
+            if (
+                self.end_date
+                and challenge.start_date
+                and self.end_date <= challenge.start_date
+            ):
+                raise ValidationError(
+                    "Phase end date must be after challenge start date."
+                )
+            if (
+                self.end_date
+                and challenge.end_date
+                and self.end_date > challenge.end_date
+            ):
+                raise ValidationError(
+                    "Phase end date must be on or before challenge end date."
+                )
+        if (
+            self.start_date
+            and self.end_date
+            and self.start_date >= self.end_date
+        ):
+            raise ValidationError(
+                "Phase start date must be before end date."
+            )
 
         # If the max_submissions_per_day is less than the
         # max_concurrent_submissions_allowed.

--- a/apps/challenges/models.py
+++ b/apps/challenges/models.py
@@ -355,7 +355,12 @@ class Challenge(TimeStampedModel):
     @property
     def is_active(self):
         """Returns if the challenge is active or not"""
-        if self.start_date < timezone.now() and self.end_date > timezone.now():
+        if (
+            self.start_date
+            and self.end_date
+            and self.start_date < timezone.now()
+            and self.end_date > timezone.now()
+        ):
             return True
         return False
 
@@ -598,7 +603,12 @@ class ChallengePhase(TimeStampedModel):
     @property
     def is_active(self):
         """Returns if the challenge is active or not"""
-        if self.start_date < timezone.now() and self.end_date > timezone.now():
+        if (
+            self.start_date
+            and self.end_date
+            and self.start_date < timezone.now()
+            and self.end_date > timezone.now()
+        ):
             return True
         return False
 

--- a/apps/challenges/serializers.py
+++ b/apps/challenges/serializers.py
@@ -39,6 +39,10 @@ class ChallengeSerializer(serializers.ModelSerializer):
     def validate(self, attrs):
         start_date = attrs.get("start_date")
         end_date = attrs.get("end_date")
+        if start_date is None and self.instance is not None:
+            start_date = self.instance.start_date
+        if end_date is None and self.instance is not None:
+            end_date = self.instance.end_date
         if start_date and end_date and start_date >= end_date:
             raise serializers.ValidationError(
                 "Challenge start date must be before end date."
@@ -160,22 +164,34 @@ class ChallengePhaseSerializer(serializers.ModelSerializer):
         start_date = attrs.get("start_date")
         end_date = attrs.get("end_date")
         challenge = attrs.get("challenge")
+        if start_date is None and self.instance is not None:
+            start_date = self.instance.start_date
+        if end_date is None and self.instance is not None:
+            end_date = self.instance.end_date
+        if challenge is None and self.instance is not None:
+            challenge = self.instance.challenge
         if challenge:
-            if start_date and challenge.start_date and start_date < challenge.start_date:
+            csd = challenge.start_date
+            ced = challenge.end_date
+            if start_date and csd and start_date < csd:
                 raise serializers.ValidationError(
-                    "Phase start date must be on or after challenge start date."
+                    "Phase start date must be on or after "
+                    "challenge start date."
                 )
-            if start_date and challenge.end_date and start_date >= challenge.end_date:
+            if start_date and ced and start_date >= ced:
                 raise serializers.ValidationError(
-                    "Phase start date must be before challenge end date."
+                    "Phase start date must be before "
+                    "challenge end date."
                 )
-            if end_date and challenge.start_date and end_date <= challenge.start_date:
+            if end_date and csd and end_date <= csd:
                 raise serializers.ValidationError(
-                    "Phase end date must be after challenge start date."
+                    "Phase end date must be after "
+                    "challenge start date."
                 )
-            if end_date and challenge.end_date and end_date > challenge.end_date:
+            if end_date and ced and end_date > ced:
                 raise serializers.ValidationError(
-                    "Phase end date must be on or before challenge end date."
+                    "Phase end date must be on or before "
+                    "challenge end date."
                 )
         if start_date and end_date and start_date >= end_date:
             raise serializers.ValidationError(
@@ -481,22 +497,34 @@ class ChallengePhaseCreateSerializer(serializers.ModelSerializer):
         start_date = attrs.get("start_date")
         end_date = attrs.get("end_date")
         challenge = attrs.get("challenge")
+        if start_date is None and self.instance is not None:
+            start_date = self.instance.start_date
+        if end_date is None and self.instance is not None:
+            end_date = self.instance.end_date
+        if challenge is None and self.instance is not None:
+            challenge = self.instance.challenge
         if challenge:
-            if start_date and challenge.start_date and start_date < challenge.start_date:
+            csd = challenge.start_date
+            ced = challenge.end_date
+            if start_date and csd and start_date < csd:
                 raise serializers.ValidationError(
-                    "Phase start date must be on or after challenge start date."
+                    "Phase start date must be on or after "
+                    "challenge start date."
                 )
-            if start_date and challenge.end_date and start_date >= challenge.end_date:
+            if start_date and ced and start_date >= ced:
                 raise serializers.ValidationError(
-                    "Phase start date must be before challenge end date."
+                    "Phase start date must be before "
+                    "challenge end date."
                 )
-            if end_date and challenge.start_date and end_date <= challenge.start_date:
+            if end_date and csd and end_date <= csd:
                 raise serializers.ValidationError(
-                    "Phase end date must be after challenge start date."
+                    "Phase end date must be after "
+                    "challenge start date."
                 )
-            if end_date and challenge.end_date and end_date > challenge.end_date:
+            if end_date and ced and end_date > ced:
                 raise serializers.ValidationError(
-                    "Phase end date must be on or before challenge end date."
+                    "Phase end date must be on or before "
+                    "challenge end date."
                 )
         if start_date and end_date and start_date >= end_date:
             raise serializers.ValidationError(

--- a/apps/challenges/serializers.py
+++ b/apps/challenges/serializers.py
@@ -37,12 +37,12 @@ class ChallengeSerializer(serializers.ModelSerializer):
         return obj.get_domain_display()
 
     def validate(self, attrs):
-        start_date = attrs.get("start_date")
-        end_date = attrs.get("end_date")
-        if start_date is None and self.instance is not None:
-            start_date = self.instance.start_date
-        if end_date is None and self.instance is not None:
-            end_date = self.instance.end_date
+        start_date = attrs.get(
+            "start_date", getattr(self.instance, "start_date", None)
+        )
+        end_date = attrs.get(
+            "end_date", getattr(self.instance, "end_date", None)
+        )
         if start_date and end_date and start_date >= end_date:
             raise serializers.ValidationError(
                 "Challenge start date must be before end date."
@@ -161,15 +161,15 @@ class ChallengePhaseSerializer(serializers.ModelSerializer):
     is_active = serializers.ReadOnlyField()
 
     def validate(self, attrs):
-        start_date = attrs.get("start_date")
-        end_date = attrs.get("end_date")
-        challenge = attrs.get("challenge")
-        if start_date is None and self.instance is not None:
-            start_date = self.instance.start_date
-        if end_date is None and self.instance is not None:
-            end_date = self.instance.end_date
-        if challenge is None and self.instance is not None:
-            challenge = self.instance.challenge
+        start_date = attrs.get(
+            "start_date", getattr(self.instance, "start_date", None)
+        )
+        end_date = attrs.get(
+            "end_date", getattr(self.instance, "end_date", None)
+        )
+        challenge = attrs.get(
+            "challenge", getattr(self.instance, "challenge", None)
+        )
         if challenge:
             csd = challenge.start_date
             ced = challenge.end_date
@@ -494,15 +494,15 @@ class ChallengePhaseCreateSerializer(serializers.ModelSerializer):
     is_active = serializers.ReadOnlyField()
 
     def validate(self, attrs):
-        start_date = attrs.get("start_date")
-        end_date = attrs.get("end_date")
-        challenge = attrs.get("challenge")
-        if start_date is None and self.instance is not None:
-            start_date = self.instance.start_date
-        if end_date is None and self.instance is not None:
-            end_date = self.instance.end_date
-        if challenge is None and self.instance is not None:
-            challenge = self.instance.challenge
+        start_date = attrs.get(
+            "start_date", getattr(self.instance, "start_date", None)
+        )
+        end_date = attrs.get(
+            "end_date", getattr(self.instance, "end_date", None)
+        )
+        challenge = attrs.get(
+            "challenge", getattr(self.instance, "challenge", None)
+        )
         if challenge:
             csd = challenge.start_date
             ced = challenge.end_date

--- a/apps/challenges/serializers.py
+++ b/apps/challenges/serializers.py
@@ -36,6 +36,15 @@ class ChallengeSerializer(serializers.ModelSerializer):
     def get_domain_name(self, obj):
         return obj.get_domain_display()
 
+    def validate(self, attrs):
+        start_date = attrs.get("start_date")
+        end_date = attrs.get("end_date")
+        if start_date and end_date and start_date >= end_date:
+            raise serializers.ValidationError(
+                "Challenge start date must be before end date."
+            )
+        return attrs
+
     def validate_worker_python_version(self, value):
         if value in (None, ""):
             return DEFAULT_WORKER_PYTHON_VERSION
@@ -146,6 +155,33 @@ class ChallengeSerializer(serializers.ModelSerializer):
 class ChallengePhaseSerializer(serializers.ModelSerializer):
 
     is_active = serializers.ReadOnlyField()
+
+    def validate(self, attrs):
+        start_date = attrs.get("start_date")
+        end_date = attrs.get("end_date")
+        challenge = attrs.get("challenge")
+        if challenge:
+            if start_date and challenge.start_date and start_date < challenge.start_date:
+                raise serializers.ValidationError(
+                    "Phase start date must be on or after challenge start date."
+                )
+            if start_date and challenge.end_date and start_date >= challenge.end_date:
+                raise serializers.ValidationError(
+                    "Phase start date must be before challenge end date."
+                )
+            if end_date and challenge.start_date and end_date <= challenge.start_date:
+                raise serializers.ValidationError(
+                    "Phase end date must be after challenge start date."
+                )
+            if end_date and challenge.end_date and end_date > challenge.end_date:
+                raise serializers.ValidationError(
+                    "Phase end date must be on or before challenge end date."
+                )
+        if start_date and end_date and start_date >= end_date:
+            raise serializers.ValidationError(
+                "Phase start date must be before end date."
+            )
+        return attrs
 
     def __init__(self, *args, **kwargs):
         super(ChallengePhaseSerializer, self).__init__(*args, **kwargs)
@@ -440,6 +476,33 @@ class ZipChallengePhaseSplitSerializer(serializers.ModelSerializer):
 class ChallengePhaseCreateSerializer(serializers.ModelSerializer):
 
     is_active = serializers.ReadOnlyField()
+
+    def validate(self, attrs):
+        start_date = attrs.get("start_date")
+        end_date = attrs.get("end_date")
+        challenge = attrs.get("challenge")
+        if challenge:
+            if start_date and challenge.start_date and start_date < challenge.start_date:
+                raise serializers.ValidationError(
+                    "Phase start date must be on or after challenge start date."
+                )
+            if start_date and challenge.end_date and start_date >= challenge.end_date:
+                raise serializers.ValidationError(
+                    "Phase start date must be before challenge end date."
+                )
+            if end_date and challenge.start_date and end_date <= challenge.start_date:
+                raise serializers.ValidationError(
+                    "Phase end date must be after challenge start date."
+                )
+            if end_date and challenge.end_date and end_date > challenge.end_date:
+                raise serializers.ValidationError(
+                    "Phase end date must be on or before challenge end date."
+                )
+        if start_date and end_date and start_date >= end_date:
+            raise serializers.ValidationError(
+                "Phase start date must be before end date."
+            )
+        return attrs
 
     def __init__(self, *args, **kwargs):
         super(ChallengePhaseCreateSerializer, self).__init__(*args, **kwargs)

--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -71,6 +71,7 @@
         vm.isSubmissionUsingUrl = null;
         vm.isSubmissionUsingCli = null;
         vm.isSubmissionUsingFile = null;
+        vm.submissionType = null;
         vm.isRemoteChallenge = false;
         vm.allowResumingSubmisisons = false;
         vm.allowCancelRunningSubmissions = false;
@@ -738,6 +739,10 @@
                             vm.projectUrl = "";
                             vm.publicationUrl = "";
                             vm.isPublicSubmission = null;
+                            vm.isSubmissionUsingCli = null;
+                            vm.isSubmissionUsingFile = null;
+                            vm.isSubmissionUsingUrl = null;
+                            vm.submissionType = null;
                             $rootScope.notify("success", "Your submission has been recorded succesfully!");
                             vm.disableSubmit = true;
                             vm.showSubmissionNumbers = false;
@@ -755,6 +760,10 @@
                             vm.projectUrl = null;
                             vm.publicationUrl = null;
                             vm.isPublicSubmission = null;
+                            vm.isSubmissionUsingCli = null;
+                            vm.isSubmissionUsingFile = null;
+                            vm.isSubmissionUsingUrl = null;
+                            vm.submissionType = null;
                             if (status == 404) {
                                 vm.subErrors.msg = "Please select phase!";
                             } else {

--- a/frontend/src/views/web/challenge/submission.html
+++ b/frontend/src/views/web/challenge/submission.html
@@ -224,14 +224,14 @@
                             <p class="fs-18 w-400">Select submission type:</p>
                             <li>
                                 <input type="radio" name="submissionOptions" class="with-gap selectPhase" id="cliSubmission"
-                                    value="cliSubmission" ng-click="challenge.isSubmissionUsingCli = true; challenge.isSubmissionUsingFile = false; challenge.isSubmissionUsingUrl = false">
+                                    value="cliSubmission" ng-model="challenge.submissionType" ng-click="challenge.isSubmissionUsingCli = true; challenge.isSubmissionUsingFile = false; challenge.isSubmissionUsingUrl = false">
                                 <label for="cliSubmission"></label>
                                 <div class="show-member-title pointer">
                                     <strong class="fs-16 w-300">Use CLI (for file size > 400MB)
                                     </strong>
                                 </div>
                                 <input type="radio" name="submissionOptions" class="with-gap selectPhase"
-                                    id="fileUpload" value="challenge.showFileUploadOption"
+                                    id="fileUpload" value="fileUpload" ng-model="challenge.submissionType"
                                     ng-click="challenge.isSubmissionUsingFile = true; challenge.isSubmissionUsingUrl = false; challenge.isSubmissionUsingCli = false;">
                                 <label for="fileUpload"></label>
                                 <div class="show-member-title pointer">

--- a/tests/unit/challenges/test_models.py
+++ b/tests/unit/challenges/test_models.py
@@ -317,9 +317,10 @@ class ChallengePhaseTestCase(BaseTestCase):
             self.challenge_phase.save()
 
     def test_save_raises_error_when_phase_start_after_phase_end(self):
-        now = timezone.now()
-        self.challenge_phase.start_date = now + timedelta(days=1)
-        self.challenge_phase.end_date = now
+        self.challenge_phase.start_date = self.challenge.start_date + timedelta(
+            hours=5
+        )
+        self.challenge_phase.end_date = self.challenge.start_date + timedelta(hours=1)
         with self.assertRaises(ValidationError):
             self.challenge_phase.save()
 

--- a/tests/unit/challenges/test_models.py
+++ b/tests/unit/challenges/test_models.py
@@ -13,6 +13,7 @@ from challenges.models import (
     LeaderboardData,
 )
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.utils import timezone
@@ -34,6 +35,8 @@ class BaseTestCase(TestCase):
             team_name="Test Challenge Host Team", created_by=self.user
         )
 
+        now = timezone.now()
+
         self.challenge = Challenge.objects.create(
             title="Test Challenge",
             description="Description for test challenge",
@@ -42,8 +45,8 @@ class BaseTestCase(TestCase):
             creator=self.challenge_host_team,
             published=False,
             enable_forum=True,
-            start_date=timezone.now() - timedelta(days=2),
-            end_date=timezone.now() + timedelta(days=1),
+            start_date=now - timedelta(days=2),
+            end_date=now + timedelta(days=1),
             anonymous_leaderboard=False,
         )
 
@@ -58,8 +61,8 @@ class BaseTestCase(TestCase):
                 description="Description for Challenge Phase",
                 leaderboard_public=False,
                 is_public=False,
-                start_date=timezone.now() - timedelta(days=2),
-                end_date=timezone.now() + timedelta(days=1),
+                start_date=now - timedelta(days=1),
+                end_date=now + timedelta(hours=1),
                 challenge=self.challenge,
                 test_annotation=SimpleUploadedFile(
                     "test_sample_file.txt",
@@ -186,6 +189,7 @@ class ChallengeTestCase(BaseTestCase):
         self.challenge.save()
 
         mock_trigger_eks_node_autoscale.reset_mock()
+        self.challenge.start_date = timezone.now() - timedelta(days=5)
         self.challenge.end_date = timezone.now() - timedelta(days=3)
         self.challenge.save()
 
@@ -193,6 +197,26 @@ class ChallengeTestCase(BaseTestCase):
             self.challenge.pk,
             trigger_source="challenge_end_date_changed",
         )
+
+    def test_save_raises_error_when_start_date_after_end_date(self):
+        self.challenge.start_date = timezone.now() + timedelta(days=1)
+        self.challenge.end_date = timezone.now() - timedelta(days=1)
+        with self.assertRaises(ValidationError):
+            self.challenge.save()
+
+    def test_save_raises_error_when_start_date_equals_end_date(self):
+        now = timezone.now()
+        self.challenge.start_date = now
+        self.challenge.end_date = now
+        with self.assertRaises(ValidationError):
+            self.challenge.save()
+
+    def test_save_succeeds_when_dates_are_valid(self):
+        self.challenge.start_date = timezone.now() - timedelta(days=2)
+        self.challenge.end_date = timezone.now() + timedelta(days=2)
+        self.challenge.save()
+        self.challenge.refresh_from_db()
+        self.assertTrue(self.challenge.is_active)
 
 
 class DatasetSplitTestCase(BaseTestCase):
@@ -269,6 +293,70 @@ class ChallengePhaseTestCase(BaseTestCase):
             ],
             retention_policies,
         )
+
+    def test_save_raises_error_when_phase_start_before_challenge_start(self):
+        self.challenge_phase.start_date = self.challenge.start_date - timedelta(
+            days=1
+        )
+        with self.assertRaises(ValidationError):
+            self.challenge_phase.save()
+
+    def test_save_raises_error_when_phase_start_on_or_after_challenge_end(self):
+        self.challenge_phase.start_date = self.challenge.end_date
+        with self.assertRaises(ValidationError):
+            self.challenge_phase.save()
+
+    def test_save_raises_error_when_phase_end_on_or_before_challenge_start(self):
+        self.challenge_phase.end_date = self.challenge.start_date
+        with self.assertRaises(ValidationError):
+            self.challenge_phase.save()
+
+    def test_save_raises_error_when_phase_end_after_challenge_end(self):
+        self.challenge_phase.end_date = self.challenge.end_date + timedelta(days=1)
+        with self.assertRaises(ValidationError):
+            self.challenge_phase.save()
+
+    def test_save_raises_error_when_phase_start_after_phase_end(self):
+        now = timezone.now()
+        self.challenge_phase.start_date = now + timedelta(days=1)
+        self.challenge_phase.end_date = now
+        with self.assertRaises(ValidationError):
+            self.challenge_phase.save()
+
+    def test_save_succeeds_when_phase_dates_are_within_challenge_dates(self):
+        self.challenge_phase.start_date = self.challenge.start_date + timedelta(
+            hours=1
+        )
+        self.challenge_phase.end_date = self.challenge.end_date - timedelta(hours=1)
+        self.challenge_phase.save()
+        self.challenge_phase.refresh_from_db()
+        self.assertEqual(
+            self.challenge_phase.start_date,
+            self.challenge.start_date + timedelta(hours=1),
+        )
+        self.assertEqual(
+            self.challenge_phase.end_date,
+            self.challenge.end_date - timedelta(hours=1),
+        )
+
+    def test_save_succeeds_when_challenge_dates_are_null(self):
+        self.challenge.start_date = None
+        self.challenge.end_date = None
+        self.challenge.save()
+        now = timezone.now()
+        self.challenge_phase.start_date = now - timedelta(days=1)
+        self.challenge_phase.end_date = now + timedelta(days=1)
+        self.challenge_phase.save()
+        self.challenge_phase.refresh_from_db()
+        self.assertTrue(self.challenge_phase.is_active)
+
+    def test_save_succeeds_when_phase_dates_are_null(self):
+        self.challenge_phase.start_date = None
+        self.challenge_phase.end_date = None
+        self.challenge_phase.save()
+        self.challenge_phase.refresh_from_db()
+        self.assertIsNone(self.challenge_phase.start_date)
+        self.assertIsNone(self.challenge_phase.end_date)
 
 
 class LeaderboardTestCase(BaseTestCase):

--- a/tests/unit/challenges/test_serializers.py
+++ b/tests/unit/challenges/test_serializers.py
@@ -192,7 +192,7 @@ class ChallengePhaseCreateSerializerTest(BaseTestCase):
                 leaderboard_public=False,
                 is_public=False,
                 start_date=timezone.now() - timedelta(days=2),
-                end_date=timezone.now() + timedelta(days=1),
+                end_date=self.challenge.end_date,
                 challenge=self.challenge,
                 test_annotation=SimpleUploadedFile(
                     "test_sample_file.txt",
@@ -331,8 +331,8 @@ class ChallengePhaseCreateSerializerTest(BaseTestCase):
                 "description": "Internal phase",
                 "leaderboard_public": False,
                 "is_public": False,
-                "start_date": timezone.now() - timedelta(days=1),
-                "end_date": timezone.now() + timedelta(days=1),
+                "start_date": self.challenge.start_date,
+                "end_date": self.challenge.end_date,
                 "max_submissions_per_day": 100000,
                 "max_submissions": 100000,
                 "max_submissions_per_month": 100000,
@@ -344,6 +344,12 @@ class ChallengePhaseCreateSerializerTest(BaseTestCase):
         self.assertTrue(serializer.is_valid(), serializer.errors)
         challenge_phase = serializer.save()
 
+        self.assertLessEqual(
+            challenge_phase.start_date, self.challenge.end_date
+        )
+        self.assertLessEqual(
+            challenge_phase.end_date, self.challenge.end_date
+        )
         self.assertEqual(
             ChallengePhase.DAYS_14,
             challenge_phase.submission_artifact_retention_policy,


### PR DESCRIPTION
## Summary
Fix submission type marker persisting on UI after submission completes.

## Related Issue
Fixes #4351

## What changed
- Added `ng-model="challenge.submissionType"` to both CLI and file-upload radio buttons in `submission.html`
- Added `vm.submissionType = null` initialization in `challengeCtrl.js`
- Reset `isSubmissionUsingCli`, `isSubmissionUsingFile`, `isSubmissionUsingUrl`, and `submissionType` to `null` on both submission success and error

## Why this approach
The radio buttons had no model binding, so AngularJS couldn't control their checked state. Once checked, they stayed checked regardless of submission lifecycle. This is the same pattern already used for phase selection (is_phase_selected).

## Testing done
- Verified radio button checked state clears after submission via model reset
- Lint/format passes

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated (not user-facing)
- [x] Lint/format passes
- [x] Linked issue referenced
- [x] Commits signed off (DCO)
- [x] No unrelated changes bundled in


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent challenges and phases from using invalid date ranges.
  * Ensured challenge phases remain within their parent challenge’s active period.
  * Improved submission form state cleanup after successful or failed submissions.
  * Standardized submission type selection for CLI and file uploads.

* **Tests**
  * Expanded coverage for date boundaries, invalid ranges, null dates, and submission-phase validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->