### PR TITLE
fix(worker): let a CHALLENGE_PK-pinned worker load an expired challenge

### DIFF
--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -1029,11 +1029,15 @@ def main():
     sys.path.append(COMPUTE_DIRECTORY_PATH)
 
     q_params = {}
-    q_params["end_date__gte"] = timezone.now()
 
     challenge_pk = os.environ.get("CHALLENGE_PK")
     if challenge_pk:
+        # A CHALLENGE_PK-pinned worker targets one specific challenge and
+        # must keep loading it past end_date, since it may still have
+        # pending submissions to drain instead of being torn down.
         q_params["pk"] = challenge_pk
+    else:
+        q_params["end_date__gte"] = timezone.now()
 
     if settings.DEBUG or settings.TEST:
         if eval(LIMIT_CONCURRENT_SUBMISSION_PROCESSING):

--- a/tests/unit/worker/test_submission_worker.py
+++ b/tests/unit/worker/test_submission_worker.py
@@ -1136,16 +1136,20 @@ class MainFunctionTest(BaseAPITestClass):
             "scripts.workers.submission_worker.settings"
         ) as mock_settings, patch(
             "scripts.workers.submission_worker.time.sleep", return_value=None
+        ), patch(
+            # LIMIT_CONCURRENT_SUBMISSION_PROCESSING is read from os.environ
+            # once at module import time, so patching os.environ here has no
+            # effect on it - the module-level name has to be patched
+            # directly to actually select the eval(...) branch below.
+            "scripts.workers.submission_worker.LIMIT_CONCURRENT_SUBMISSION_PROCESSING",
+            "True",
         ):
             mock_settings.DEBUG = True
             mock_settings.TEST = False
 
             with patch.dict(
                 "os.environ",
-                {
-                    "LIMIT_CONCURRENT_SUBMISSION_PROCESSING": "True",
-                    "CHALLENGE_PK": str(self.challenge.pk),
-                },
+                {"CHALLENGE_PK": str(self.challenge.pk)},
             ):
                 killer_instance = MagicMock()
                 killer_instance.kill_now = True
@@ -1277,49 +1281,46 @@ class MainFunctionTest(BaseAPITestClass):
             "scripts.workers.submission_worker.time.sleep", return_value=None
         ), patch(
             "scripts.workers.submission_worker.Challenge"
-        ) as mock_Challenge:
+        ) as mock_Challenge, patch(
+            # See test_main_debug_limit_concurrent - os.environ has no
+            # effect on this module-level name once imported.
+            "scripts.workers.submission_worker.LIMIT_CONCURRENT_SUBMISSION_PROCESSING",
+            "False",
+        ):
             mock_settings.DEBUG = True
             mock_settings.TEST = False
-            with patch.dict(
-                "os.environ",
-                {"LIMIT_CONCURRENT_SUBMISSION_PROCESSING": "False"},
-            ):
-                killer_instance = MagicMock()
-                killer_instance.kill_now = True
-                mock_GracefulKiller.return_value = killer_instance
-                mock_challenge = MagicMock()
-                mock_Challenge.objects.filter.return_value = [mock_challenge]
-                mock_queue = MagicMock()
-                mock_message = MagicMock()
-                mock_message.body = (
-                    '{"is_static_dataset_code_upload_submission": false}'
-                )
-                mock_queue.receive_messages.return_value = [mock_message]
-                mock_get_or_create_sqs_queue.return_value = mock_queue
+            killer_instance = MagicMock()
+            killer_instance.kill_now = True
+            mock_GracefulKiller.return_value = killer_instance
+            mock_challenge = MagicMock()
+            mock_Challenge.objects.filter.return_value = [mock_challenge]
+            mock_queue = MagicMock()
+            mock_message = MagicMock()
+            mock_message.body = (
+                '{"is_static_dataset_code_upload_submission": false}'
+            )
+            mock_queue.receive_messages.return_value = [mock_message]
+            mock_get_or_create_sqs_queue.return_value = mock_queue
 
-                main()
+            main()
 
-                # Without a CHALLENGE_PK, this stays the multi-challenge
-                # dev/test loader and must keep excluding expired
-                # challenges - unlike the CHALLENGE_PK-pinned case above.
-                filter_call_kwargs = (
-                    mock_Challenge.objects.filter.call_args.kwargs
-                )
-                self.assertIn("end_date__gte", filter_call_kwargs)
-                self.assertNotIn("pk", filter_call_kwargs)
-                assert any(
-                    str(call_args[0][0]).startswith("WORKER_LOG Using ")
-                    for call_args in mock_logger_info.call_args_list
-                )
-                mock_delete_old_temp_directories.assert_called()
-                mock_create_dir_as_python_package.assert_any_call(mock.ANY)
-                mock_get_or_create_sqs_queue.assert_called()
-                mock_queue.receive_messages.assert_called_with(
-                    WaitTimeSeconds=20
-                )
-                mock_process_submission_callback.assert_called_with(
-                    mock_message.body
-                )
+            # Without a CHALLENGE_PK, this stays the multi-challenge
+            # dev/test loader and must keep excluding expired
+            # challenges - unlike the CHALLENGE_PK-pinned case above.
+            filter_call_kwargs = mock_Challenge.objects.filter.call_args.kwargs
+            self.assertIn("end_date__gte", filter_call_kwargs)
+            self.assertNotIn("pk", filter_call_kwargs)
+            assert any(
+                str(call_args[0][0]).startswith("WORKER_LOG Using ")
+                for call_args in mock_logger_info.call_args_list
+            )
+            mock_delete_old_temp_directories.assert_called()
+            mock_create_dir_as_python_package.assert_any_call(mock.ANY)
+            mock_get_or_create_sqs_queue.assert_called()
+            mock_queue.receive_messages.assert_called_with(WaitTimeSeconds=20)
+            mock_process_submission_callback.assert_called_with(
+                mock_message.body
+            )
 
 
 class DeleteOldTempDirectoriesTest(BaseAPITestClass):

--- a/tests/unit/worker/test_submission_worker.py
+++ b/tests/unit/worker/test_submission_worker.py
@@ -295,6 +295,31 @@ class BaseAPITestClass(APITestCase):
                 )
             )
 
+    @mock.patch("scripts.workers.submission_worker.load_challenge")
+    def test_load_challenge_and_return_max_submissions_for_expired_challenge(
+        self, mocked_load_challenge
+    ):
+        """
+        Regression test: a CHALLENGE_PK-pinned q_params (pk only, no
+        end_date filter) must load an already-expired, persisted
+        challenge successfully instead of raising DoesNotExist.
+        """
+        self.challenge.end_date = timezone.now() - timedelta(days=1)
+        self.challenge.save()
+
+        response = load_challenge_and_return_max_submissions(
+            {"pk": self.challenge.pk}
+        )
+
+        mocked_load_challenge.assert_called_with(self.challenge)
+        self.assertEqual(
+            response,
+            (
+                self.challenge.max_concurrent_submission_evaluation,
+                self.challenge,
+            ),
+        )
+
     @mock_sqs()
     def test_get_or_create_sqs_queue_for_existing_queue(self):
         self.sqs_client.create_queue(

--- a/tests/unit/worker/test_submission_worker.py
+++ b/tests/unit/worker/test_submission_worker.py
@@ -1142,6 +1142,12 @@ class MainFunctionTest(BaseAPITestClass):
 
                 main()
 
+                # A CHALLENGE_PK-pinned lookup must not filter by end_date,
+                # so a worker can reload its challenge after it has expired
+                # (regression test for the crash-on-restart bug).
+                mock_load_challenge_and_return_max_submissions.assert_called_with(
+                    {"pk": str(self.challenge.pk)}
+                )
                 assert any(
                     str(call_args[0][0]).startswith("WORKER_LOG Using ")
                     for call_args in mock_logger_info.call_args_list
@@ -1154,6 +1160,65 @@ class MainFunctionTest(BaseAPITestClass):
                 )
                 mock_process_submission_callback.assert_called_with(
                     mock_message.body
+                )
+
+    @patch("scripts.workers.submission_worker.importlib.import_module")
+    @patch("scripts.workers.submission_worker.importlib.invalidate_caches")
+    @patch("scripts.workers.submission_worker.GracefulKiller")
+    @patch("scripts.workers.submission_worker.logger.info")
+    @patch("scripts.workers.submission_worker.delete_old_temp_directories")
+    @patch("scripts.workers.submission_worker.create_dir_as_python_package")
+    @patch(
+        "scripts.workers.submission_worker.load_challenge_and_return_max_submissions"
+    )
+    @patch("scripts.workers.submission_worker.get_or_create_sqs_queue")
+    @patch("scripts.workers.submission_worker.process_submission_callback")
+    @patch("scripts.workers.submission_worker.Submission")
+    def test_main_production_loads_expired_challenge_when_challenge_pk_set(
+        self,
+        mock_Submission,
+        mock_process_submission_callback,
+        mock_get_or_create_sqs_queue,
+        mock_load_challenge_and_return_max_submissions,
+        mock_create_dir_as_python_package,
+        mock_delete_old_temp_directories,
+        mock_logger_info,
+        mock_GracefulKiller,
+        mock_invalidate_caches,
+        mock_import_module,
+    ):
+        """
+        The production path (settings.DEBUG=False) must be able to load a
+        CHALLENGE_PK-pinned challenge even after its end_date has passed,
+        so a worker restarting after expiry doesn't crash-loop on
+        Challenge.DoesNotExist while pending submissions are still queued.
+        """
+        with patch.object(sys, "argv", ["worker"]), patch(
+            "scripts.workers.submission_worker.settings"
+        ) as mock_settings, patch(
+            "scripts.workers.submission_worker.time.sleep", return_value=None
+        ):
+            mock_settings.DEBUG = False
+            mock_settings.TEST = False
+
+            with patch.dict(
+                "os.environ", {"CHALLENGE_PK": str(self.challenge.pk)}
+            ):
+                killer_instance = MagicMock()
+                killer_instance.kill_now = True
+                mock_GracefulKiller.return_value = killer_instance
+                mock_load_challenge_and_return_max_submissions.return_value = (
+                    1,
+                    self.challenge,
+                )
+                mock_queue = MagicMock()
+                mock_queue.receive_messages.return_value = []
+                mock_get_or_create_sqs_queue.return_value = mock_queue
+
+                main()
+
+                mock_load_challenge_and_return_max_submissions.assert_called_with(
+                    {"pk": str(self.challenge.pk)}
                 )
 
     @patch("scripts.workers.submission_worker.importlib.import_module")
@@ -1209,6 +1274,14 @@ class MainFunctionTest(BaseAPITestClass):
 
                 main()
 
+                # Without a CHALLENGE_PK, this stays the multi-challenge
+                # dev/test loader and must keep excluding expired
+                # challenges - unlike the CHALLENGE_PK-pinned case above.
+                filter_call_kwargs = (
+                    mock_Challenge.objects.filter.call_args.kwargs
+                )
+                self.assertIn("end_date__gte", filter_call_kwargs)
+                self.assertNotIn("pk", filter_call_kwargs)
                 assert any(
                     str(call_args[0][0]).startswith("WORKER_LOG Using ")
                     for call_args in mock_logger_info.call_args_list


### PR DESCRIPTION
## Summary
- `submission_worker.py:main()` unconditionally filtered the challenge lookup by `end_date__gte=timezone.now()`. A worker container restarting for any reason (crash, scale event, redeploy) after its challenge's `end_date` would hit `Challenge.DoesNotExist` and die immediately — even with submissions still sitting in its own queue.
- That filter's original intent ([af383a90](https://github.com/Cloud-CV/EvalAI/commit/af383a90), [2a661cdf](https://github.com/Cloud-CV/EvalAI/commit/2a661cdf)) was to stop a worker serving an already-ended challenge, from back when workers were expected to be torn down at `end_date` regardless. That assumption no longer holds — challenge cleanup now skips deletion when a challenge has pending submissions (#5179), so the worker legitimately needs to keep loading itself past `end_date` in that case.
- Fix: a `CHALLENGE_PK`-pinned worker (both branches that require it, including the production path) targets exactly one challenge by design — drop the `end_date` filter whenever `CHALLENGE_PK` is set. The `CHALLENGE_PK`-less multi-challenge dev/test loader is unaffected and keeps filtering to currently-active challenges only.

Found this while verifying #5179/#5181 in production against a real expired challenge with pending submissions: the ECS service came back up fine, but the worker container inside it crash-looped on `Challenge.DoesNotExist` because of this filter.

## Test plan
- [x] `python -m py_compile scripts/workers/submission_worker.py`
- [x] Deploy to staging, restart a worker for a challenge whose `end_date` is in the past, confirm it loads and processes queued submissions instead of crash-looping
- [x] Confirm the `CHALLENGE_PK`-less dev-mode multi-challenge path still excludes expired challenges (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pending submissions for a specified challenge can now continue processing even after the challenge end date.
  * Challenge-specific processing remains available when a challenge identifier is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->