### PR TITLE
fix(challenges): keep the EKS autoscale sweep deployed and scoped

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -363,7 +363,7 @@ jobs:
           rule_name="${function_name}-sweep"
 
           if [ "${DRY_RUN_DEPLOYMENT}" = "true" ]; then
-            echo "Dry run: checking the autoscale Lambda and its sweep schedule exist."
+            echo "Dry run: checking the autoscale Lambda and its sweep schedule."
 
             if ! aws lambda get-function --region "${AWS_REGION}" \
                 --function-name "${function_name}" >/dev/null; then
@@ -371,10 +371,34 @@ jobs:
               exit 1
             fi
 
-            if ! aws events describe-rule --region "${AWS_REGION}" \
-                --name "${rule_name}" >/dev/null; then
+            # Existence alone is too weak a check. A disabled rule matches
+            # nothing and never self-triggers on its schedule, and a target
+            # registered without the sweep input makes EventBridge invoke the
+            # Lambda with an empty event, which the handler rejects as a
+            # malformed single-challenge request. Either leaves autoscaling
+            # with no reconciliation while looking correctly configured.
+            if ! rule_state="$(aws events describe-rule \
+                --region "${AWS_REGION}" --name "${rule_name}" \
+                --query State --output text)"; then
               echo "Sweep schedule '${rule_name}' is missing. Autoscaling has" >&2
               echo "no reconciliation safety net until a real deployment runs." >&2
+              exit 1
+            fi
+
+            if [ "${rule_state}" != "ENABLED" ]; then
+              echo "Sweep schedule '${rule_name}' is ${rule_state}, so it never" >&2
+              echo "fires and no challenge is ever reconciled." >&2
+              exit 1
+            fi
+
+            sweep_input="$(aws events list-targets-by-rule \
+              --region "${AWS_REGION}" --rule "${rule_name}" \
+              --query "Targets[?Id=='1'].Input | [0]" --output text)"
+
+            if [ "${sweep_input}" != '{"sweep":true}' ]; then
+              echo "Sweep target input is '${sweep_input}', expected" >&2
+              echo "'{\"sweep\":true}'. The schedule would invoke the Lambda" >&2
+              echo "without asking it to sweep." >&2
               exit 1
             fi
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -345,3 +345,40 @@ jobs:
           export COMMIT_ID="$(git rev-parse HEAD)"
           bash ./scripts/deployment/push.sh
           bash ./scripts/deployment/deploy.sh auto_deploy
+
+      # Deploying this Lambda by hand meant its code and its EventBridge sweep
+      # schedule could silently fall behind the repository: production ran a
+      # build with no sweep support and no sweep rule at all, so a single
+      # dropped event-driven invocation left a nodegroup running indefinitely
+      # with nothing to reconcile it.
+      - name: Deploy EKS node autoscale Lambda
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          ENVIRONMENT: ${{ steps.deployment_context.outputs.deployment_environment_name }}
+          EVALAI_API_SERVER: ${{ secrets.EVALAI_API_SERVER }}
+          LAMBDA_AUTH_TOKEN: ${{ secrets.LAMBDA_AUTH_TOKEN }}
+          DRY_RUN_DEPLOYMENT: ${{ steps.deployment_context.outputs.run_deployment_in_dry_mode }}
+        run: |
+          function_name="evalai-${ENVIRONMENT}-auto-scale-eks-nodes"
+          rule_name="${function_name}-sweep"
+
+          if [ "${DRY_RUN_DEPLOYMENT}" = "true" ]; then
+            echo "Dry run: checking the autoscale Lambda and its sweep schedule exist."
+
+            if ! aws lambda get-function --region "${AWS_REGION}" \
+                --function-name "${function_name}" >/dev/null; then
+              echo "Autoscale Lambda '${function_name}' is missing." >&2
+              exit 1
+            fi
+
+            if ! aws events describe-rule --region "${AWS_REGION}" \
+                --name "${rule_name}" >/dev/null; then
+              echo "Sweep schedule '${rule_name}' is missing. Autoscaling has" >&2
+              echo "no reconciliation safety net until a real deployment runs." >&2
+              exit 1
+            fi
+
+            exit 0
+          fi
+
+          bash ./scripts/lambda/deploy_auto_scale_eks_nodes_lambda.sh

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -8,7 +8,7 @@ import tempfile
 import time
 import uuid
 import zipfile
-from datetime import datetime
+from datetime import datetime, timedelta
 from os.path import basename, isfile, join
 
 import pytz
@@ -5797,11 +5797,21 @@ def get_autoscale_eligible_challenges(request):
     Autoscaling is otherwise purely event-driven, so a single dropped Lambda
     invocation can leave a nodegroup stuck at zero nodes with submissions
     pending indefinitely. A scheduled sweep over this list reconciles that.
+
+    Challenges that ended more than EKS_AUTOSCALE_SWEEP_GRACE_PERIOD_DAYS ago
+    are excluded. The grace period keeps a recently ended challenge in the
+    sweep long enough to be forced to zero nodes; past that its cluster may
+    already be deleted or its cross-account role revoked, so every sweep would
+    fail on it forever and bury genuine failures on live challenges.
+    Challenges with no end_date are never excluded by this filter.
     """
     auth_error = _authenticate_lambda_request(request)
     if auth_error:
         return auth_error
 
+    sweep_cutoff = timezone.now() - timedelta(
+        days=settings.EKS_AUTOSCALE_SWEEP_GRACE_PERIOD_DAYS
+    )
     challenges = (
         Challenge.objects.filter(
             is_docker_based=True,
@@ -5809,6 +5819,7 @@ def get_autoscale_eligible_challenges(request):
             approved_by_admin=True,
         )
         .exclude(challengeevaluationcluster__isnull=True)
+        .exclude(end_date__lt=sweep_cutoff)
         .values_list("pk", flat=True)
     )
     challenge_pks = list(challenges)

--- a/docs/source/04-development/deployment/scaling-guidelines.md
+++ b/docs/source/04-development/deployment/scaling-guidelines.md
@@ -28,9 +28,9 @@ ENVIRONMENT=production EVALAI_API_SERVER=https://eval.ai LAMBDA_AUTH_TOKEN=xxx \
   ./scripts/lambda/deploy_auto_scale_eks_nodes_lambda.sh
 ```
 
-The deployment OIDC role needs `lambda:GetFunction`, `lambda:UpdateFunctionCode`, `lambda:UpdateFunctionConfiguration`, `lambda:AddPermission`, `events:PutRule`, `events:DescribeRule`, `events:PutTargets`, and `events:ListTargetsByRule`.
+The deployment OIDC role needs `lambda:GetFunction`, `lambda:GetFunctionConfiguration`, `lambda:UpdateFunctionCode`, `lambda:UpdateFunctionConfiguration`, `lambda:AddPermission`, `events:PutRule`, `events:DescribeRule`, `events:PutTargets`, and `events:ListTargetsByRule`. `lambda:GetFunctionConfiguration` is what the `aws lambda wait function-updated` waiter polls, so a role without it fails mid-deployment even though the update itself succeeded.
 
-Pass `DLQ_ARN` to route failed asynchronous invocations to a dead-letter queue. The handler raises on unrecoverable failures rather than returning an error status code, so those failures appear in the Lambda `Errors` metric — alarm on it.
+Pass `DLQ_ARN` to route failed asynchronous invocations to a dead-letter queue. The script only sets the dead-letter configuration; the Lambda's own execution role still needs `sqs:SendMessage` on that queue, or `sns:Publish` on that topic, or failed invocations are counted as `DeadLetterErrors` instead of arriving. The handler raises on unrecoverable failures rather than returning an error status code, so those failures appear in the Lambda `Errors` metric — alarm on it.
 
 ### Which challenges the sweep covers
 

--- a/docs/source/04-development/deployment/scaling-guidelines.md
+++ b/docs/source/04-development/deployment/scaling-guidelines.md
@@ -19,16 +19,22 @@ Code-upload challenges run submissions as Kubernetes Jobs on a per-challenge EKS
 It runs in two modes:
 
 - **Event-driven** — Django invokes it asynchronously via `trigger_eks_node_autoscale()` when a submission is created or crosses the pending/terminal boundary.
-- **Scheduled sweep** — an EventBridge rule invokes it with `{"sweep": true}` to reconcile every eligible challenge. Event-driven invocations are best-effort, so this sweep is what prevents a single dropped invoke from leaving a nodegroup stuck at zero nodes with submissions pending.
+- **Scheduled sweep** — an EventBridge rule invokes it with `{"sweep": true}` to reconcile every eligible challenge. Event-driven invocations are best-effort, so this sweep is what prevents a single dropped invoke from leaving a nodegroup running with nothing left to scale it down, or stuck at zero nodes with submissions pending.
 
-Deploy both with:
+The `Deploy EKS node autoscale Lambda` step of the `ci-cd` workflow runs the deploy script on every staging and production deployment, so the Lambda's code and its sweep schedule stay in step with the repository. Deploying by hand is only needed outside that pipeline:
 
 ```bash
 ENVIRONMENT=production EVALAI_API_SERVER=https://eval.ai LAMBDA_AUTH_TOKEN=xxx \
   ./scripts/lambda/deploy_auto_scale_eks_nodes_lambda.sh
 ```
 
+The deployment OIDC role needs `lambda:GetFunction`, `lambda:UpdateFunctionCode`, `lambda:UpdateFunctionConfiguration`, `lambda:AddPermission`, `events:PutRule`, `events:DescribeRule`, `events:PutTargets`, and `events:ListTargetsByRule`.
+
 Pass `DLQ_ARN` to route failed asynchronous invocations to a dead-letter queue. The handler raises on unrecoverable failures rather than returning an error status code, so those failures appear in the Lambda `Errors` metric — alarm on it.
+
+### Which challenges the sweep covers
+
+The sweep reconciles approved, docker-based, non-remote challenges that have an evaluation cluster, excluding any that ended more than `EKS_AUTOSCALE_SWEEP_GRACE_PERIOD_DAYS` (default 30) ago. The grace period keeps a just-ended challenge in the sweep long enough for its nodegroup to be forced to zero. Past that, the host is free to delete the cluster or revoke the cross-account role, so sweeping it would fail on every scheduled run and bury genuine failures on live challenges.
 
 ### Challenges in a host's own AWS account
 

--- a/scripts/lambda/deploy_auto_scale_eks_nodes_lambda.sh
+++ b/scripts/lambda/deploy_auto_scale_eks_nodes_lambda.sh
@@ -116,8 +116,32 @@ if ! ADD_PERMISSION_OUTPUT="$(aws_cli lambda add-permission \
     echo "    invoke permission already present"
 fi
 
+# The target must be passed as JSON, not CLI shorthand: shorthand cannot
+# express an Input value containing braces and quotes, and rejects it with
+# "Expected: '=', received: '\"'". A target registered without this Input
+# makes EventBridge invoke the Lambda with an empty event, which the handler
+# treats as a malformed single-challenge invocation, so the sweep never runs.
+TARGETS_PATH="${BUILD_DIR}/sweep-target.json"
+cat > "${TARGETS_PATH}" <<EOF
+[{"Id":"1","Arn":"${FUNCTION_ARN}","Input":"{\"sweep\":true}"}]
+EOF
+
 aws_cli events put-targets \
     --rule "${RULE_NAME}" \
-    --targets "Id=1,Arn=${FUNCTION_ARN},Input={\"sweep\":true}" >/dev/null
+    --targets "file://${TARGETS_PATH}" >/dev/null
+
+# put-targets reports per-entry failures in the response body instead of a
+# non-zero exit code, so a silently unregistered target would otherwise look
+# like a successful deploy.
+REGISTERED_INPUT="$(aws_cli events list-targets-by-rule \
+    --rule "${RULE_NAME}" \
+    --query "Targets[?Id=='1'].Input | [0]" --output text)"
+
+if [ "${REGISTERED_INPUT}" != '{"sweep":true}' ]; then
+    echo "Sweep target is not registered with the expected input." >&2
+    echo "Expected: {\"sweep\":true}" >&2
+    echo "Found:    ${REGISTERED_INPUT}" >&2
+    exit 1
+fi
 
 echo "==> Done: ${FUNCTION_NAME}"

--- a/settings/common.py
+++ b/settings/common.py
@@ -518,6 +518,16 @@ EKS_AUTOSCALE_LAMBDA_ROLE_ARN = os.environ.get(
     "EKS_AUTOSCALE_LAMBDA_ROLE_ARN", ""
 )
 
+# Challenges that ended longer ago than this are dropped from the autoscale
+# Lambda's reconciliation sweep. A just-ended challenge is kept so the sweep
+# can still force its nodegroup to zero; once that is done there is nothing
+# left to reconcile, and the host is free to delete the cluster or revoke the
+# cross-account role. Sweeping those forever turns every scheduled run into a
+# failed invocation, which masks real failures on live challenges.
+EKS_AUTOSCALE_SWEEP_GRACE_PERIOD_DAYS = int(
+    os.environ.get("EKS_AUTOSCALE_SWEEP_GRACE_PERIOD_DAYS", "30")
+)
+
 EKS_AUTOSCALE_CROSS_ACCOUNT_POLICY_NAME = "evalai-autoscale-nodegroup-access"
 
 EKS_AUTOSCALE_CROSS_ACCOUNT_POLICY_DOCUMENT = {

--- a/settings/common.py
+++ b/settings/common.py
@@ -16,6 +16,7 @@ import sys
 from datetime import timedelta
 
 from celery.schedules import crontab
+from django.core.exceptions import ImproperlyConfigured
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -527,6 +528,15 @@ EKS_AUTOSCALE_LAMBDA_ROLE_ARN = os.environ.get(
 EKS_AUTOSCALE_SWEEP_GRACE_PERIOD_DAYS = int(
     os.environ.get("EKS_AUTOSCALE_SWEEP_GRACE_PERIOD_DAYS", "30")
 )
+
+# A negative value moves the sweep cutoff into the future, which would drop
+# every challenge ending before that point — including live ones still
+# accepting submissions — and silently leave them with no reconciliation.
+if EKS_AUTOSCALE_SWEEP_GRACE_PERIOD_DAYS < 0:
+    raise ImproperlyConfigured(
+        "EKS_AUTOSCALE_SWEEP_GRACE_PERIOD_DAYS must be zero or greater, got "
+        f"{EKS_AUTOSCALE_SWEEP_GRACE_PERIOD_DAYS}."
+    )
 
 EKS_AUTOSCALE_CROSS_ACCOUNT_POLICY_NAME = "evalai-autoscale-nodegroup-access"
 

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -8925,6 +8925,47 @@ class AutoscaleEligibleChallengesAPITest(BaseAPITestClass):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertNotIn(self.challenge.pk, response.data["challenge_pks"])
 
+    def test_excludes_challenge_ended_beyond_grace_period(self):
+        """
+        A long-ended challenge has nothing left to reconcile, and its cluster
+        or cross-account role may already be gone. Sweeping it forever turns
+        every scheduled run into a failure.
+        """
+        grace_days = settings.EKS_AUTOSCALE_SWEEP_GRACE_PERIOD_DAYS
+        self._make_challenge_eligible(
+            end_date=timezone.now() - timedelta(days=grace_days + 1)
+        )
+        ChallengeEvaluationCluster.objects.create(
+            challenge=self.challenge, name="long-ended-cluster"
+        )
+        with mock.patch.dict(
+            os.environ, {"LAMBDA_AUTH_TOKEN": self.auth_token}
+        ):
+            response = self._client_with_auth().get(self.url, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotIn(self.challenge.pk, response.data["challenge_pks"])
+
+    def test_includes_challenge_ended_within_grace_period(self):
+        """
+        A just-ended challenge must stay in the sweep so its nodegroup is
+        still forced to zero nodes.
+        """
+        grace_days = settings.EKS_AUTOSCALE_SWEEP_GRACE_PERIOD_DAYS
+        self._make_challenge_eligible(
+            end_date=timezone.now() - timedelta(days=max(grace_days - 1, 0))
+        )
+        ChallengeEvaluationCluster.objects.create(
+            challenge=self.challenge, name="recently-ended-cluster"
+        )
+        with mock.patch.dict(
+            os.environ, {"LAMBDA_AUTH_TOKEN": self.auth_token}
+        ):
+            response = self._client_with_auth().get(self.url, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(self.challenge.pk, response.data["challenge_pks"])
+
 
 class GetChallengeSubmissionMetricsByPkTest(BaseAPITestClass):
     """Tests for the get_challenge_submission_metrics_by_pk endpoint."""


### PR DESCRIPTION
## Problem

After a code-upload submission finished evaluating, the challenge's EKS nodegroup sometimes stayed at `desiredSize=1` instead of scaling back to zero — intermittently, not every time.

Root cause turned out to be two stacked failures, both operational rather than logical:

1. **The reconciliation sweep was never deployed to production.** Invoking the Lambda with `{"sweep": true}` returned `{"statusCode": 400, "body": "Missing challenge_pk"}` — the deployed build predated the sweep branch entirely — and `events describe-rule` returned `ResourceNotFoundException` for the schedule. Autoscaling was therefore running purely on best-effort async invocations from `trigger_eks_node_autoscale()`. A single dropped terminal event left the nodegroup up with nothing to reconcile it.

2. **Deploying the Lambda was a manual step.** `scripts/lambda/deploy_auto_scale_eks_nodes_lambda.sh` was referenced only by the docs and by itself — no CI, no Terraform, no CloudFormation anywhere in the repo. So merging the sweep feature changed nothing in production, silently.

Once the sweep was running, it exposed a third issue: it failed on **15 of 16** eligible challenges. Every failure was a challenge that had already ended, and the only success was the one still-active challenge.

| | count | challenges |
|---|---|---|
| eligible | 16 | |
| ended, failing | 15 | 802, 1615, 1693, 1820, 1844, 1992, 2088, 2100, 2105, 2164, 2264, 2278, 2373, 2394, 2628 |
| active, succeeding | 1 | 2319 |

14 failed with `AccessDenied` on `sts:AssumeRole` against `evalai-autoscale-crossaccount` across 7 host accounts; 1 (2264) with `ResourceNotFoundException` — its cluster no longer exists. Because `_sweep` re-raises when any challenge fails, every scheduled run ended in error, got retried twice by AWS, and buried genuine failures on the live challenge.

## Changes

**Scope the sweep to challenges that still matter** — `get_autoscale_eligible_challenges` now excludes challenges that ended more than `EKS_AUTOSCALE_SWEEP_GRACE_PERIOD_DAYS` (default 30, env-overridable) ago. The grace period keeps a just-ended challenge in the sweep long enough for its nodegroup to be forced to zero; past that the host is free to delete the cluster or revoke the cross-account role. Challenges with no `end_date` are unaffected.

**Deploy the Lambda from CI** — the deployment job now runs the existing deploy script for staging and production. In dry-run mode it verifies the function and the sweep rule exist and fails with an explicit message if either is missing, so this class of drift surfaces instead of going unnoticed.

**Fix `put-targets` in the deploy script** — the target was passed as CLI shorthand, which cannot express an `Input` containing braces and quotes and fails with `Expected: '=', received: '"'`. It is now passed as JSON, and the registered `Input` is asserted afterwards: `put-targets` reports per-entry failures in its response body rather than via exit code, so a target that never registered would otherwise look like a successful deploy. Without that `Input`, EventBridge invokes the Lambda with an empty event and the sweep never runs.

**Docs** — record that CI owns the deploy, list the IAM permissions the deployment role needs, and document the sweep's eligibility rules.

## Before merging

The deployment OIDC role needs `lambda:GetFunction`, `lambda:UpdateFunctionCode`, `lambda:UpdateFunctionConfiguration`, `lambda:AddPermission`, `events:PutRule`, `events:DescribeRule`, `events:PutTargets`, `events:ListTargetsByRule`. **If it does not have these, the new step will fail the deployment job** — worth confirming first. `EVALAI_API_SERVER` and `LAMBDA_AUTH_TOKEN` are read as repository secrets; if unset, the script skips the configuration update and still deploys code and schedule.

## Not covered here

- **The 15 ended challenges are excluded, not repaired.** Their nodegroups are unreachable from the Lambda, so if any still has `desired > 0` it is running unnoticed. EvalAI holds per-challenge host credentials, so this is auditable from the Django side — worth doing as a follow-up, since exclusion makes them invisible to the sweep.
- **Missing cross-account roles.** Per [scaling-guidelines.md](docs/source/04-development/deployment/scaling-guidelines.md), `setup_eks_cluster()` skips creating `evalai-autoscale-crossaccount` when `EKS_AUTOSCALE_LAMBDA_ROLE_ARN` is unset, which matches the observed `AccessDenied`. Confirm that variable is set in production, or new host-credential challenges will keep being created without a working autoscale path.
- **The dropped async invocation itself** still happens; the sweep bounds the damage to one cycle rather than forever. Setting `DLQ_ARN` would make drops visible.

## Testing

- Two new tests in `AutoscaleEligibleChallengesAPITest` covering exclusion beyond the grace period and inclusion within it.
- `pytest tests/unit/challenges/test_views.py -k AutoscaleEligibleChallenges` — 7 passed.
- `black`, `isort`, and `flake8` clean on all changed Python files.
- `bash -n` clean on the deploy script.

Production has since been brought up to date manually — the sweep rule was created, the Lambda redeployed, and `Sweeping N challenges` confirmed in CloudWatch — so this PR is what stops it drifting again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production deployment (Lambda/EventBridge) and changes which challenges are reconciled; misconfiguration of grace period or missing OIDC IAM permissions could block deploys or leave stale clusters out of sweep.
> 
> **Overview**
> Keeps EKS node autoscaling reconciliation from drifting in production and stops scheduled sweeps from failing on long-ended challenges.
> 
> **CI/CD** adds a **Deploy EKS node autoscale Lambda** step after service deploy: real runs invoke `deploy_auto_scale_eks_nodes_lambda.sh`; dry runs assert the Lambda exists, the sweep EventBridge rule is **ENABLED**, and the target input is exactly `{"sweep":true}`.
> 
> **API** — `get_autoscale_eligible_challenges` now drops challenges whose `end_date` is older than `EKS_AUTOSCALE_SWEEP_GRACE_PERIOD_DAYS` (default 30, env-overridable); challenges without `end_date` are unchanged. Startup rejects negative grace values via `ImproperlyConfigured`.
> 
> **Deploy script** registers the sweep target via a JSON file (CLI shorthand broke `Input`) and fails the deploy if `list-targets-by-rule` does not show the expected sweep payload.
> 
> Docs and unit tests cover eligibility rules, IAM needs, and grace-period inclusion/exclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9606c5cb584eb2d7aa5c89077edc6d428de3a4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable grace-period handling for completed challenges during autoscaling reconciliation.
  * Automated deployment of the autoscaling function and scheduled sweep in supported environments.
  * Added validation to ensure scheduled sweeps receive the correct input payload.
  * Added startup validation to reject negative grace-period settings.

* **Bug Fixes**
  * Prevented challenges that ended beyond the configured grace period from being considered for autoscaling.

* **Documentation**
  * Clarified autoscaling eligibility, reconciliation behavior, deployment coverage, and required permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->