### PR TITLE
fix: add libGL and glib runtime libs to submission worker images

### DIFF
--- a/docker/dev/worker_py3_7/Dockerfile
+++ b/docker/dev/worker_py3_7/Dockerfile
@@ -83,7 +83,9 @@ RUN apt-get update && \
     libtiff5 \
     libfreetype6 \
     liblcms2-2 \
-    libwebp6 && \
+    libwebp6 \
+    libgl1 \
+    libglib2.0-0 && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/dev/worker_py3_8/Dockerfile
+++ b/docker/dev/worker_py3_8/Dockerfile
@@ -112,7 +112,9 @@ RUN apt-get update && \
     libfreetype6 \
     liblcms2-2 \
     libwebp6 \
-    libgmp10 && \
+    libgmp10 \
+    libgl1 \
+    libglib2.0-0 && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/dev/worker_py3_9/Dockerfile
+++ b/docker/dev/worker_py3_9/Dockerfile
@@ -85,7 +85,9 @@ RUN apt-get update && \
     libtiff5 \
     libfreetype6 \
     liblcms2-2 \
-    libwebp6 && \
+    libwebp6 \
+    libgl1 \
+    libglib2.0-0 && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/worker_py3_7/Dockerfile
+++ b/docker/prod/worker_py3_7/Dockerfile
@@ -111,7 +111,9 @@ RUN apt-get update && \
     libfreetype6 \
     liblcms2-2 \
     libwebp6 \
-    libgmp10 && \
+    libgmp10 \
+    libgl1 \
+    libglib2.0-0 && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/worker_py3_8/Dockerfile
+++ b/docker/prod/worker_py3_8/Dockerfile
@@ -109,7 +109,9 @@ RUN apt-get update && \
     libfreetype6 \
     liblcms2-2 \
     libwebp6 \
-    libgmp10 && \
+    libgmp10 \
+    libgl1 \
+    libglib2.0-0 && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/worker_py3_9/Dockerfile
+++ b/docker/prod/worker_py3_9/Dockerfile
@@ -114,7 +114,9 @@ RUN apt-get update && \
     libfreetype6 \
     liblcms2-2 \
     libwebp6 \
-    libgmp10 && \
+    libgmp10 \
+    libgl1 \
+    libglib2.0-0 && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 


### PR DESCRIPTION
Challenge evaluation scripts that pip-install opencv-python fail at `import cv2` with `libGL.so.1: cannot open shared object file` because the slim-bullseye worker runtime stage lacks the mesa GL library. Add libgl1 (provides libGL.so.1) and libglib2.0-0 (provides libgthread-2.0.so.0, cv2's usual second missing dependency) to the runtime apt install for all submission workers (py3.7/3.8/3.9, prod + dev). Code-upload workers are unaffected: evaluation runs in the participant's own container, so they are intentionally left out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated runtime environments to include required graphics and system libraries.
  * Improved compatibility for workloads that rely on OpenGL and GLib support across supported Python worker images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->