### PR TITLE
fix(ecs): strip .fifo suffix from all ECS resource names

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -62,14 +62,20 @@ def load_aws_api_kwargs(formatted_kwargs):
     return ast.literal_eval(formatted_kwargs)
 
 
-def get_ecs_service_name(queue_name):
-    """Return ECS-safe service name from a queue name.
+def strip_fifo_suffix(queue_name):
+    """Strip the ``.fifo`` suffix from an SQS queue name.
 
-    Strips the .fifo suffix (which contains a dot illegal in ECS
-    service names) before appending ``_service``.
+    The suffix contains a dot which is illegal in ECS resource names
+    (service names, task-definition families, container names).
     """
-    base = queue_name[:-5] if queue_name.endswith(".fifo") else queue_name
-    return f"{base}_service"
+    if queue_name.endswith(".fifo"):
+        return queue_name[:-5]
+    return queue_name
+
+
+def get_ecs_service_name(queue_name):
+    """Return ECS-safe service name from a queue name."""
+    return f"{strip_fifo_suffix(queue_name)}_service"
 
 
 def get_evalai_submission_worker_ecr_prefixes():
@@ -333,6 +339,9 @@ def build_task_definition_dict(
             "ResponseMetadata": {"HTTPStatusCode": HTTPStatus.BAD_REQUEST},
         }
 
+    sqs_queue_name = queue_name
+    queue_name = strip_fifo_suffix(queue_name)
+
     container_name = f"worker_{queue_name}"
     code_upload_container_name = f"code_upload_worker_{queue_name}"
     worker_cpu_cores = (
@@ -383,6 +392,7 @@ def build_task_definition_dict(
             code_upload_container = (
                 container_definition_code_upload_worker.format(
                     queue_name=queue_name,
+                    sqs_queue_name=sqs_queue_name,
                     code_upload_container_name=code_upload_container_name,
                     auth_token=token.refresh_token,
                     cluster_name=cluster_name,
@@ -398,6 +408,7 @@ def build_task_definition_dict(
             submission_container = (
                 container_definition_submission_worker.format(
                     queue_name=queue_name,
+                    sqs_queue_name=sqs_queue_name,
                     container_name=container_name,
                     ENV=ENV,
                     challenge_pk=challenge.pk,
@@ -420,6 +431,7 @@ def build_task_definition_dict(
         else:
             definition = task_definition_code_upload_worker.format(
                 queue_name=queue_name,
+                sqs_queue_name=sqs_queue_name,
                 code_upload_container_name=code_upload_container_name,
                 ENV=ENV,
                 challenge_pk=challenge.pk,
@@ -439,6 +451,7 @@ def build_task_definition_dict(
     else:
         definition = task_definition.format(
             queue_name=queue_name,
+            sqs_queue_name=sqs_queue_name,
             container_name=container_name,
             ENV=ENV,
             challenge_pk=challenge.pk,

--- a/apps/challenges/task_definitions.py
+++ b/apps/challenges/task_definitions.py
@@ -35,7 +35,7 @@ task_definition = """
                 }},
                 {{
                   "name": "CHALLENGE_QUEUE",
-                  "value": "{queue_name}"
+                  "value": "{sqs_queue_name}"
                 }},
                 {{
                   "name": "CELERY_QUEUE_NAME",
@@ -183,7 +183,7 @@ task_definition_code_upload_worker = """
                 }},
                 {{
                   "name": "QUEUE_NAME",
-                  "value": "{queue_name}"
+                  "value": "{sqs_queue_name}"
                 }},
                 {{
                   "name": "EVALAI_API_SERVER",
@@ -281,7 +281,7 @@ container_definition_submission_worker = """
         }},
         {{
             "name": "CHALLENGE_QUEUE",
-            "value": "{queue_name}"
+            "value": "{sqs_queue_name}"
         }},
         {{
             "name": "CELERY_QUEUE_NAME",
@@ -414,7 +414,7 @@ container_definition_code_upload_worker = """
         }},
         {{
             "name": "QUEUE_NAME",
-            "value": "{queue_name}"
+            "value": "{sqs_queue_name}"
         }},
         {{
             "name": "EVALAI_API_SERVER",

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -126,6 +126,7 @@ from .aws_utils import (
     start_workers,
     stop_ec2_instance,
     stop_workers,
+    strip_fifo_suffix,
     terminate_ec2_instance,
 )
 from .models import (
@@ -3766,7 +3767,7 @@ def get_worker_logs(request, challenge_pk):
     response_data = []
 
     log_group_name = get_log_group_name(challenge.pk)
-    log_stream_prefix = challenge.queue
+    log_stream_prefix = strip_fifo_suffix(challenge.queue)
     pattern = ""  # Empty string to get all logs including container logs.
 
     # This is to specify the time window for fetching logs: 3 days before from

--- a/tests/unit/challenges/test_aws_utils.py
+++ b/tests/unit/challenges/test_aws_utils.py
@@ -54,6 +54,7 @@ from challenges.aws_utils import (
     start_workers,
     stop_ec2_instance,
     stop_workers,
+    strip_fifo_suffix,
     terminate_ec2_instance,
     trigger_eks_node_autoscale,
     update_challenge_cleanup_schedule,
@@ -7320,6 +7321,17 @@ class TestWorkerImageHelpers(TestCase):
         )
         self.assertEqual(kwargs["cluster"], "evalai-prod-cluster")
         self.assertTrue(kwargs["forceNewDeployment"])
+
+    def test_strip_fifo_suffix_standard_queue(self):
+        self.assertEqual(strip_fifo_suffix("my-queue"), "my-queue")
+
+    def test_strip_fifo_suffix_fifo_queue(self):
+        self.assertEqual(strip_fifo_suffix("my-queue.fifo"), "my-queue")
+
+    def test_strip_fifo_suffix_no_double_strip(self):
+        self.assertEqual(
+            strip_fifo_suffix("my-queue.fifo.fifo"), "my-queue.fifo"
+        )
 
     def test_get_ecs_service_name_standard_queue(self):
         self.assertEqual(get_ecs_service_name("my-queue"), "my-queue_service")


### PR DESCRIPTION
## Summary

- Fixes `ClientException: Family contains invalid characters` when registering ECS task definitions for FIFO-queue challenges
- The `.fifo` suffix in SQS FIFO queue names contains a dot, which is illegal in ECS resource names (task-definition families, container names, service names, log-stream prefixes)
- Extracts `strip_fifo_suffix()` helper and applies it comprehensively across all ECS resource naming paths

## Changes

- **`aws_utils.py`**: Added `strip_fifo_suffix()` helper; refactored `get_ecs_service_name()` to use it; strip `.fifo` at the top of `build_task_definition_dict()` before constructing container names, families, and log prefixes
- **`task_definitions.py`**: Changed `CHALLENGE_QUEUE` and `QUEUE_NAME` env var values from `{queue_name}` to `{sqs_queue_name}` — workers need the original queue name (with `.fifo`) to connect to SQS
- **`views.py`**: Fixed CloudWatch log stream prefix to use stripped queue name (must match `awslogs-stream-prefix` in task definitions)
- **`test_aws_utils.py`**: Added unit tests for `strip_fifo_suffix()`

## Context

Follow-up to #5169 which fixed only service names. This PR fixes the remaining ECS resource naming paths: task definition families, container names, and log stream prefixes.

## Test plan

- [ ] CI passes (black, isort, pylint, unit tests)
- [ ] Verify challenge 2698 worker task definition refresh succeeds
- [ ] Verify standard (non-FIFO) challenges are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for FIFO queues when managing challenge workers.
  * Ensured ECS services, scaling, task definitions, and log retrieval use compatible queue names while preserving the original queue configuration.
  * Prevented incorrect or duplicated FIFO suffix handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->