### PR TITLE
Ensure EC2 containers restart after deployment migrations

### DIFF
--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -173,8 +173,10 @@ fi
 docker compose -f "docker-compose-\${TARGET_ENVIRONMENT}.yml" pull django nodejs celery memcached
 # Run migrations before starting django. container-start.sh also calls migrate on
 # startup; running both concurrently races on CREATE TABLE (pg_type_typname_nsp_index).
+# Detach stdin so compose cannot consume the remaining commands from the SSH heredoc.
 docker compose -f "docker-compose-\${TARGET_ENVIRONMENT}.yml" run --rm \
-  django sh -c "python manage.py migrate --noinput && python manage.py refresh_worker_task_definitions --commit-id \${COMMIT_ID}"
+  django sh -c "python manage.py migrate --noinput && python manage.py refresh_worker_task_definitions --commit-id \${COMMIT_ID}" \
+  </dev/null
 docker compose -f "docker-compose-\${TARGET_ENVIRONMENT}.yml" up -d --force-recreate --remove-orphans django nodejs celery memcached
 ENDSSH
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- detach the one-off Django deployment container from the SSH heredoc stdin
- preserve the subsequent `docker compose up --force-recreate` command so EC2 services restart after migrations and worker task refreshes

## Testing
- `bash -n scripts/deployment/deploy.sh`
- `git diff --check`
- mocked SSH/Compose deployment confirms the final `up -d --force-recreate` command executes after the one-off migration container attempts to drain stdin
- `./scripts/run-all-tests.sh` — 600 frontend tests and 1,869 backend tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e37c2eec-e5b0-4930-b8dc-aaaa98fff226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e37c2eec-e5b0-4930-b8dc-aaaa98fff226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated deployments by preventing container commands from consuming subsequent deployment instructions.
  * Ensured database migrations and refresh steps execute reliably during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->