### PR TITLE
fix(frontend): hide Environment Logs column for non-docker challenges

### DIFF
--- a/frontend/src/js/controllers/challengeCtrl.js
+++ b/frontend/src/js/controllers/challengeCtrl.js
@@ -387,6 +387,7 @@
                 vm.is_approval_requested = details.is_approval_requested;
                 vm.isFrozen = details.is_frozen;
                 vm.isRemoteChallenge = details.remote_evaluation;
+                vm.isDockerBased = details.is_docker_based;
                 vm.isStaticCodeUploadChallenge = details.is_static_dataset_code_upload;
                 vm.allowResumingSubmissions = details.allow_resuming_submissions;
                 vm.allowHostCancelSubmissions = details.allow_host_cancel_submissions,

--- a/frontend/src/views/web/challenge/my-challenge-all-submission.html
+++ b/frontend/src/views/web/challenge/my-challenge-all-submission.html
@@ -88,7 +88,7 @@
                         <th class="fs-18 w-300" data-field="file">Submitted file</th>
                         <th class="fs-18 w-300" data-field="file">Stdout file</th>
                         <th class="fs-18 w-300" data-field="file">Stderr file</th>
-                        <th class="fs-18 w-300" ng-if="challenge.isChallengeHost &&
+                        <th class="fs-18 w-300" ng-if="challenge.isChallengeHost && challenge.isDockerBased &&
                                 !challenge.isStaticCodeUploadChallenge" data-field="file">Environment Logs</th>
                         <th class="fs-18 w-300" data-field="file">Result file</th>
                         <th class="fs-18 w-300" data-field="file">Metadata file</th>
@@ -127,11 +127,11 @@
                                     class="blue-text"><i class="fa fa-external-link"></i> Link</a></td>
                             <td ng-if="!key.stderr_file">None</td>
 
-                            <td ng-if="key.environment_log_file && challenge.isChallengeHost &&
+                            <td ng-if="key.environment_log_file && challenge.isChallengeHost && challenge.isDockerBased &&
                                     !challenge.isStaticCodeUploadChallenge">
                                 <a href="{{key.environment_log_file}}" target="_blank"
                                     class="blue-text"><i class="fa fa-external-link"></i> Link</a></td>
-                            <td ng-if="!key.environment_log_file && challenge.isChallengeHost &&
+                            <td ng-if="!key.environment_log_file && challenge.isChallengeHost && challenge.isDockerBased &&
                                     !challenge.isStaticCodeUploadChallenge">None</td>
 
                             <td ng-if="key.submission_result_file"><a href="{{key.submission_result_file}}"

--- a/frontend/src/views/web/challenge/my-submission.html
+++ b/frontend/src/views/web/challenge/my-submission.html
@@ -63,7 +63,7 @@
                             <th class="fs-18 w-300" data-field="file">Result file</th>
                             <th class="fs-18 w-300" data-field="file">Stdout file</th>
                             <th class="fs-18 w-300" data-field="file">Stderr file</th>
-                            <th class="fs-18 w-300" ng-if="challenge.isChallengeHost &&
+                            <th class="fs-18 w-300" ng-if="challenge.isChallengeHost && challenge.isDockerBased &&
                                     !challenge.isStaticCodeUploadChallenge" data-field="file">Environment Logs</th>
                             <th class="align-center fs-18 w-300" data-field="file">Submitted at</th>
                             <th class="align-center fs-18 w-300" ng-if="challenge.currentPhaseLeaderboardPublic"
@@ -112,11 +112,11 @@
                                         class="blue-text"><i class="fa fa-external-link"></i> Link</a></td>
                                 <td ng-if="!key.stderr_file">None</td>
 
-                                <td ng-if="key.environment_log_file && challenge.isChallengeHost &&
+                                <td ng-if="key.environment_log_file && challenge.isChallengeHost && challenge.isDockerBased &&
                                         !challenge.isStaticCodeUploadChallenge">
                                     <a href="{{key.environment_log_file}}" target="_blank"
                                         class="blue-text"><i class="fa fa-external-link"></i> Link</a></td>
-                                <td ng-if="!key.environment_log_file && challenge.isChallengeHost &&
+                                <td ng-if="!key.environment_log_file && challenge.isChallengeHost && challenge.isDockerBased &&
                                         !challenge.isStaticCodeUploadChallenge">None</td>
 
                                 <td>{{key.submitted_at | date:'medium'}}</td>


### PR DESCRIPTION
## Change Description

The **Environment Logs** column in the submission tables was gated only on `challenge.isChallengeHost && !challenge.isStaticCodeUploadChallenge`. As a result it rendered for challenge hosts on plain prediction-upload challenges (non-docker, non-code-upload) that never produce environment logs — showing an empty `None` column on the UI.

Root cause: `vm.isDockerBased` was declared in `challengeCtrl.js` but **never assigned** from the challenge details response, so it stayed permanently `false` and was unusable in the templates.

## What changed

- `challengeCtrl.js`: populate `vm.isDockerBased = details.is_docker_based;` from the challenge details response.
- `my-submission.html` (participant view) and `my-challenge-all-submission.html` (host view): add `challenge.isDockerBased` to the Environment Logs header and both cell `ng-if` conditions.

## Behavior (host view)

| Challenge type | Before | After |
| :--- | :--- | :--- |
| Docker-based | shown | shown (unchanged) |
| Static-dataset code-upload | hidden | hidden (unchanged) |
| Plain prediction / non-docker remote | **shown (bug)** | **hidden (fixed)** |

Participants never see the column (backend pops `environment_log_file` for non-hosts, and `isChallengeHost` is false).

## Change Type
- [x] Bug fix (fix)

## Testing
Frontend AngularJS template + controller change; no compile step. Verified conditions across both views. Rebuild frontend (`gulp`) to serve updated `dist/`.

## Notes for reviewer
Kept the existing `!isStaticCodeUploadChallenge` exclusion intact (intentional per #3879). This PR only adds the missing positive docker-based gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment Logs are now displayed only for Docker-based challenges.
  * Challenge details correctly determine whether a challenge uses Docker.
  * Environment log columns and links are hidden when the challenge type does not support them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->