### PR TITLE
fix(worker): pin challenge deps to core stack

### DIFF
--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -309,6 +309,39 @@ def return_file_url_per_environment(url):
     return url
 
 
+def get_challenge_pip_constraints_file():
+    """
+    Return the path to the worker's pinned dependency file for the running
+    Python version, or None if it is not present.
+
+    This file is passed to pip as a constraints file (``-c``) when installing
+    challenge-supplied ``requirements.txt`` so a challenge cannot upgrade the
+    worker's core scientific stack (numpy, scipy, pandas, scikit-learn, ...).
+    Upgrading numpy/scipy in place breaks the worker image's already-compiled
+    C extensions (e.g. scipy built against the numpy 1.x ABI raises a
+    ``TypeError`` at import when numpy 2.x is installed on top of it).
+    """
+    repo_root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+    constraints_file = join(
+        repo_root,
+        "requirements",
+        "worker_py{0}_{1}.txt".format(
+            sys.version_info.major, sys.version_info.minor
+        ),
+    )
+    if os.path.isfile(constraints_file):
+        return constraints_file
+    logger.warning(
+        "{} Worker constraints file not found at {}; installing challenge "
+        "requirements without pinning the core dependency stack.".format(
+            WORKER_LOGS_PREFIX, constraints_file
+        )
+    )
+    return None
+
+
 def extract_challenge_data(challenge, phases):
     """
     * Expects a challenge object and an array of phase object
@@ -337,27 +370,45 @@ def extract_challenge_data(challenge, phases):
         evaluation_script_url, challenge_zip_file, challenge_data_directory
     )
 
-    try:
-        requirements_location = join(
-            challenge_data_directory, "requirements.txt"
-        )
-        if os.path.isfile(requirements_location):
+    requirements_location = join(challenge_data_directory, "requirements.txt")
+    if os.path.isfile(requirements_location):
+        pip_install_command = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "-r",
+            requirements_location,
+        ]
+        # Pin the worker's core dependency stack so a challenge cannot
+        # upgrade numpy/scipy/etc. and break already-compiled C extensions.
+        constraints_file = get_challenge_pip_constraints_file()
+        if constraints_file:
+            pip_install_command += ["-c", constraints_file]
+        try:
             subprocess.check_output(
-                [
-                    sys.executable,
-                    "-m",
-                    "pip",
-                    "install",
-                    "-r",
-                    requirements_location,
-                ]
+                pip_install_command, stderr=subprocess.STDOUT
             )
-        else:
-            logger.info(
-                "No custom requirements for challenge {}".format(challenge.id)
+        except subprocess.CalledProcessError as e:
+            # Surface dependency-install failures directly on the challenge
+            # instead of swallowing them and continuing to a misleading
+            # import error below.
+            pip_output = (
+                e.output.decode("utf-8", errors="replace") if e.output else ""
             )
-    except Exception as e:
-        logger.error(e)
+            error_message = (
+                "Failed to install requirements for challenge {}:\n{}".format(
+                    challenge.id, pip_output
+                )
+            )
+            challenge.evaluation_module_error = error_message
+            challenge.save()
+            logger.exception("{} {}".format(WORKER_LOGS_PREFIX, error_message))
+            raise
+    else:
+        logger.info(
+            "No custom requirements for challenge {}".format(challenge.id)
+        )
 
     phase_data_base_directory = PHASE_DATA_BASE_DIR.format(
         challenge_id=challenge.id

--- a/tests/unit/worker/test_submission_worker.py
+++ b/tests/unit/worker/test_submission_worker.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import signal
+import subprocess
 import sys
 import tempfile
 import zipfile
@@ -590,14 +591,12 @@ class ExtractChallengeDataWorkerTest(BaseAPITestClass):
     @patch("scripts.workers.submission_worker.download_and_extract_file")
     @patch("scripts.workers.submission_worker.os.path.isfile")
     @patch("scripts.workers.submission_worker.subprocess.check_output")
-    @patch("scripts.workers.submission_worker.logger.error")
     @patch("scripts.workers.submission_worker.importlib.import_module")
     @patch("scripts.workers.submission_worker.importlib.invalidate_caches")
     def test_extract_challenge_data_requirements_error(
         self,
         mock_invalidate_caches,
         mock_import_module,
-        mock_logger_error,
         mock_check_output,
         mock_isfile,
         mock_download_and_extract_file,
@@ -605,16 +604,65 @@ class ExtractChallengeDataWorkerTest(BaseAPITestClass):
         mock_download_and_extract_zip_file,
         mock_create_dir_as_python_package,
     ):
+        # A failed dependency install must surface on the challenge as
+        # evaluation_module_error and abort, rather than being swallowed and
+        # continuing to a misleading import error.
         mock_isfile.return_value = True
-        mock_check_output.side_effect = Exception("pip error")
+        mock_check_output.side_effect = subprocess.CalledProcessError(
+            returncode=1,
+            cmd="pip install",
+            output=b"ERROR: Could not find a version for numpy==2.0.2",
+        )
+        challenge = self.challenge
+        phase = self.challenge_phase
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            extract_challenge_data(challenge, [phase])
+
+        self.assertIsNotNone(challenge.evaluation_module_error)
+        self.assertIn(
+            "Could not find a version", challenge.evaluation_module_error
+        )
+        # Worker must not import a challenge whose requirements failed to install
+        mock_import_module.assert_not_called()
+        mock_invalidate_caches.assert_not_called()
+
+    @patch("scripts.workers.submission_worker.create_dir_as_python_package")
+    @patch("scripts.workers.submission_worker.download_and_extract_zip_file")
+    @patch("scripts.workers.submission_worker.create_dir")
+    @patch("scripts.workers.submission_worker.download_and_extract_file")
+    @patch("scripts.workers.submission_worker.os.path.isfile")
+    @patch("scripts.workers.submission_worker.subprocess.check_output")
+    @patch("scripts.workers.submission_worker.importlib.import_module")
+    @patch("scripts.workers.submission_worker.importlib.invalidate_caches")
+    def test_extract_challenge_data_pins_core_constraints(
+        self,
+        mock_invalidate_caches,
+        mock_import_module,
+        mock_check_output,
+        mock_isfile,
+        mock_download_and_extract_file,
+        mock_create_dir,
+        mock_download_and_extract_zip_file,
+        mock_create_dir_as_python_package,
+    ):
+        # Both the challenge requirements.txt and the worker constraints file
+        # exist, so pip must be invoked with a `-c` constraints file that pins
+        # the worker's core dependency stack (prevents challenge deps from
+        # upgrading numpy/scipy and breaking compiled C extensions).
+        mock_isfile.return_value = True
         challenge = self.challenge
         phase = self.challenge_phase
 
         extract_challenge_data(challenge, [phase])
 
-        mock_logger_error.assert_called()
-        mock_import_module.assert_called()
-        mock_invalidate_caches.assert_called()
+        mock_check_output.assert_called_once()
+        pip_command = mock_check_output.call_args[0][0]
+        self.assertIn("-r", pip_command)
+        self.assertIn("-c", pip_command)
+        constraints_arg = pip_command[pip_command.index("-c") + 1]
+        self.assertIn("requirements", constraints_arg)
+        self.assertTrue(constraints_arg.endswith(".txt"))
 
 
 class RunSubmissionRemoteEvaluationTest(BaseAPITestClass):


### PR DESCRIPTION
## Problem

Sentry surfaced a `TypeError` (8 events) raised in the submission worker while building the Python module for `challenge_id 356`:

- `extract_challenge_data` → `importlib.import_module("challenge_data.challenge_356")`
- the challenge imports scipy → crash at import in `scipy/interpolate/_fitpack_impl.py:103` (`array([], dfitpack_int)`).

### Root cause

A challenge's `requirements.txt` is `pip install`ed into the **shared** submission worker with **no version constraints**. The worker image ships scipy compiled against the **numpy 1.x ABI**; the challenge dragged **numpy 2.0.2** in on top of it. Under numpy 2's changed ABI, scipy's compiled `_dfitpack` dtype (`dfitpack_int`) is malformed, so `numpy.array([], dfitpack_int)` raises at import. Reproduced locally as `ValueError: numpy.dtype size changed ... binary incompatibility` (same ABI break; exact exception class varies by scipy build).

The pip failure path also swallowed errors (`except Exception: logger.error(e)`), so a broken install proceeded to a misleading downstream import crash.

## Fix

- **Constrain challenge installs.** Pass the matching `requirements/worker_py3_X.txt` as a pip constraints file (`-c`) when installing a challenge's `requirements.txt`. A challenge can still add its own deps, but can no longer move the worker's pinned core stack (numpy/scipy/pandas/scikit-learn/matplotlib). New helper `get_challenge_pip_constraints_file()` selects the file for the running Python and degrades gracefully (warns) if absent.
- **Surface install failures.** On `CalledProcessError`, record the pip output on `challenge.evaluation_module_error`, log it, and re-raise instead of continuing to a misleading import error.

## Testing

- `pytest tests/unit/worker/test_submission_worker.py -k ExtractChallengeData` → **14 passed** against real Postgres (`docker compose run django`). New test asserts `-c` constraints are passed; the requirements-error test was rewritten to assert the failure surfaces + re-raises + the import is not attempted.
- Verified under `python:3.9.21`: module compiles, constraints path resolves to `/code/requirements/worker_py3_9.txt`.
- Reproduced bug + fix in a venv: numpy 2.0.2 on scipy 1.11.4 → ABI import error; `pip install numpy==2.0.2 -c worker_py3_9.txt` → `ResolutionImpossible` (bump blocked).

## Deploy notes

- **Rebuild + redeploy the py3_9 worker** — the live container still has the corrupted numpy 2.0.2 baked in; the code fix only prevents recurrence.
- **Tradeoff:** challenges that genuinely require numpy ≥ 2 will now fail install loudly (a `-c` conflict) rather than silently corrupting the ABI. Supporting them would need the worker base image on a numpy-2 stack (scipy ≥ 1.13 built for numpy 2) — a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Challenge dependency installation now uses Python-version-specific constraints when available, helping ensure consistent evaluation environments.
  * Clear logging is provided when custom requirements or constraint files are unavailable.

* **Bug Fixes**
  * Dependency installation failures are now surfaced immediately with detailed error information.
  * Challenge modules are no longer imported after dependency installation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->