### PR TITLE
Fix #4970: Block SSRF via file_url submissions

### DIFF
--- a/apps/jobs/utils.py
+++ b/apps/jobs/utils.py
@@ -1,8 +1,11 @@
 import datetime
+import ipaddress
 import logging
 import os
+import socket
 import tempfile
 import urllib.request
+from urllib.parse import urlparse
 
 import requests
 from base.utils import get_model_object, suppress_autotime
@@ -182,12 +185,45 @@ def get_remaining_submission_for_a_phase(
         return response_data, status.HTTP_200_OK
 
 
-def is_url_valid(url):
+def is_public_http_url(url):
     """
-    Checks that a given URL is reachable.
+    Checks that a URL uses http(s) and that every IP address its hostname
+    resolves to is publicly routable. Used to block SSRF attempts via
+    file_url submissions that target loopback, private, link-local,
+    reserved, or multicast network destinations.
     :param url: A URL
     :return type: bool
     """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return False
+    try:
+        addr_infos = socket.getaddrinfo(parsed.hostname, None)
+    except socket.gaierror:
+        return False
+    for addr_info in addr_infos:
+        ip = ipaddress.ip_address(addr_info[4][0])
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            return False
+    return True
+
+
+def is_url_valid(url):
+    """
+    Checks that a given URL targets a public network destination and is
+    reachable.
+    :param url: A URL
+    :return type: bool
+    """
+    if not is_public_http_url(url):
+        return False
     request = urllib.request.Request(url)
     request.get_method = lambda: "HEAD"
     try:
@@ -199,6 +235,11 @@ def is_url_valid(url):
 
 def get_file_from_url(url):
     """Get file object from a url"""
+
+    if not is_public_http_url(url):
+        raise ValueError(
+            "The file URL does not point to a public network destination!"
+        )
 
     BASE_TEMP_DIR = tempfile.mkdtemp()
     file_name = url.split("/")[-1]

--- a/tests/unit/jobs/test_utils.py
+++ b/tests/unit/jobs/test_utils.py
@@ -11,6 +11,7 @@ from jobs.utils import (
     get_remaining_submission_for_a_phase,
     handle_submission_rerun,
     handle_submission_resume,
+    is_public_http_url,
     is_url_valid,
     reorder_submissions_comparator_to_key,
     response_if_submissions_paused,
@@ -18,10 +19,49 @@ from jobs.utils import (
 from jobs.views import _compute_remaining_limits
 from rest_framework import status
 
+PUBLIC_ADDR_INFO = [(2, 1, 6, "", ("93.184.216.34", 0))]
+
 
 class TestUtils(unittest.TestCase):
+    @patch("jobs.utils.socket.getaddrinfo")
+    def test_is_public_http_url_accepts_public_address(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = PUBLIC_ADDR_INFO
+        self.assertTrue(is_public_http_url("http://example.com"))
+
+    def test_is_public_http_url_rejects_non_http_scheme(self):
+        self.assertFalse(is_public_http_url("file:///etc/passwd"))
+
+    @patch("jobs.utils.socket.getaddrinfo")
+    def test_is_public_http_url_rejects_loopback_address(
+        self, mock_getaddrinfo
+    ):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("127.0.0.1", 0))]
+        self.assertFalse(is_public_http_url("http://localhost"))
+
+    @patch("jobs.utils.socket.getaddrinfo")
+    def test_is_public_http_url_rejects_private_address(
+        self, mock_getaddrinfo
+    ):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("10.0.0.5", 0))]
+        self.assertFalse(is_public_http_url("http://internal.example"))
+
+    @patch("jobs.utils.socket.getaddrinfo")
+    def test_is_public_http_url_rejects_link_local_address(
+        self, mock_getaddrinfo
+    ):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("169.254.169.254", 0))]
+        self.assertFalse(is_public_http_url("http://metadata.internal"))
+
+    def test_is_public_http_url_rejects_unresolvable_host(self):
+        self.assertFalse(
+            is_public_http_url("http://this-host-does-not-resolve.invalid")
+        )
+
+    @patch("jobs.utils.socket.getaddrinfo")
     @patch("urllib.request.urlopen")
-    def test_is_url_valid(self, mock_urlopen):
+    def test_is_url_valid(self, mock_urlopen, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = PUBLIC_ADDR_INFO
+
         # Test with a valid URL
         mock_urlopen.return_value = True
         self.assertTrue(is_url_valid("http://example.com"))
@@ -32,8 +72,15 @@ class TestUtils(unittest.TestCase):
         )
         self.assertFalse(is_url_valid("http://invalid-url.com"))
 
+    @patch("jobs.utils.socket.getaddrinfo")
+    def test_is_url_valid_rejects_private_address(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("10.0.0.5", 0))]
+        self.assertFalse(is_url_valid("http://internal.example"))
+
+    @patch("jobs.utils.socket.getaddrinfo")
     @patch("requests.get")
-    def test_get_file_from_url(self, mock_get):
+    def test_get_file_from_url(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = PUBLIC_ADDR_INFO
         mock_response = MagicMock()
         mock_response.iter_content = lambda chunk_size: [b"test data"]
         mock_get.return_value = mock_response
@@ -41,6 +88,12 @@ class TestUtils(unittest.TestCase):
         file_obj = get_file_from_url("http://example.com/file.txt")
         self.assertEqual(file_obj["name"], "file.txt")
         self.assertTrue(os.path.exists(file_obj["temp_dir_path"]))
+
+    @patch("jobs.utils.socket.getaddrinfo")
+    def test_get_file_from_url_rejects_private_address(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("10.0.0.5", 0))]
+        with self.assertRaises(ValueError):
+            get_file_from_url("http://internal.example/file.txt")
 
     @patch("challenges.models.LeaderboardData.objects.exclude")
     @patch("challenges.models.LeaderboardData.objects.filter")


### PR DESCRIPTION
Fixes #4970.

## Problem

apps/jobs/utils.py's get_file_from_url() (used by the async submission task in apps/jobs/tasks.py) and is_url_valid() (used at submission time in apps/jobs/views.py) fetch whatever URL a participant supplies as file_url, without checking where that URL actually resolves to. Since the fetch happens from the EvalAI backend, a participant can point file_url at a loopback, private, or link-local address (e.g. a cloud metadata endpoint) and have the response stored and served back as their submission file - classic SSRF leading to internal data exfiltration.

## Fix

Added is_public_http_url() to apps/jobs/utils.py, which:
- rejects non-http/https schemes and missing hostnames,
- resolves the hostname via socket.getaddrinfo(),
- rejects the URL if any resolved address is private, loopback, link-local, multicast, reserved, or unspecified,
- rejects unresolvable hostnames.

Both is_url_valid() and get_file_from_url() now call this check before doing anything else, so the guard applies on both the synchronous validation path (views.py) and the async download path (tasks.py).

## How Has This Been Tested?

```
  cd tests/unit/jobs
  python -m pytest test_utils.py -v -k "is_public_http_url or is_url_valid or get_file_from_url"

  python -m black --check apps/jobs/utils.py tests/unit/jobs/test_utils.py
  python -m isort --profile black --line-length 79 --skip migrations --check-only apps/jobs/utils.py tests/unit/jobs/test_utils.py
  python -m flake8 apps/jobs/utils.py tests/unit/jobs/test_utils.py
```

Added new test cases covering: public IP accepted, non-http scheme rejected, loopback rejected, private (10.x) rejected, link-local (169.254.x, the common cloud metadata range) rejected, unresolvable hostname rejected, and that get_file_from_url raises ValueError for a private-resolving host.

I don't have the full Dockerized EvalAI dev stack running in my current environment, so I additionally verified the resolution/classification logic standalone against public, loopback, private, link-local, multicast, and unresolvable hostnames (9/9 cases correct), and confirmed black/isort/flake8 pass against the repo's own pyproject.toml/.flake8 config before opening  this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security for URL-based file fetching by blocking requests to private, loopback, link-local, reserved, and otherwise non-public network addresses.
  - Restricted fetchable URLs to HTTP and HTTPS schemes.
  - Invalid or unsafe file URLs now fail with a clear validation error instead of being downloaded.

- **Tests**
  - Added coverage for public, private, invalid, and unreachable URL destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->