### PR TITLE
Pin cilium-operator to 1 replica for single-node challenge clusters

### DIFF
--- a/scripts/workers/code_upload_worker_utils/install_dependencies.sh
+++ b/scripts/workers/code_upload_worker_utils/install_dependencies.sh
@@ -163,7 +163,8 @@ fi
 if ! helm upgrade --install cilium cilium/cilium --version "$CILIUM_TARGET_VERSION" \
   --namespace kube-system \
   --set ipam.mode=cluster-pool \
-  --set kubeProxyReplacement=false; then
+  --set kubeProxyReplacement=false \
+  --set operator.replicas=1; then
   echo "### Cilium Helm install failed" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

Code-upload worker was crash-looping on production challenge clusters with:

```
error: deployment "cilium-operator" exceeded its progress deadline
error: failed to create configmap: configmaps "fluent-bit-cluster-info" already exists
```

Root cause: challenge EKS nodegroups default to a single node on scale-up (`SCALE_UP_DESIRED_SIZE = 1` in `scripts/monitoring/auto_scale_eks_nodes.py`, and the equivalent `scale_up_cap` default of 1 in `scripts/lambda/auto_scale_eks_nodes_lambda.py`). The Cilium Helm chart defaults `operator.replicas` to 2 with pod anti-affinity, so the 2nd `cilium-operator` replica can never schedule on a 1-node cluster. The Deployment never reaches `Available`, the `kubectl rollout status --timeout=120s` wait in `install_dependencies.sh` times out, the script exits 1, and the worker container crash-loops — which also explains the repeating `fluent-bit-cluster-info` "already exists" error, since `kubectl create configmap` isn't idempotent and reruns on every restart.

`cilium-operator` is a singleton, leader-elected controller rather than a per-node component, so pinning it to 1 replica works identically at any node count. The only tradeoff is losing standby failover for that pod, which is acceptable for these ephemeral, scale-to-zero challenge clusters.

## Change

Add `--set operator.replicas=1` to the `helm upgrade --install cilium` call in `scripts/workers/code_upload_worker_utils/install_dependencies.sh`.

## Test plan

- [x] Deploy to a challenge with a fresh/reset EKS cluster and confirm `install_dependencies.sh` completes without the `cilium-operator` progress-deadline error on a 1-node nodegroup
- [x] Confirm the code-upload worker container no longer crash-loops and submissions process normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the Cilium Helm installation to run a single operator replica.
  * Retained the existing kube-proxy replacement configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->