### PR TITLE
fix(worker): scale EKS nodegroups for cross-account code-upload challenges

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -5719,6 +5719,7 @@ def get_challenge_autoscale_meta(request, challenge_pk):
         "aws_region": challenge.aws_region
         or os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
         "use_host_credentials": challenge.use_host_credentials,
+        "aws_account_id": challenge.aws_account_id,
         "scale_up_cap": challenge.max_worker_instance or 1,
     }
     return Response(response_data, status=status.HTTP_200_OK)

--- a/scripts/lambda/auto_scale_eks_nodes_lambda.py
+++ b/scripts/lambda/auto_scale_eks_nodes_lambda.py
@@ -10,6 +10,9 @@ Environment variables required:
 - EVALAI_API_SERVER: EvalAI API server URL (e.g. https://eval.ai)
 - LAMBDA_AUTH_TOKEN: shared secret for internal Lambda-auth APIs
 - AWS_REGION: AWS region (optional, defaults to us-east-1)
+- EKS_AUTOSCALE_CROSS_ACCOUNT_ROLE_NAME: name of the IAM role assumed in a
+  challenge's host AWS account for cross-account nodegroup scaling
+  (optional, defaults to "evalai-autoscale-crossaccount")
 """
 
 import json
@@ -28,6 +31,9 @@ logger.setLevel(logging.INFO)
 EVALAI_API_SERVER = os.environ.get("EVALAI_API_SERVER")
 LAMBDA_AUTH_TOKEN = os.environ.get("LAMBDA_AUTH_TOKEN")
 AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+CROSS_ACCOUNT_ROLE_NAME = os.environ.get(
+    "EKS_AUTOSCALE_CROSS_ACCOUNT_ROLE_NAME", "evalai-autoscale-crossaccount"
+)
 
 
 def _validate_env():
@@ -82,6 +88,34 @@ def _should_force_scale_down(challenge_meta):
         logger.warning("Invalid end_date format: %s", end_date)
         return False
     return challenge_end <= datetime.now(challenge_end.tzinfo)
+
+
+def _build_eks_client(aws_region, challenge_meta):
+    """
+    Build an EKS client for the challenge's nodegroup.
+
+    Challenges that run in a host-provided AWS account (use_host_credentials)
+    have their EKS cluster in a different account than this Lambda. For those
+    we assume a cross-account role in the challenge's account; otherwise we use
+    the Lambda's own execution role (same-account behaviour, unchanged).
+    """
+    account_id = challenge_meta.get("aws_account_id")
+    if challenge_meta.get("use_host_credentials") and account_id:
+        role_arn = "arn:aws:iam::{0}:role/{1}".format(
+            account_id, CROSS_ACCOUNT_ROLE_NAME
+        )
+        credentials = boto3.client("sts").assume_role(
+            RoleArn=role_arn,
+            RoleSessionName="evalai-eks-autoscale",
+        )["Credentials"]
+        return boto3.client(
+            "eks",
+            region_name=aws_region,
+            aws_access_key_id=credentials["AccessKeyId"],
+            aws_secret_access_key=credentials["SecretAccessKey"],
+            aws_session_token=credentials["SessionToken"],
+        )
+    return boto3.client("eks", region_name=aws_region)
 
 
 def handler(event, context):
@@ -152,7 +186,7 @@ def handler(event, context):
     force_scale_down = _should_force_scale_down(challenge_meta)
 
     try:
-        eks_client = boto3.client("eks", region_name=aws_region)
+        eks_client = _build_eks_client(aws_region, challenge_meta)
         nodegroup_name = _get_nodegroup_name(eks_client, cluster_name)
         current = _get_scaling_config(eks_client, cluster_name, nodegroup_name)
         current_desired = int(current.get("desiredSize", 0))

--- a/tests/unit/lambda/test_auto_scale_eks_nodes_lambda.py
+++ b/tests/unit/lambda/test_auto_scale_eks_nodes_lambda.py
@@ -293,6 +293,107 @@ class TestAutoScaleEksNodesLambda(unittest.TestCase):
         kwargs = mock_eks.update_nodegroup_config.call_args.kwargs
         self.assertEqual(kwargs["scalingConfig"]["desiredSize"], 0)
 
+    @patch("boto3.client")
+    @patch("auto_scale_eks_nodes_lambda._call_evalai_api")
+    def test_assumes_cross_account_role_for_host_credentials(
+        self, mock_call_evalai_api, mock_boto_client
+    ):
+        mock_call_evalai_api.side_effect = [
+            {
+                "is_docker_based": True,
+                "remote_evaluation": False,
+                "cluster_name": "cluster-1",
+                "scale_up_cap": 5,
+                "use_host_credentials": True,
+                "aws_account_id": "123456789012",
+                "end_date": None,
+            },
+            {"pending_submissions": 4},
+        ]
+        mock_sts = MagicMock()
+        mock_sts.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "AKIATEST",
+                "SecretAccessKey": "secret",
+                "SessionToken": "token",
+            }
+        }
+        mock_eks = MagicMock()
+        mock_eks.list_nodegroups.return_value = {"nodegroups": ["ng-1"]}
+        mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {
+                "scalingConfig": {"minSize": 0, "desiredSize": 0, "maxSize": 1}
+            }
+        }
+        mock_eks.update_nodegroup_config.return_value = {
+            "update": {"id": "upd-xacct"}
+        }
+
+        def client_factory(service, *args, **kwargs):
+            return mock_sts if service == "sts" else mock_eks
+
+        mock_boto_client.side_effect = client_factory
+
+        response = self.module.handler({"challenge_pk": 42}, None)
+
+        self.assertEqual(response["statusCode"], 200)
+        mock_sts.assume_role.assert_called_once_with(
+            RoleArn="arn:aws:iam::123456789012:role/evalai-autoscale-crossaccount",
+            RoleSessionName="evalai-eks-autoscale",
+        )
+        mock_boto_client.assert_any_call(
+            "eks",
+            region_name="us-east-1",
+            aws_access_key_id="AKIATEST",
+            aws_secret_access_key="secret",
+            aws_session_token="token",
+        )
+        self.assertEqual(
+            mock_eks.update_nodegroup_config.call_args.kwargs["scalingConfig"][
+                "desiredSize"
+            ],
+            4,
+        )
+
+    @patch("boto3.client")
+    @patch("auto_scale_eks_nodes_lambda._call_evalai_api")
+    def test_uses_default_client_without_host_credentials(
+        self, mock_call_evalai_api, mock_boto_client
+    ):
+        mock_call_evalai_api.side_effect = [
+            {
+                "is_docker_based": True,
+                "remote_evaluation": False,
+                "cluster_name": "cluster-1",
+                "scale_up_cap": 5,
+                "use_host_credentials": False,
+                "aws_account_id": "123456789012",
+                "end_date": None,
+            },
+            {"pending_submissions": 4},
+        ]
+        mock_eks = MagicMock()
+        mock_eks.list_nodegroups.return_value = {"nodegroups": ["ng-1"]}
+        mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {
+                "scalingConfig": {"minSize": 0, "desiredSize": 0, "maxSize": 1}
+            }
+        }
+        mock_eks.update_nodegroup_config.return_value = {
+            "update": {"id": "upd-same"}
+        }
+        mock_boto_client.return_value = mock_eks
+
+        response = self.module.handler({"challenge_pk": 77}, None)
+
+        self.assertEqual(response["statusCode"], 200)
+        # No cross-account assume when use_host_credentials is False.
+        for call in mock_boto_client.call_args_list:
+            self.assertNotEqual(call.args[0], "sts")
+        mock_boto_client.assert_called_once_with(
+            "eks", region_name="us-east-1"
+        )
+
 
 class TestDesiredSizeLogic(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Problem

The EKS node autoscale Lambda (`auto_scale_eks_nodes_lambda`) builds its EKS client with the Lambda's own execution role, so it can only manage nodegroups in the platform account. Challenges that run in a host-provided AWS account (`use_host_credentials`) keep their EKS cluster in a **different** account, so every autoscale invocation fails with `AccessDenied` on `eks:ListNodegroups`. The nodegroup is never scaled up from zero and submission pods stay `Pending` indefinitely.

## Fix

- When `use_host_credentials` is set and `aws_account_id` is present, the Lambda assumes a cross-account role in the challenge's account and builds the EKS client with the temporary credentials. Same-account behaviour is unchanged.
- `get_challenge_autoscale_meta` now returns `aws_account_id` so the Lambda knows which account to assume into.
- Role name configurable via `EKS_AUTOSCALE_CROSS_ACCOUNT_ROLE_NAME` (default `evalai-autoscale-crossaccount`).

## Ops prerequisites

In each host account, an IAM role (default `evalai-autoscale-crossaccount`) that (a) trusts the Lambda execution role and (b) has `eks:ListNodegroups`, `eks:DescribeNodegroup`, `eks:UpdateNodegroupConfig`. The Lambda role needs `sts:AssumeRole` on it. Deploy the server change (adds `aws_account_id` to `autoscale_meta`) and the Lambda together.

## Tests

- `test_assumes_cross_account_role_for_host_credentials`
- `test_uses_default_client_without_host_credentials`
- Existing autoscale tests still pass (13 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * EKS node autoscaling now supports challenges hosted in separate AWS accounts.
  * Autoscaling can securely assume a configured cross-account role when host credentials are required.
  * Challenge autoscaling metadata now includes the associated AWS account ID.

* **Bug Fixes**
  * Improved handling of AWS credentials for cross-account EKS nodegroup scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->