### PR TITLE
fix(ecs): strip .fifo suffix from ECS service names

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -62,6 +62,16 @@ def load_aws_api_kwargs(formatted_kwargs):
     return ast.literal_eval(formatted_kwargs)
 
 
+def get_ecs_service_name(queue_name):
+    """Return ECS-safe service name from a queue name.
+
+    Strips the .fifo suffix (which contains a dot illegal in ECS
+    service names) before appending ``_service``.
+    """
+    base = queue_name.removesuffix(".fifo")
+    return f"{base}_service"
+
+
 def get_evalai_submission_worker_ecr_prefixes():
     """
     Return accepted ECR URL prefixes for EvalAI-managed submission worker images.
@@ -553,7 +563,7 @@ def setup_auto_scaling_for_service(challenge):
         return True
 
     queue_name = challenge.queue
-    service_name = f"{queue_name}_service"
+    service_name = get_ecs_service_name(queue_name)
     cluster = COMMON_SETTINGS_DICT["CLUSTER"]
     resource_id = f"service/{cluster}/{service_name}"
     # A ceiling of 0 would leave the service permanently switched off, since the
@@ -682,7 +692,7 @@ def cleanup_auto_scaling_for_service(challenge):
         return
 
     queue_name = challenge.queue
-    service_name = f"{queue_name}_service"
+    service_name = get_ecs_service_name(queue_name)
     cluster = COMMON_SETTINGS_DICT["CLUSTER"]
     resource_id = f"service/{cluster}/{service_name}"
 
@@ -1263,7 +1273,7 @@ def create_service_by_challenge_pk(client, challenge, client_token):
     """
 
     queue_name = challenge.queue
-    service_name = f"{queue_name}_service"
+    service_name = get_ecs_service_name(queue_name)
     if (
         challenge.workers is None
     ):  # Verify if the challenge is new (i.e, service not yet created.).
@@ -1361,7 +1371,7 @@ def update_service_by_challenge_pk(
     """
 
     queue_name = challenge.queue
-    service_name = f"{queue_name}_service"
+    service_name = get_ecs_service_name(queue_name)
     task_def_arn = challenge.task_def_arn
 
     kwargs = update_service_args.format(
@@ -1400,7 +1410,7 @@ def delete_service_by_challenge_pk(challenge):
     """
     client = get_boto3_client("ecs", aws_keys)
     queue_name = challenge.queue
-    service_name = f"{queue_name}_service"
+    service_name = get_ecs_service_name(queue_name)
     kwargs = delete_service_args.format(
         CLUSTER=COMMON_SETTINGS_DICT["CLUSTER"],
         service_name=service_name,
@@ -2108,7 +2118,7 @@ def scale_resources(challenge, worker_cpu_cores, worker_memory):
         challenge.task_def_arn = task_def_arn
         challenge.save()
         force_new_deployment = False
-        service_name = f"{challenge.queue}_service"
+        service_name = get_ecs_service_name(challenge.queue)
         num_of_tasks = challenge.workers
         kwargs = update_service_args.format(
             CLUSTER=COMMON_SETTINGS_DICT["CLUSTER"],

--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -68,7 +68,7 @@ def get_ecs_service_name(queue_name):
     Strips the .fifo suffix (which contains a dot illegal in ECS
     service names) before appending ``_service``.
     """
-    base = queue_name.removesuffix(".fifo")
+    base = queue_name[:-5] if queue_name.endswith(".fifo") else queue_name
     return f"{base}_service"
 
 

--- a/tests/unit/challenges/test_aws_utils.py
+++ b/tests/unit/challenges/test_aws_utils.py
@@ -27,6 +27,7 @@ from challenges.aws_utils import (
     get_code_upload_setup_meta_for_challenge,
     get_current_ecr_env,
     get_deployed_worker_image_urls,
+    get_ecs_service_name,
     get_evalai_code_upload_worker_ecr_image,
     get_evalai_submission_worker_ecr_image,
     get_evalai_submission_worker_ecr_prefixes,
@@ -7319,6 +7320,20 @@ class TestWorkerImageHelpers(TestCase):
         )
         self.assertEqual(kwargs["cluster"], "evalai-prod-cluster")
         self.assertTrue(kwargs["forceNewDeployment"])
+
+    def test_get_ecs_service_name_standard_queue(self):
+        self.assertEqual(get_ecs_service_name("my-queue"), "my-queue_service")
+
+    def test_get_ecs_service_name_fifo_queue(self):
+        self.assertEqual(
+            get_ecs_service_name("my-queue.fifo"), "my-queue_service"
+        )
+
+    def test_get_ecs_service_name_no_double_strip(self):
+        self.assertEqual(
+            get_ecs_service_name("my-queue.fifo.fifo"),
+            "my-queue.fifo_service",
+        )
 
     @patch.dict(
         "challenges.aws_utils.aws_keys",


### PR DESCRIPTION
FIFO queue names end with ".fifo" which contains a dot — illegal in ECS service names (regex ^[a-zA-Z0-9\-_]{1,255}$). Add get_ecs_service_name() helper that strips the suffix before appending "_service", and use it at all 6 call sites in aws_utils.py.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS resource handling for FIFO queues.
  * ECS service names are now generated correctly by removing the `.fifo` suffix, preventing invalid service names during creation, updates, scaling, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->