### PR TITLE
fix(worker): Persist stdout/stderr/result files when artifact serialization fails

### DIFF
--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -147,6 +147,29 @@ def alarm_handler(signum, frame):
     raise ExecutionTimeLimitExceeded
 
 
+def serialize_submission_artifact(value):
+    """Serialize evaluate() artifacts for Django ContentFile / FileField.
+
+    Challenge evaluation scripts commonly return ``dict`` / ``list`` metadata
+    (see the documented ``evaluate`` return format) and may include values that
+    are not JSON-native (e.g. numpy scalars). Passing a non-string to
+    ``ContentFile`` raises ``TypeError``, and ``json.dumps`` without a fallback
+    can raise as well. Either failure used to abort ``run_submission`` after
+    status was already set to FINISHED/FAILED, so stdout/stderr/result files
+    were never persisted.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value)
+    except TypeError:
+        return json.dumps(value, default=str)
+
+
 def download_and_extract_file(url, download_location):
     """
     * Function to extract download a file.
@@ -633,24 +656,34 @@ def run_submission(
             submission.completed_at = timezone.now()
             submission.save()
             if not challenge_phase.disable_logs:
-                log_submission_artifact_upload_context(
-                    submission,
-                    "submission_worker.run_submission.remote_eval_failed_logs",
-                )
-                with open(stdout_file, "r") as stdout:
-                    stdout_content = stdout.read()
-                    submission.stdout_file.save(
-                        "stdout.txt", ContentFile(stdout_content)
+                try:
+                    log_submission_artifact_upload_context(
+                        submission,
+                        "submission_worker.run_submission.remote_eval_failed_logs",
                     )
-                with open(stderr_file, "r") as stderr:
-                    stderr_content = stderr.read()
-                    submission.stderr_file.save(
-                        "stderr.txt", ContentFile(stderr_content)
+                    with open(stdout_file, "r") as stdout_fh:
+                        stdout_content = stdout_fh.read().encode("utf-8")
+                        submission.stdout_file.save(
+                            "stdout.txt", ContentFile(stdout_content)
+                        )
+                    with open(stderr_file, "r") as stderr_fh:
+                        stderr_content = stderr_fh.read().encode("utf-8")
+                        submission.stderr_file.save(
+                            "stderr.txt", ContentFile(stderr_content)
+                        )
+                    enqueue_submission_artifact_retention_tagging(
+                        submission,
+                        [
+                            submission.stdout_file.name,
+                            submission.stderr_file.name,
+                        ],
                     )
-                enqueue_submission_artifact_retention_tagging(
-                    submission,
-                    [submission.stdout_file.name, submission.stderr_file.name],
-                )
+                except Exception:
+                    logger.exception(
+                        "{} Failed to persist remote-eval logs for submission {}".format(
+                            SUBMISSION_LOGS_PREFIX, submission.id
+                        )
+                    )
 
             # delete the complete temp run directory
             shutil.rmtree(temp_run_dir)
@@ -784,65 +817,88 @@ def run_submission(
     submission.completed_at = timezone.now()
     submission.save()
 
-    # after the execution is finished, set `status` to finished and hence
-    # `completed_at`
-    if submission_output and successful_submission_flag:
-        log_submission_artifact_upload_context(
-            submission,
-            "submission_worker.run_submission.before_result_files",
-        )
-        output = {}
-        output["result"] = submission_output.get("result", "")
-        submission.output = output
-
-        # Save submission_result_file
-        submission_result = submission_output.get("submission_result", "")
-        submission_result = json.dumps(submission_result)
-        submission.submission_result_file.save(
-            "submission_result.json", ContentFile(submission_result)
-        )
-
-        # Save submission_metadata_file
-        submission_metadata = submission_output.get("submission_metadata", "")
-        submission.submission_metadata_file.save(
-            "submission_metadata.json", ContentFile(submission_metadata)
-        )
-        submission.save()
-        enqueue_submission_artifact_retention_tagging(
-            submission,
-            [
-                submission.submission_result_file.name,
-                submission.submission_metadata_file.name,
-            ],
-        )
-
-    stderr.close()
+    # Always close redirected handles before reading temp log files.
     stdout.close()
-    stderr_content = open(stderr_file, "r").read()
-    stdout_content = open(stdout_file, "r").read()
+    stderr.close()
 
-    # TODO :: see if two updates can be combine into a single update.
+    # Persist stdout/stderr BEFORE result/metadata artifacts. Serialization of
+    # evaluate() return values (dict metadata without dumps, numpy scalars,
+    # etc.) or retention-tagging failures used to raise here and skip logs,
+    # leaving users with finished/failed submissions and empty file fields.
     if not challenge_phase.disable_logs:
-        log_submission_artifact_upload_context(
-            submission, "submission_worker.run_submission.before_stdout_stderr"
-        )
-        with open(stdout_file, "r") as stdout:
-            stdout_content = stdout.read()
-            submission.stdout_file.save(
-                "stdout.txt", ContentFile(stdout_content)
+        try:
+            log_submission_artifact_upload_context(
+                submission,
+                "submission_worker.run_submission.before_stdout_stderr",
             )
-        if submission_status is Submission.FAILED:
-            with open(stderr_file, "r") as stderr:
-                stderr_content = stderr.read().encode("utf-8")
-                submission.stderr_file.save(
-                    "stderr.txt", ContentFile(stderr_content)
+            with open(stdout_file, "r") as stdout_fh:
+                stdout_content = stdout_fh.read().encode("utf-8")
+                submission.stdout_file.save(
+                    "stdout.txt", ContentFile(stdout_content)
                 )
-        artifact_paths = [submission.stdout_file.name]
-        if submission.stderr_file.name:
-            artifact_paths.append(submission.stderr_file.name)
-        enqueue_submission_artifact_retention_tagging(
-            submission, artifact_paths
-        )
+            if submission_status == Submission.FAILED:
+                with open(stderr_file, "r") as stderr_fh:
+                    stderr_content = stderr_fh.read().encode("utf-8")
+                    submission.stderr_file.save(
+                        "stderr.txt", ContentFile(stderr_content)
+                    )
+            artifact_paths = [submission.stdout_file.name]
+            if submission.stderr_file.name:
+                artifact_paths.append(submission.stderr_file.name)
+            enqueue_submission_artifact_retention_tagging(
+                submission, artifact_paths
+            )
+        except Exception:
+            logger.exception(
+                "{} Failed to persist stdout/stderr for submission {}".format(
+                    SUBMISSION_LOGS_PREFIX, submission.id
+                )
+            )
+
+    # Persist result/metadata after logs so serialization or tagging failures
+    # cannot drop stdout/stderr for participants.
+    if submission_output and successful_submission_flag:
+        try:
+            log_submission_artifact_upload_context(
+                submission,
+                "submission_worker.run_submission.before_result_files",
+            )
+            output = {}
+            output["result"] = submission_output.get("result", "")
+            submission.output = output
+
+            # Preserve historical json.dumps for submission_result (including
+            # string values). default=str covers numpy scalars and similar.
+            submission_result = json.dumps(
+                submission_output.get("submission_result", ""),
+                default=str,
+            )
+            # Metadata is often a dict in evaluate() return values; ContentFile
+            # requires str/bytes, so serialize first (matches remote worker).
+            submission_metadata = serialize_submission_artifact(
+                submission_output.get("submission_metadata", "")
+            )
+
+            submission.submission_result_file.save(
+                "submission_result.json", ContentFile(submission_result)
+            )
+            submission.submission_metadata_file.save(
+                "submission_metadata.json", ContentFile(submission_metadata)
+            )
+            submission.save()
+            enqueue_submission_artifact_retention_tagging(
+                submission,
+                [
+                    submission.submission_result_file.name,
+                    submission.submission_metadata_file.name,
+                ],
+            )
+        except Exception:
+            logger.exception(
+                "{} Failed to persist result/metadata for submission {}".format(
+                    SUBMISSION_LOGS_PREFIX, submission.id
+                )
+            )
 
     # delete the complete temp run directory
     shutil.rmtree(temp_run_dir)

--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -166,8 +166,11 @@ def serialize_submission_artifact(value):
         return value
     try:
         return json.dumps(value)
-    except TypeError:
-        return json.dumps(value, default=str)
+    except (TypeError, ValueError):
+        try:
+            return json.dumps(value, default=str)
+        except (TypeError, ValueError):
+            return str(value)
 
 
 def download_and_extract_file(url, download_location):

--- a/tests/unit/worker/test_submission_worker.py
+++ b/tests/unit/worker/test_submission_worker.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import signal
@@ -8,6 +9,7 @@ import zipfile
 from datetime import timedelta
 from io import BytesIO
 from os.path import join
+from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
 import boto3
@@ -48,6 +50,7 @@ from scripts.workers.submission_worker import (
     process_add_challenge_message,
     return_file_url_per_environment,
     run_submission,
+    serialize_submission_artifact,
 )
 from settings.common import SQS_RETENTION_PERIOD
 
@@ -1357,3 +1360,164 @@ class ExtractChallengeDataConstraintEnvTest(APITestCase):
 
         mock_configure.assert_called_once_with()
         mock_import.assert_called_once()
+
+
+class SerializeSubmissionArtifactTest(TestCase):
+    def test_none_and_empty(self):
+        self.assertEqual(serialize_submission_artifact(None), "")
+        self.assertEqual(serialize_submission_artifact(""), "")
+
+    def test_string_passthrough(self):
+        self.assertEqual(serialize_submission_artifact("already"), "already")
+
+    def test_bytes_decoded(self):
+        self.assertEqual(serialize_submission_artifact(b"logs"), "logs")
+
+    def test_dict_json_serialized(self):
+        serialized = serialize_submission_artifact({"foo": "bar", "n": 1})
+        self.assertEqual(json.loads(serialized), {"foo": "bar", "n": 1})
+
+    def test_list_json_serialized(self):
+        serialized = serialize_submission_artifact([1, "a"])
+        self.assertEqual(json.loads(serialized), [1, "a"])
+
+    def test_non_json_native_uses_default_str(self):
+        class Weird:
+            def __str__(self):
+                return "weird-value"
+
+        serialized = serialize_submission_artifact({"x": Weird()})
+        self.assertIn("weird-value", serialized)
+
+
+class RunSubmissionArtifactPersistenceTest(BaseAPITestClass):
+    def _setup_phase_map(self):
+        PHASE_ANNOTATION_FILE_NAME_MAP[self.challenge.id] = {
+            self.challenge_phase.id: "dummy_annotation.txt"
+        }
+
+    @patch("scripts.workers.submission_worker.EVALUATION_SCRIPTS")
+    @patch("scripts.workers.submission_worker.MultiOut")
+    @patch("scripts.workers.submission_worker.stdout_redirect")
+    @patch("scripts.workers.submission_worker.stderr_redirect")
+    @patch("scripts.workers.submission_worker.shutil.rmtree")
+    @patch("scripts.workers.submission_worker.LeaderboardData")
+    @patch("scripts.workers.submission_worker.ChallengePhaseSplit.objects.get")
+    def test_dict_metadata_still_persists_stdout_and_result_files(
+        self,
+        mock_cps_get,
+        mock_leaderboard_data,
+        mock_rmtree,
+        mock_stderr_redirect,
+        mock_stdout_redirect,
+        mock_multiout,
+        mock_evaluation_scripts,
+    ):
+        """Dict submission_metadata used to TypeError in ContentFile and skip
+        all artifact uploads after status was already marked finished."""
+        self._setup_phase_map()
+        submission = self.submission
+        submission.challenge_phase.challenge.remote_evaluation = False
+        submission.challenge_phase.disable_logs = False
+
+        mock_evaluation_scripts.__getitem__.return_value.evaluate.return_value = {
+            "result": [{"split_codename_1": {"key1": 10}}],
+            "submission_result": {"score": 10},
+            "submission_metadata": {"foo": "bar", "split": "dev"},
+        }
+
+        mock_cps = MagicMock()
+        mock_cps.leaderboard = MagicMock()
+        mock_cps.dataset_split.codename = "split_codename_1"
+        mock_cps_get.return_value = mock_cps
+
+        temp_run_dir = join(
+            SUBMISSION_DATA_DIR.format(submission_id=submission.id), "run"
+        )
+        os.makedirs(temp_run_dir, exist_ok=True)
+        with open(join(temp_run_dir, "temp_stdout.txt"), "w") as fh:
+            fh.write("eval stdout")
+        with open(join(temp_run_dir, "temp_stderr.txt"), "w") as fh:
+            fh.write("")
+
+        run_submission(
+            self.challenge.id,
+            self.challenge_phase,
+            submission,
+            "dummy/path",
+        )
+
+        submission.refresh_from_db()
+        self.assertEqual(submission.status, Submission.FINISHED)
+        self.assertTrue(bool(submission.stdout_file.name))
+        self.assertTrue(bool(submission.submission_result_file.name))
+        self.assertTrue(bool(submission.submission_metadata_file.name))
+        self.assertIn(b"eval stdout", submission.stdout_file.read())
+        self.assertEqual(
+            json.loads(submission.submission_metadata_file.read().decode()),
+            {"foo": "bar", "split": "dev"},
+        )
+        self.assertEqual(
+            json.loads(submission.submission_result_file.read().decode()),
+            {"score": 10},
+        )
+
+    @patch("scripts.workers.submission_worker.EVALUATION_SCRIPTS")
+    @patch("scripts.workers.submission_worker.MultiOut")
+    @patch("scripts.workers.submission_worker.stdout_redirect")
+    @patch("scripts.workers.submission_worker.stderr_redirect")
+    @patch("scripts.workers.submission_worker.shutil.rmtree")
+    @patch("scripts.workers.submission_worker.LeaderboardData")
+    @patch("scripts.workers.submission_worker.ChallengePhaseSplit.objects.get")
+    @patch(
+        "scripts.workers.submission_worker.enqueue_submission_artifact_retention_tagging",
+        side_effect=[None, RuntimeError("tagging boom")],
+    )
+    def test_result_artifact_failure_still_persists_stdout(
+        self,
+        mock_enqueue,
+        mock_cps_get,
+        mock_leaderboard_data,
+        mock_rmtree,
+        mock_stderr_redirect,
+        mock_stdout_redirect,
+        mock_multiout,
+        mock_evaluation_scripts,
+    ):
+        """Failures while saving/tagging result files must not drop stdout."""
+        self._setup_phase_map()
+        submission = self.submission
+        submission.challenge_phase.challenge.remote_evaluation = False
+        submission.challenge_phase.disable_logs = False
+
+        mock_evaluation_scripts.__getitem__.return_value.evaluate.return_value = {
+            "result": [{"split_codename_1": {"key1": 10}}],
+            "submission_result": {"score": 10},
+            "submission_metadata": {"foo": "bar"},
+        }
+
+        mock_cps = MagicMock()
+        mock_cps.leaderboard = MagicMock()
+        mock_cps.dataset_split.codename = "split_codename_1"
+        mock_cps_get.return_value = mock_cps
+
+        temp_run_dir = join(
+            SUBMISSION_DATA_DIR.format(submission_id=submission.id), "run"
+        )
+        os.makedirs(temp_run_dir, exist_ok=True)
+        with open(join(temp_run_dir, "temp_stdout.txt"), "w") as fh:
+            fh.write("kept stdout")
+        with open(join(temp_run_dir, "temp_stderr.txt"), "w") as fh:
+            fh.write("")
+
+        run_submission(
+            self.challenge.id,
+            self.challenge_phase,
+            submission,
+            "dummy/path",
+        )
+
+        submission.refresh_from_db()
+        self.assertEqual(submission.status, Submission.FINISHED)
+        self.assertTrue(bool(submission.stdout_file.name))
+        self.assertIn(b"kept stdout", submission.stdout_file.read())

--- a/tests/unit/worker/test_submission_worker.py
+++ b/tests/unit/worker/test_submission_worker.py
@@ -1417,8 +1417,10 @@ class RunSubmissionArtifactPersistenceTest(BaseAPITestClass):
         all artifact uploads after status was already marked finished."""
         self._setup_phase_map()
         submission = self.submission
+        # remote_evaluation is read from submission.challenge_phase.challenge;
+        # disable_logs is read from the challenge_phase arg to run_submission.
         submission.challenge_phase.challenge.remote_evaluation = False
-        submission.challenge_phase.disable_logs = False
+        self.challenge_phase.disable_logs = False
 
         mock_evaluation_scripts.__getitem__.return_value.evaluate.return_value = {
             "result": [{"split_codename_1": {"key1": 10}}],
@@ -1487,8 +1489,10 @@ class RunSubmissionArtifactPersistenceTest(BaseAPITestClass):
         """Failures while saving/tagging result files must not drop stdout."""
         self._setup_phase_map()
         submission = self.submission
+        # remote_evaluation is read from submission.challenge_phase.challenge;
+        # disable_logs is read from the challenge_phase arg to run_submission.
         submission.challenge_phase.challenge.remote_evaluation = False
-        submission.challenge_phase.disable_logs = False
+        self.challenge_phase.disable_logs = False
 
         mock_evaluation_scripts.__getitem__.return_value.evaluate.return_value = {
             "result": [{"split_codename_1": {"key1": 10}}],
@@ -1521,3 +1525,7 @@ class RunSubmissionArtifactPersistenceTest(BaseAPITestClass):
         self.assertEqual(submission.status, Submission.FINISHED)
         self.assertTrue(bool(submission.stdout_file.name))
         self.assertIn(b"kept stdout", submission.stdout_file.read())
+        # Second enqueue (result/metadata tagging) must have raised after
+        # result files were already saved; stdout must still be present.
+        self.assertEqual(mock_enqueue.call_count, 2)
+        self.assertTrue(bool(submission.submission_result_file.name))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After deploying the Python 3.9 submission worker, successful evaluations could finish with **empty `stdout_file` / `stderr_file` / `submission_result_file`**.

Root cause in `scripts/workers/submission_worker.py`:

1. Status was saved as `finished`/`failed` first.
2. Result/metadata persistence ran next and could raise:
   - `ContentFile(dict)` when `submission_metadata` is a dict (the documented `evaluate()` return shape)
   - `json.dumps(...)` on numpy scalars / other non-JSON-native values in `submission_result`
   - retention-tagging errors after artifact upload
3. Stdout/stderr were saved **after** that block, so any exception aborted the worker callback and left users with no log or result files.

## Fix

- Add `serialize_submission_artifact()` for safe metadata serialization (matches remote worker behavior).
- Use `json.dumps(..., default=str)` for result payloads.
- Persist stdout/stderr **before** result/metadata artifacts.
- Wrap each persistence step so one failure cannot drop the others.
- Encode stdout as UTF-8 consistently with stderr.

## Test plan

- [x] `pytest tests/unit/worker/test_submission_worker.py` (170 passed)
- [x] Coverage for dict metadata + result-tagging failure still keeping stdout
- [x] black / isort on touched files
- [ ] Redeploy py3.9 worker image and confirm a finished submission has downloadable stdout + result JSON

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aaf7dd51-18d0-4931-bbf7-f89b539689f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aaf7dd51-18d0-4931-bbf7-f89b539689f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of persisting submission stdout, results, and metadata artifacts after evaluation.
  * Submissions now complete and store available artifacts even if artifact serialization or retention tagging fails.
  * Enhanced support for different artifact types (text, bytes, structured JSON, and other values) with safe fallbacks.
  * Improved capture and storage of remote evaluation logs on failure.
* **Tests**
  * Added unit coverage for artifact serialization, persistence behavior, and error recovery during retention tagging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->