### PR TITLE
fix(ecs): sanitize FIFO queue names for ECS task definition families

### DIFF
--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -62,6 +62,9 @@ def load_aws_api_kwargs(formatted_kwargs):
     return ast.literal_eval(formatted_kwargs)
 
 
+ECS_RESOURCE_NAME_PATTERN = re.compile(r"[^a-zA-Z0-9_-]+")
+
+
 def strip_fifo_suffix(queue_name):
     """Strip the ``.fifo`` suffix from an SQS queue name.
 
@@ -73,9 +76,14 @@ def strip_fifo_suffix(queue_name):
     return queue_name
 
 
+def sanitize_ecs_resource_name(name):
+    """Return a name safe for ECS families, services, and containers."""
+    return ECS_RESOURCE_NAME_PATTERN.sub("-", strip_fifo_suffix(name))
+
+
 def get_ecs_service_name(queue_name):
     """Return ECS-safe service name from a queue name."""
-    return f"{strip_fifo_suffix(queue_name)}_service"
+    return f"{sanitize_ecs_resource_name(queue_name)}_service"
 
 
 def get_evalai_submission_worker_ecr_prefixes():
@@ -340,7 +348,7 @@ def build_task_definition_dict(
         }
 
     sqs_queue_name = queue_name
-    queue_name = strip_fifo_suffix(queue_name)
+    queue_name = sanitize_ecs_resource_name(queue_name)
 
     container_name = f"worker_{queue_name}"
     code_upload_container_name = f"code_upload_worker_{queue_name}"

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -126,7 +126,7 @@ from .aws_utils import (
     start_workers,
     stop_ec2_instance,
     stop_workers,
-    strip_fifo_suffix,
+    sanitize_ecs_resource_name,
     terminate_ec2_instance,
 )
 from .models import (
@@ -3767,7 +3767,7 @@ def get_worker_logs(request, challenge_pk):
     response_data = []
 
     log_group_name = get_log_group_name(challenge.pk)
-    log_stream_prefix = strip_fifo_suffix(challenge.queue)
+    log_stream_prefix = sanitize_ecs_resource_name(challenge.queue)
     pattern = ""  # Empty string to get all logs including container logs.
 
     # This is to specify the time window for fetching logs: 3 days before from

--- a/scripts/lambda/challenge_cleanup_lambda.py
+++ b/scripts/lambda/challenge_cleanup_lambda.py
@@ -23,9 +23,20 @@ Event payload (from EventBridge Scheduler):
 import json
 import logging
 import os
+import re
 
 import boto3
 from botocore.exceptions import ClientError
+
+ECS_RESOURCE_NAME_PATTERN = re.compile(r"[^a-zA-Z0-9_-]+")
+
+
+def get_ecs_service_name(queue_name):
+    """Return ECS-safe service name from an SQS queue name."""
+    base = queue_name[:-5] if queue_name.endswith(".fifo") else queue_name
+    base = ECS_RESOURCE_NAME_PATTERN.sub("-", base)
+    return f"{base}_service"
+
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -46,7 +57,7 @@ def handler(event, context):
         logger.error("Missing challenge_pk or queue_name in event: %s", event)
         return {"statusCode": 400, "body": "Missing required fields"}
 
-    service_name = f"{queue_name}_service"
+    service_name = get_ecs_service_name(queue_name)
     resource_id = f"service/{ECS_CLUSTER}/{service_name}"
     log_group_name = f"challenge-pk-{challenge_pk}-{ENVIRONMENT}-workers"
 

--- a/tests/unit/challenges/test_aws_utils.py
+++ b/tests/unit/challenges/test_aws_utils.py
@@ -55,6 +55,7 @@ from challenges.aws_utils import (
     stop_ec2_instance,
     stop_workers,
     strip_fifo_suffix,
+    sanitize_ecs_resource_name,
     terminate_ec2_instance,
     trigger_eks_node_autoscale,
     update_challenge_cleanup_schedule,
@@ -7345,6 +7346,60 @@ class TestWorkerImageHelpers(TestCase):
         self.assertEqual(
             get_ecs_service_name("my-queue.fifo.fifo"),
             "my-queue.fifo_service",
+        )
+
+    def test_sanitize_ecs_resource_name_fifo_queue(self):
+        self.assertEqual(
+            sanitize_ecs_resource_name("my-queue.fifo"),
+            "my-queue",
+        )
+
+    def test_sanitize_ecs_resource_name_removes_other_invalid_chars(self):
+        self.assertEqual(
+            sanitize_ecs_resource_name("my.queue_name.fifo"),
+            "my-queue_name",
+        )
+
+    @patch.dict(
+        "os.environ", {"CELERY_QUEUE_NAME": "evalai-celery"}, clear=False
+    )
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    @patch("challenges.aws_utils.task_definition")
+    def test_build_task_definition_dict_fifo_queue_uses_ecs_safe_family(
+        self, mock_task_definition, mock_get_aws_credentials
+    ):
+        challenge = MagicMock(
+            pk=2698,
+            is_docker_based=False,
+            worker_cpu_cores=1024,
+            worker_memory=2048,
+            ephemeral_storage=21,
+        )
+        mock_get_aws_credentials.return_value = {}
+        mock_task_definition.format.return_value = "{'family': 'ecs-safe'}"
+
+        with patch(
+            "challenges.aws_utils.load_aws_api_kwargs",
+            side_effect=lambda value: {"family": "ecs-safe"},
+        ):
+            task_def, error = build_task_definition_dict(
+                challenge, "mars2-challenge-2698-production-abc.fifo"
+            )
+
+        self.assertIsNone(error)
+        self.assertEqual(task_def["family"], "ecs-safe")
+        format_kwargs = mock_task_definition.format.call_args.kwargs
+        self.assertEqual(
+            format_kwargs["queue_name"],
+            "mars2-challenge-2698-production-abc",
+        )
+        self.assertEqual(
+            format_kwargs["sqs_queue_name"],
+            "mars2-challenge-2698-production-abc.fifo",
+        )
+        self.assertEqual(
+            format_kwargs["container_name"],
+            "worker_mars2-challenge-2698-production-abc",
         )
 
     @patch.dict(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Starting workers for Challenge 2698 (FIFO SQS queue) fails with:

```
ClientException: Family contains invalid characters.
```

FIFO queue names end with `.fifo`, but ECS task definition families, service names, and container names only allow `[a-zA-Z0-9_-]`. The `.fifo` suffix was being passed through as the ECS task-definition `family`, causing `register_task_definition` to fail when starting workers.

## Solution

- Add `sanitize_ecs_resource_name()` that strips the `.fifo` suffix and removes any remaining invalid characters.
- Use it when building ECS task definitions (family, container names) and ECS service names.
- Keep the original SQS queue name (with `.fifo`) in `CHALLENGE_QUEUE` / `QUEUE_NAME` environment variables so workers connect to the correct queue.
- Apply the same sanitization in `challenge_cleanup_lambda.py` when deriving the ECS service name.

## Testing

- Added unit tests for `sanitize_ecs_resource_name` and FIFO task-definition building.
- Ran:
  `pytest tests/unit/challenges/test_aws_utils.py::TestWorkerImageHelpers::test_sanitize_ecs_resource_name_fifo_queue tests/unit/challenges/test_aws_utils.py::TestWorkerImageHelpers::test_sanitize_ecs_resource_name_removes_other_invalid_chars tests/unit/challenges/test_aws_utils.py::TestWorkerImageHelpers::test_build_task_definition_dict_fifo_queue_uses_ecs_safe_family tests/unit/challenges/test_aws_utils.py::TestWorkerImageHelpers::test_get_ecs_service_name_fifo_queue -q`
- All 4 tests passed.

## After merge

Retry starting workers for Challenge 2698. No database changes are required — the SQS queue name stays the same; only ECS resource naming is sanitized.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b4f8611-4608-4601-ae3d-5a79432afb0d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b4f8611-4608-4601-ae3d-5a79432afb0d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of challenge resources when queue names contain unsupported characters.
  * Challenge worker logs, services, task definitions, and cleanup operations now use consistently normalized resource names.
  * Preserved original queue names while ensuring generated ECS resources remain valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->