### PR TITLE
Deploy core services before refreshing challenge workers

### DIFF
--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -175,9 +175,18 @@ docker compose -f "docker-compose-\${TARGET_ENVIRONMENT}.yml" pull django nodejs
 # startup; running both concurrently races on CREATE TABLE (pg_type_typname_nsp_index).
 # Detach stdin so compose cannot consume the remaining commands from the SSH heredoc.
 docker compose -f "docker-compose-\${TARGET_ENVIRONMENT}.yml" run --rm \
-  django sh -c "python manage.py migrate --noinput && python manage.py refresh_worker_task_definitions --commit-id \${COMMIT_ID}" \
+  django python manage.py migrate --noinput \
   </dev/null
 docker compose -f "docker-compose-\${TARGET_ENVIRONMENT}.yml" up -d --force-recreate --remove-orphans django nodejs celery memcached
+
+# Refresh challenge workers only after the core application has been deployed.
+# A stale or missing ECS service is challenge-specific and must not prevent the
+# independently managed application containers from being rolled out.
+if ! docker compose -f "docker-compose-\${TARGET_ENVIRONMENT}.yml" run --rm \
+  django python manage.py refresh_worker_task_definitions --commit-id "\${COMMIT_ID}" \
+  </dev/null; then
+    echo "WARNING: Core services deployed, but one or more worker task definitions failed to refresh." >&2
+fi
 ENDSSH
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- run database migrations independently of worker refresh
- deploy Django, frontend, Celery, and Memcached before refreshing ECS worker task definitions
- report challenge-specific worker refresh failures without failing the completed core deployment

## Testing
- `bash -n scripts/deployment/deploy.sh`
- `pytest tests/unit/challenges/test_refresh_worker_task_definitions_command.py -q` (4 passed in Docker)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d771206a-1c76-48d3-8bd0-e71b085cde47?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d771206a-1c76-48d3-8bd0-e71b085cde47&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment resilience: separated database migration and worker task definition refresh into distinct operations. Worker task definition refresh failures now log warnings instead of blocking deployment, preventing non-critical operations from halting the entire deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->