### PR TITLE
Speed up remaining_submissions by aggregating from the submission table

### DIFF
--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -998,44 +998,49 @@ def get_remaining_submissions(request, challenge_pk):
     ).order_by("pk")
     if not is_user_a_host_of_challenge(request.user, challenge_pk):
         challenge_phases = challenge_phases.filter(is_public=True)
+    challenge_phases = list(challenge_phases)
 
     now = timezone.now()
     month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
 
-    # Omitting submissions__challenge_phase__challenge here intentionally:
-    # challenge_phases is already filtered to this challenge, so the JOIN
-    # on submission.challenge_phase_id already scopes submissions correctly.
-    # Including it caused Django ORM to emit a redundant self-join on
-    # challenge_phase (T4 alias), inflating query cost significantly.
-    submission_filter = Q(
-        submissions__participant_team=participant_team,
-    ) & ~Q(submissions__status__in=submission_status_to_exclude)
-
-    challenge_phases = challenge_phases.annotate(
-        submissions_count=Count(
-            "submissions",
-            filter=submission_filter,
-        ),
-        submissions_this_month_count=Count(
-            "submissions",
-            filter=submission_filter
-            & Q(submissions__submitted_at__gte=month_start),
-        ),
-        submissions_today_count=Count(
-            "submissions",
-            filter=submission_filter
-            & Q(submissions__submitted_at__gte=today_start),
-        ),
+    # Aggregate from the submission side instead of annotating the phase
+    # queryset. Annotating phases emits a LEFT JOIN whose only join predicate
+    # is challenge_phase_id, so the participant_team check ends up inside
+    # FILTER (WHERE ...) and is applied during aggregation, not to prune the
+    # join. Postgres therefore reads every submission of the challenge to
+    # count the handful belonging to one team. Driving the query from
+    # submission puts participant_team_id in the WHERE clause, where its index
+    # narrows the scan to this team's rows before any grouping happens.
+    phase_counts = (
+        Submission.objects.filter(
+            participant_team=participant_team,
+            challenge_phase_id__in=[phase.pk for phase in challenge_phases],
+        )
+        .exclude(status__in=submission_status_to_exclude)
+        .values("challenge_phase_id")
+        .annotate(
+            submissions_count=Count("id"),
+            submissions_this_month_count=Count(
+                "id", filter=Q(submitted_at__gte=month_start)
+            ),
+            submissions_today_count=Count(
+                "id", filter=Q(submitted_at__gte=today_start)
+            ),
+        )
     )
+    counts_by_phase_id = {
+        row["challenge_phase_id"]: row for row in phase_counts
+    }
 
     phase_data_list = []
     for phase in challenge_phases:
+        counts = counts_by_phase_id.get(phase.pk, {})
         limits = _compute_remaining_limits(
             phase,
-            phase.submissions_count,
-            phase.submissions_this_month_count,
-            phase.submissions_today_count,
+            counts.get("submissions_count", 0),
+            counts.get("submissions_this_month_count", 0),
+            counts.get("submissions_today_count", 0),
             now,
         )
         phase_data_list.append(


### PR DESCRIPTION
## Problem

`/api/jobs/{challenge_pk}/remaining_submissions/` is a long-standing Sentry `performance_slow_db_query` issue — 826 events across 146 users over two months, peaking at **8.25s** on challenge 830 (99% of an 8.31s transaction).

`get_remaining_submissions` annotated the `ChallengePhase` queryset, which placed the `participant_team` predicate inside `FILTER (WHERE ...)`. Postgres applies a `FILTER` clause during aggregation, so it cannot use it to prune the join — the `LEFT JOIN`'s only predicate was `challenge_phase_id`.

The result: **every submission of the challenge, from every team**, was read in order to count the handful belonging to the requesting team. Cost grew with challenge popularity, which is why it only fires on large challenges and got steadily worse.

This supersedes #5069, which removed a redundant `challenge_phase` self-join but left the full-challenge scan untouched.

## Fix

Drive the aggregate from `Submission` instead of annotating the phase queryset. `participant_team_id` then sits in the `WHERE` clause where its foreign-key index applies, and the join disappears entirely. `status NOT IN (...)` also moves out of `FILTER` into `WHERE`.

## Measurements

`EXPLAIN ANALYZE`, 200k seeded submissions on one challenge, counting one team's 500:

```
before: Nested Loop Left Join  (actual time=2.140..62.318 rows=200000 loops=1)   57.8ms
after:  Index Scan using submission_participant_team_id_409973b4 on submission
                               (actual time=0.008..0.099 rows=500 loops=1)        0.8ms
```

Timing no longer scales with challenge size:

| challenge submissions | before | after |
|---|---|---|
| 20,000 | 7.8 ms | 0.8 ms |
| 100,000 | 29.7 ms | 0.8 ms |
| 200,000 | 57.8 ms | 0.8 ms |

Cost now scales with the requesting team's own submission count rather than the challenge's total.

## Correctness

The old and new querysets were asserted to return identical per-phase count tuples on the seeded dataset before benchmarking. `.exclude(status__in=...)` is equivalent to the previous `~Q(...)` here because `submission.status` is non-nullable.

## Testing

- `pytest tests/unit/jobs/` — 338 passed
- `pytest tests/` — 1976 passed, 1 failed. The failure is `tests/integration/worker/test_submission_worker.py::ProcessSubmissionCallbackTestClass::test_process_submission_message_succesfully`, which fails identically on unmodified master (`FileNotFoundError` on a worker tmpdir path) and is unrelated to this endpoint.
- `black --check --line-length=79` and `isort --check --profile=black --line-length=79` clean.

## Note on indexing

No new index is added. The existing `submission.participant_team_id` foreign-key index already produces the index scan above. A composite `(participant_team_id, challenge_phase_id)` index would only be worth the `CREATE INDEX CONCURRENTLY` migration on the production `submission` table if this endpoint is still slow after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized query refactor in one read endpoint with equivalent filters and limit math; main risk is a subtle count mismatch if aggregation filters diverge from the old annotations.
> 
> **Overview**
> **Speeds up** `get_remaining_submissions` by replacing per-phase `Count` annotations on `ChallengePhase` with one grouped query on `Submission`.
> 
> The old ORM shape put `participant_team` inside aggregate `FILTER` clauses on a phase `LEFT JOIN`, so Postgres scanned **all** challenge submissions to count one team’s rows. The new path filters `Submission` by `participant_team` and phase IDs in `WHERE`, groups by `challenge_phase_id`, and maps totals (including month/today filtered counts) into the existing `_compute_remaining_limits` loop. Phases are evaluated as a `list` so phase metadata and counts stay decoupled.
> 
> **API behavior** for remaining limits is unchanged; only query shape and performance differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9eeda60b645bde2fe9673a0cfcd44c4d70ec52f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected remaining submission counts for phases with participant-specific submissions.
  * Phases without submissions now correctly display a count of zero.
  * Existing submission limits and response formatting remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->