### PR TITLE
fix(worker): constrain all challenge pip installs to the core stack

### DIFF
--- a/docker/dev/worker_py3_7/Dockerfile
+++ b/docker/dev/worker_py3_7/Dockerfile
@@ -95,6 +95,12 @@ WORKDIR /code
 COPY --from=builder /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 
+# Force every runtime pip invocation (challenge requirements.txt and the
+# evaluation_script __init__.py install() helper) to honor the worker's pinned
+# core dependency stack, preventing numpy/scipy ABI breakage.
+ENV PIP_CONSTRAINT=/code/requirements/worker_py3_7.txt \
+    PIP_BUILD_CONSTRAINT=/code/requirements/worker_py3_7.txt
+
 # Copy application code
 COPY . /code/
 

--- a/docker/dev/worker_py3_8/Dockerfile
+++ b/docker/dev/worker_py3_8/Dockerfile
@@ -128,6 +128,12 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /runtime-libs/ /usr/local/lib/
 RUN ldconfig
 
+# Force every runtime pip invocation (challenge requirements.txt and the
+# evaluation_script __init__.py install() helper) to honor the worker's pinned
+# core dependency stack, preventing numpy/scipy ABI breakage.
+ENV PIP_CONSTRAINT=/code/requirements/worker_py3_8.txt \
+    PIP_BUILD_CONSTRAINT=/code/requirements/worker_py3_8.txt
+
 # Copy application code
 COPY . /code/
 

--- a/docker/dev/worker_py3_9/Dockerfile
+++ b/docker/dev/worker_py3_9/Dockerfile
@@ -97,6 +97,12 @@ WORKDIR /code
 COPY --from=builder /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 
+# Force every runtime pip invocation (challenge requirements.txt and the
+# evaluation_script __init__.py install() helper) to honor the worker's pinned
+# core dependency stack, preventing numpy/scipy ABI breakage.
+ENV PIP_CONSTRAINT=/code/requirements/worker_py3_9.txt \
+    PIP_BUILD_CONSTRAINT=/code/requirements/worker_py3_9.txt
+
 # Copy application code
 COPY . /code/
 

--- a/docker/prod/worker_py3_7/Dockerfile
+++ b/docker/prod/worker_py3_7/Dockerfile
@@ -130,6 +130,12 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /runtime-libs/ /usr/local/lib/
 RUN ldconfig
 
+# Force every runtime pip invocation (challenge requirements.txt and the
+# evaluation_script __init__.py install() helper) to honor the worker's pinned
+# core dependency stack, preventing numpy/scipy ABI breakage.
+ENV PIP_CONSTRAINT=/code/requirements/worker_py3_7.txt \
+    PIP_BUILD_CONSTRAINT=/code/requirements/worker_py3_7.txt
+
 # Copy application code
 COPY . /code/
 

--- a/docker/prod/worker_py3_8/Dockerfile
+++ b/docker/prod/worker_py3_8/Dockerfile
@@ -128,6 +128,12 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /runtime-libs/ /usr/local/lib/
 RUN ldconfig
 
+# Force every runtime pip invocation (challenge requirements.txt and the
+# evaluation_script __init__.py install() helper) to honor the worker's pinned
+# core dependency stack, preventing numpy/scipy ABI breakage.
+ENV PIP_CONSTRAINT=/code/requirements/worker_py3_8.txt \
+    PIP_BUILD_CONSTRAINT=/code/requirements/worker_py3_8.txt
+
 # Copy application code
 COPY . /code/
 

--- a/docker/prod/worker_py3_9/Dockerfile
+++ b/docker/prod/worker_py3_9/Dockerfile
@@ -135,6 +135,12 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /runtime-libs/ /usr/local/lib/
 RUN ldconfig
 
+# Force every runtime pip invocation (challenge requirements.txt and the
+# evaluation_script __init__.py install() helper) to honor the worker's pinned
+# core dependency stack, preventing numpy/scipy ABI breakage.
+ENV PIP_CONSTRAINT=/code/requirements/worker_py3_9.txt \
+    PIP_BUILD_CONSTRAINT=/code/requirements/worker_py3_9.txt
+
 # Copy application code
 COPY . /code/
 

--- a/requirements/worker_py3_7.txt
+++ b/requirements/worker_py3_7.txt
@@ -1,3 +1,8 @@
+# Default-provided worker stack (Python 3.7). These packages are baked into every
+# submission worker image and pinned. Challenge requirements.txt and the
+# evaluation_script install() helper are constrained to these versions
+# (PIP_CONSTRAINT), so a challenge cannot move them. To add or bump a shared
+# package, open a PR against this file so the base image is rebuilt and tested.
 matplotlib==3.3.3
 networkx==2.5
 numpy==1.21.0

--- a/requirements/worker_py3_8.txt
+++ b/requirements/worker_py3_8.txt
@@ -1,3 +1,8 @@
+# Default-provided worker stack (Python 3.8). These packages are baked into every
+# submission worker image and pinned. Challenge requirements.txt and the
+# evaluation_script install() helper are constrained to these versions
+# (PIP_CONSTRAINT), so a challenge cannot move them. To add or bump a shared
+# package, open a PR against this file so the base image is rebuilt and tested.
 matplotlib==3.3.3
 networkx==2.5
 numpy==1.21.0

--- a/requirements/worker_py3_9.txt
+++ b/requirements/worker_py3_9.txt
@@ -1,3 +1,8 @@
+# Default-provided worker stack (Python 3.9). These packages are baked into every
+# submission worker image and pinned. Challenge requirements.txt and the
+# evaluation_script install() helper are constrained to these versions
+# (PIP_CONSTRAINT), so a challenge cannot move them. To add or bump a shared
+# package, open a PR against this file so the base image is rebuilt and tested.
 matplotlib==3.8.4
 cfn-lint==0.79.5
 networkx==3.2.1

--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -342,12 +342,39 @@ def get_challenge_pip_constraints_file():
     return None
 
 
+def configure_challenge_pip_environment():
+    """Force every pip invocation in the worker to honor the core dependency
+    pins.
+
+    Both challenge dependency paths run pip: the ``requirements.txt`` install in
+    ``extract_challenge_data`` and the ``install()`` helper shipped inside a
+    challenge's ``evaluation_script/__init__.py`` (which runs
+    ``sys.executable -m pip install`` at import time). Exporting
+    ``PIP_CONSTRAINT``/``PIP_BUILD_CONSTRAINT`` into the process environment
+    makes *both* subprocesses inherit the constraint, so a challenge cannot move
+    numpy/scipy/etc. off the worker's already-compiled core stack.
+
+    Returns the constraints file path applied, or ``None`` if no per-version
+    constraints file was found (environment left untouched).
+    """
+    constraints_file = get_challenge_pip_constraints_file()
+    if constraints_file:
+        os.environ["PIP_CONSTRAINT"] = constraints_file
+        os.environ["PIP_BUILD_CONSTRAINT"] = constraints_file
+    return constraints_file
+
+
 def extract_challenge_data(challenge, phases):
     """
     * Expects a challenge object and an array of phase object
     * Extracts `evaluation_script` for challenge and `annotation_file` for each phase
 
     """
+
+    # Pin the core dependency stack for every pip path (requirements.txt and the
+    # challenge __init__.py install() helper) before any challenge dependency is
+    # installed or the challenge module is imported.
+    configure_challenge_pip_environment()
 
     challenge_data_directory = CHALLENGE_DATA_DIR.format(
         challenge_id=challenge.id

--- a/tests/unit/worker/test_submission_worker.py
+++ b/tests/unit/worker/test_submission_worker.py
@@ -1304,12 +1304,19 @@ class ConfigureChallengePipEnvironmentTest(APITestCase):
     )
     def test_no_constraints_file_leaves_env_untouched(self, mock_constraints):
         mock_constraints.return_value = None
+        os.environ["PIP_CONSTRAINT"] = "/existing/constraints.txt"
+        os.environ["PIP_BUILD_CONSTRAINT"] = "/existing/build-constraints.txt"
 
         returned = configure_challenge_pip_environment()
 
         self.assertIsNone(returned)
-        self.assertNotIn("PIP_CONSTRAINT", os.environ)
-        self.assertNotIn("PIP_BUILD_CONSTRAINT", os.environ)
+        self.assertEqual(
+            os.environ["PIP_CONSTRAINT"], "/existing/constraints.txt"
+        )
+        self.assertEqual(
+            os.environ["PIP_BUILD_CONSTRAINT"],
+            "/existing/build-constraints.txt",
+        )
 
 
 class ExtractChallengeDataConstraintEnvTest(APITestCase):
@@ -1334,6 +1341,10 @@ class ExtractChallengeDataConstraintEnvTest(APITestCase):
         mock_file,
         mock_import,
     ):
+        # Fail if the challenge module is imported before the pip environment
+        # is configured (the install() helper runs at import time).
+        mock_configure.side_effect = mock_import.assert_not_called
+
         challenge = MagicMock()
         challenge.id = 356
         challenge.evaluation_script.url = "http://server/eval.zip"
@@ -1344,4 +1355,5 @@ class ExtractChallengeDataConstraintEnvTest(APITestCase):
 
         extract_challenge_data(challenge, [phase])
 
-        self.assertTrue(mock_configure.called)
+        mock_configure.assert_called_once_with()
+        mock_import.assert_called_once()

--- a/tests/unit/worker/test_submission_worker.py
+++ b/tests/unit/worker/test_submission_worker.py
@@ -32,6 +32,7 @@ from scripts.workers.submission_worker import (
     GracefulKiller,
     MultiOut,
     alarm_handler,
+    configure_challenge_pip_environment,
     create_dir,
     create_dir_as_python_package,
     delete_old_temp_directories,
@@ -1262,3 +1263,85 @@ class ExtractSubmissionDataCancelledTest(BaseAPITestClass):
                 "SUBMISSION_LOG", 123
             )
         )
+
+
+class ConfigureChallengePipEnvironmentTest(APITestCase):
+    def setUp(self):
+        self._saved = {
+            key: os.environ.get(key)
+            for key in ("PIP_CONSTRAINT", "PIP_BUILD_CONSTRAINT")
+        }
+        os.environ.pop("PIP_CONSTRAINT", None)
+        os.environ.pop("PIP_BUILD_CONSTRAINT", None)
+
+    def tearDown(self):
+        for key, value in self._saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    @patch(
+        "scripts.workers.submission_worker.get_challenge_pip_constraints_file"
+    )
+    def test_sets_both_pip_constraint_env_vars(self, mock_constraints):
+        mock_constraints.return_value = "/code/requirements/worker_py3_9.txt"
+
+        returned = configure_challenge_pip_environment()
+
+        self.assertEqual(returned, "/code/requirements/worker_py3_9.txt")
+        self.assertEqual(
+            os.environ["PIP_CONSTRAINT"],
+            "/code/requirements/worker_py3_9.txt",
+        )
+        self.assertEqual(
+            os.environ["PIP_BUILD_CONSTRAINT"],
+            "/code/requirements/worker_py3_9.txt",
+        )
+
+    @patch(
+        "scripts.workers.submission_worker.get_challenge_pip_constraints_file"
+    )
+    def test_no_constraints_file_leaves_env_untouched(self, mock_constraints):
+        mock_constraints.return_value = None
+
+        returned = configure_challenge_pip_environment()
+
+        self.assertIsNone(returned)
+        self.assertNotIn("PIP_CONSTRAINT", os.environ)
+        self.assertNotIn("PIP_BUILD_CONSTRAINT", os.environ)
+
+
+class ExtractChallengeDataConstraintEnvTest(APITestCase):
+    @patch("scripts.workers.submission_worker.importlib.import_module")
+    @patch("scripts.workers.submission_worker.download_and_extract_file")
+    @patch("scripts.workers.submission_worker.download_and_extract_zip_file")
+    @patch("scripts.workers.submission_worker.create_dir_as_python_package")
+    @patch("scripts.workers.submission_worker.create_dir")
+    @patch(
+        "scripts.workers.submission_worker.os.path.isfile", return_value=False
+    )
+    @patch(
+        "scripts.workers.submission_worker.configure_challenge_pip_environment"
+    )
+    def test_configures_pip_env_before_import(
+        self,
+        mock_configure,
+        mock_isfile,
+        mock_create_dir,
+        mock_create_pkg,
+        mock_zip,
+        mock_file,
+        mock_import,
+    ):
+        challenge = MagicMock()
+        challenge.id = 356
+        challenge.evaluation_script.url = "http://server/eval.zip"
+        phase = MagicMock()
+        phase.id = 1
+        phase.test_annotation.url = "http://server/ann.txt"
+        phase.test_annotation.name = "ann.txt"
+
+        extract_challenge_data(challenge, [phase])
+
+        self.assertTrue(mock_configure.called)

--- a/tests/unit/worker/test_worker_pip_constraints.py
+++ b/tests/unit/worker/test_worker_pip_constraints.py
@@ -26,12 +26,16 @@ def test_worker_dockerfile_sets_pip_constraint(
     # ENV would not.
     runtime_stage = re.split(r"(?mi)^FROM\s+", content)[-1]
     expected = f"/code/requirements/{requirements_name}"
-    assert (
-        f"PIP_CONSTRAINT={expected}" in runtime_stage
-    ), f"{dockerfile_path} must set PIP_CONSTRAINT to {expected}"
-    assert (
-        f"PIP_BUILD_CONSTRAINT={expected}" in runtime_stage
-    ), f"{dockerfile_path} must set PIP_BUILD_CONSTRAINT to {expected}"
+    # Match real ENV assignments (ENV on the first line, backslash-continued
+    # for the second) rather than a bare substring that could sit in a comment.
+    for variable in ("PIP_CONSTRAINT", "PIP_BUILD_CONSTRAINT"):
+        pattern = (
+            rf"(?m)^\s*(?:ENV\s+)?{variable}"
+            rf"={re.escape(expected)}(?:\s|\\|$)"
+        )
+        assert re.search(
+            pattern, runtime_stage
+        ), f"{dockerfile_path} must set {variable} to {expected}"
 
 
 @pytest.mark.parametrize(
@@ -45,5 +49,5 @@ def test_pip_constraint_points_at_runtime_stage_requirements(
     content = (REPO_ROOT / dockerfile_path).read_text()
     runtime_stage = re.split(r"(?mi)^FROM\s+", content)[-1]
     assert re.search(
-        r"COPY\s+\.\s+/code/", runtime_stage
+        r"(?m)^COPY\s+\.\s+/code/(?:\s|$)", runtime_stage
     ), f"{dockerfile_path} must copy the app (incl. requirements/) into /code"

--- a/tests/unit/worker/test_worker_pip_constraints.py
+++ b/tests/unit/worker/test_worker_pip_constraints.py
@@ -22,12 +22,15 @@ def test_worker_dockerfile_sets_pip_constraint(
     dockerfile_path, requirements_name
 ):
     content = (REPO_ROOT / dockerfile_path).read_text()
+    # Only the final runtime stage reaches the running worker; a builder-only
+    # ENV would not.
+    runtime_stage = re.split(r"(?mi)^FROM\s+", content)[-1]
     expected = f"/code/requirements/{requirements_name}"
     assert (
-        f"PIP_CONSTRAINT={expected}" in content
+        f"PIP_CONSTRAINT={expected}" in runtime_stage
     ), f"{dockerfile_path} must set PIP_CONSTRAINT to {expected}"
     assert (
-        f"PIP_BUILD_CONSTRAINT={expected}" in content
+        f"PIP_BUILD_CONSTRAINT={expected}" in runtime_stage
     ), f"{dockerfile_path} must set PIP_BUILD_CONSTRAINT to {expected}"
 
 
@@ -37,9 +40,10 @@ def test_worker_dockerfile_sets_pip_constraint(
 def test_pip_constraint_points_at_runtime_stage_requirements(
     dockerfile_path, requirements_name
 ):
-    # The constraints file must be copied into the image (COPY . /code/ or
-    # COPY requirements/) so PIP_CONSTRAINT resolves at container runtime.
+    # The constraints file must be copied into the image (COPY . /code/) in the
+    # runtime stage so PIP_CONSTRAINT resolves at container runtime.
     content = (REPO_ROOT / dockerfile_path).read_text()
+    runtime_stage = re.split(r"(?mi)^FROM\s+", content)[-1]
     assert re.search(
-        r"COPY\s+\.\s+/code/", content
+        r"COPY\s+\.\s+/code/", runtime_stage
     ), f"{dockerfile_path} must copy the app (incl. requirements/) into /code"

--- a/tests/unit/worker/test_worker_pip_constraints.py
+++ b/tests/unit/worker/test_worker_pip_constraints.py
@@ -1,0 +1,45 @@
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+WORKER_DOCKERFILES = [
+    ("docker/prod/worker_py3_7/Dockerfile", "worker_py3_7.txt"),
+    ("docker/prod/worker_py3_8/Dockerfile", "worker_py3_8.txt"),
+    ("docker/prod/worker_py3_9/Dockerfile", "worker_py3_9.txt"),
+    ("docker/dev/worker_py3_7/Dockerfile", "worker_py3_7.txt"),
+    ("docker/dev/worker_py3_8/Dockerfile", "worker_py3_8.txt"),
+    ("docker/dev/worker_py3_9/Dockerfile", "worker_py3_9.txt"),
+]
+
+
+@pytest.mark.parametrize(
+    "dockerfile_path,requirements_name", WORKER_DOCKERFILES
+)
+def test_worker_dockerfile_sets_pip_constraint(
+    dockerfile_path, requirements_name
+):
+    content = (REPO_ROOT / dockerfile_path).read_text()
+    expected = f"/code/requirements/{requirements_name}"
+    assert (
+        f"PIP_CONSTRAINT={expected}" in content
+    ), f"{dockerfile_path} must set PIP_CONSTRAINT to {expected}"
+    assert (
+        f"PIP_BUILD_CONSTRAINT={expected}" in content
+    ), f"{dockerfile_path} must set PIP_BUILD_CONSTRAINT to {expected}"
+
+
+@pytest.mark.parametrize(
+    "dockerfile_path,requirements_name", WORKER_DOCKERFILES
+)
+def test_pip_constraint_points_at_runtime_stage_requirements(
+    dockerfile_path, requirements_name
+):
+    # The constraints file must be copied into the image (COPY . /code/ or
+    # COPY requirements/) so PIP_CONSTRAINT resolves at container runtime.
+    content = (REPO_ROOT / dockerfile_path).read_text()
+    assert re.search(
+        r"COPY\s+\.\s+/code/", content
+    ), f"{dockerfile_path} must copy the app (incl. requirements/) into /code"


### PR DESCRIPTION
## Problem

A challenge's dependency install can move `numpy`/`scipy`/etc. off the worker image's already-compiled core stack, producing an import-time ABI failure deep in SciPy:

```
File ".../scipy/interpolate/_fitpack_impl.py", line 103, in <module>
    'iwrk': array([], dfitpack_int), 'u': array([], float),
TypeError
```

This surfaced on the nuScenes detection challenge (`challenge_356`) worker: `from nuscenes import NuScenes` → `import sklearn.metrics` → `import scipy.stats` → SciPy fails to import because the installed NumPy no longer matches the ABI SciPy was compiled against.

#5152 constrained the challenge `requirements.txt` install with `-c`. But the EvalAI-Starters `evaluation_script/__init__.py` also ships an `install()` helper that runs `sys.executable -m pip install <pkg>` **in-process at import time**, with **no** constraint. That path (and any transitive upgrade it triggers) can still move the core stack — the actual hole behind this failure class.

## Fix

Export `PIP_CONSTRAINT` / `PIP_BUILD_CONSTRAINT` so **every** pip invocation in the worker — the `requirements.txt` install, the `install()` helper, and transitive deps — honors the worker's pinned core stack.

- `configure_challenge_pip_environment()` sets both env vars from the per-version constraints file (`requirements/worker_py3_<minor>.txt`) and is called at the top of `extract_challenge_data()`, before any challenge dependency is installed or the challenge module is imported.
- The same env is baked into all six worker images (`docker/{prod,dev}/worker_py3_{7,8,9}`) as defense-in-depth for any pip run outside that path.
- The default-provided, pinned package set is documented inline in `requirements/worker_py3_*.txt`.

A challenge that genuinely needs a different core version now gets a clean, surfaced pip resolution error instead of a cryptic ABI crash at import.

## Testing

- Unit: `configure_challenge_pip_environment()` sets both vars from the constraints file (and leaves the env untouched when none is found); `extract_challenge_data()` calls it before importing the challenge module.
- Dockerfile guard: all six worker images pin `PIP_CONSTRAINT`/`PIP_BUILD_CONSTRAINT` to their matching requirements file and copy the app into the image (12 cases, passing).
- `black`, `isort`, `flake8`, `pylint` (8.10/10) clean via pre-commit.

## Follow-up

This is the immediate, fleet-wide hardening (Tier A). A follow-up introduces per-challenge baked worker images built at challenge creation and rebuilt fleet-wide on deploy with promote-on-green gating (Tier C), for challenges that need a divergent core stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency installation consistency for challenges and evaluation steps by enforcing each worker image’s pinned core packages through pip constraints.
  * Lowers the likelihood of ABI-incompatible NumPy/SciPy combinations during challenge setup and any install actions triggered during module import.
* **Tests**
  * Added unit tests to confirm pip constraint environment variables are set correctly and applied before challenge module import.
  * Added tests verifying Docker runtime stages include the expected constraint settings and that the constraint file is available at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->