### PR TITLE
feat(challenges): sync EKS nodegroup config from the challenge record

### DIFF
--- a/apps/challenges/admin.py
+++ b/apps/challenges/admin.py
@@ -6,6 +6,7 @@ from django.contrib.admin.helpers import ActionForm
 from .admin_filters import ChallengeFilter
 from .aws_utils import (
     delete_workers,
+    recreate_eks_nodegroup,
     refresh_worker_task_definitions,
     restart_workers,
     scale_workers,
@@ -98,6 +99,7 @@ class ChallengeAdmin(ImportExportTimeStampedAdmin):
         "unfreeze_selected_challenges",
         "pause_selected_challenge_submissions",
         "unpause_selected_challenge_submissions",
+        "recreate_selected_eks_nodegroups",
     ]
     action_form = UpdateNumOfWorkersForm
 
@@ -318,6 +320,35 @@ class ChallengeAdmin(ImportExportTimeStampedAdmin):
 
     unpause_selected_challenge_submissions.short_description = (
         "Unpause submissions for selected challenges."
+    )
+
+    def recreate_selected_eks_nodegroups(self, request, queryset):
+        skipped = 0
+        queued = 0
+        for challenge in queryset:
+            if not challenge.is_docker_based or challenge.remote_evaluation:
+                skipped += 1
+                continue
+            recreate_eks_nodegroup.delay(challenge.pk)
+            queued += 1
+
+        if queued:
+            messages.success(
+                request,
+                "Queued nodegroup recreation for {} challenge(s). Nodes "
+                "running submissions will be terminated. Check the worker "
+                "logs for the outcome.".format(queued),
+            )
+        if skipped:
+            messages.warning(
+                request,
+                "{} challenge(s) skipped: not code-upload challenges.".format(
+                    skipped
+                ),
+            )
+
+    recreate_selected_eks_nodegroups.short_description = (
+        "Recreate EKS nodegroup (applies instance type, AMI and disk size)."
     )
 
 

--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -13,6 +13,7 @@ import yaml
 from accounts.models import JwtToken
 from base.utils import get_boto3_client
 from botocore.exceptions import BotoCoreError, ClientError
+from celery.exceptions import MaxRetriesExceededError
 from django.conf import settings
 from django.core import serializers
 from django.core.files.temp import NamedTemporaryFile
@@ -2912,8 +2913,8 @@ def _resolve_nodegroup_name(client, challenge_pk, cluster):
     return nodegroup_name
 
 
-@app.task
-def recreate_eks_nodegroup(challenge_pk):
+@app.task(bind=True, max_retries=settings.EKS_NODEGROUP_SYNC_MAX_RETRIES)
+def recreate_eks_nodegroup(self, challenge_pk):
     """
     Replace a challenge's EKS nodegroup so immutable config changes take effect.
 
@@ -2956,11 +2957,25 @@ def recreate_eks_nodegroup(challenge_pk):
         return {"error": str(e)}
 
     if status != "ACTIVE":
+        # Most often the initial setup_eks_cluster chain is still building this
+        # nodegroup. Giving up here would drop the edit for good: the callback
+        # has already refreshed its snapshots, so saving the same value again
+        # dispatches nothing. Retry until the nodegroup settles instead.
         message = (
-            "Nodegroup {} for challenge {} is {}, not ACTIVE. Skipping "
+            "Nodegroup {} for challenge {} is {}, not ACTIVE. Retrying "
             "recreate.".format(nodegroup_name, challenge_pk, status)
         )
         logger.warning(message)
+        try:
+            self.retry(countdown=settings.EKS_NODEGROUP_SYNC_RETRY_SECONDS)
+        except MaxRetriesExceededError:
+            logger.error(
+                "Nodegroup %s for challenge %s never became ACTIVE. Its "
+                "worker configuration change was not applied; use the "
+                "'Recreate EKS nodegroup' admin action to retry.",
+                nodegroup_name,
+                challenge_pk,
+            )
         return {"error": message}
 
     errors = validate_eks_nodegroup_config(challenge, client, cluster_name)
@@ -3019,8 +3034,8 @@ def recreate_eks_nodegroup(challenge_pk):
     return {"message": message}
 
 
-@app.task
-def update_eks_nodegroup_scaling(challenge_pk):
+@app.task(bind=True, max_retries=settings.EKS_NODEGROUP_SYNC_MAX_RETRIES)
+def update_eks_nodegroup_scaling(self, challenge_pk):
     """
     Push a challenge's scaling bounds to its existing EKS nodegroup.
 
@@ -3055,17 +3070,38 @@ def update_eks_nodegroup_scaling(challenge_pk):
     min_size = challenge.min_worker_instance
     max_size = challenge.max_worker_instance
     try:
-        current = client.describe_nodegroup(
+        nodegroup = client.describe_nodegroup(
             clusterName=cluster_name, nodegroupName=nodegroup_name
-        )["nodegroup"]["scalingConfig"]
+        )["nodegroup"]
+        status = nodegroup["status"]
         # Keep whatever the Lambda last decided, but inside the new bounds so
         # AWS does not reject the update.
         desired_size = min(
-            max(int(current["desiredSize"]), min_size), max_size
+            max(int(nodegroup["scalingConfig"]["desiredSize"]), min_size),
+            max_size,
         )
     except (ClientError, BotoCoreError, KeyError, TypeError, ValueError) as e:
         logger.exception(e)
         return {"error": str(e)}
+
+    if status != "ACTIVE":
+        # Same window as recreate_eks_nodegroup: the snapshots are already
+        # refreshed, so dropping this would lose the edit permanently.
+        message = (
+            "Nodegroup {} for challenge {} is {}, not ACTIVE. Retrying "
+            "scaling update.".format(nodegroup_name, challenge_pk, status)
+        )
+        logger.warning(message)
+        try:
+            self.retry(countdown=settings.EKS_NODEGROUP_SYNC_RETRY_SECONDS)
+        except MaxRetriesExceededError:
+            logger.error(
+                "Nodegroup %s for challenge %s never became ACTIVE. Its "
+                "scaling change was not applied.",
+                nodegroup_name,
+                challenge_pk,
+            )
+        return {"error": message}
 
     try:
         client.update_nodegroup_config(

--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -2626,7 +2626,10 @@ def create_nodegroup_for_challenge(
         cluster_name {str} -- name of eks cluster
         nodegroup_name {str} -- name of the nodegroup to create
     Returns:
-        {dict or None} -- the create_nodegroup response, or None on failure
+        {dict or None} -- the create_nodegroup response, or None when the
+            nodegroup was not created. A nodegroup that was created but did
+            not reach ACTIVE within the waiter's budget still returns the
+            response, because it exists and must not be treated as absent.
     """
     from .models import ChallengeEvaluationCluster
 
@@ -2663,11 +2666,17 @@ def create_nodegroup_for_challenge(
         waiter = client.get_waiter("nodegroup_active")
         waiter.wait(clusterName=cluster_name, nodegroupName=nodegroup_name)
     except (ClientError, BotoCoreError) as e:
-        # WaiterError is a BotoCoreError. Without this the exception escapes
-        # to the caller, which would skip both the failure logging here and
-        # the code-upload worker start in create_eks_nodegroup.
+        # WaiterError is a BotoCoreError. Letting it escape would skip the
+        # caller's error handling entirely; returning None would be worse
+        # still, since the nodegroup does exist and the caller would report it
+        # as missing and may delete it on the next attempt.
         logger.exception(e)
-        return None
+        logger.warning(
+            "Nodegroup %s for challenge %s was created but has not reached "
+            "ACTIVE yet. Treating it as created.",
+            nodegroup_name,
+            challenge_obj.pk,
+        )
 
     return response
 
@@ -2680,10 +2689,22 @@ def create_eks_nodegroup(challenge, cluster_name):
         instance {<class 'django.db.models.query.QuerySet'>} -- instance of the model calling the post hook
         cluster_name {str} -- name of eks cluster
     """
+    from .models import Challenge
     from .utils import get_aws_credentials_for_challenge
 
     for obj in serializers.deserialize("json", challenge):
         challenge_obj = obj.object
+
+    # The serialized challenge is a snapshot taken when approved_by_admin
+    # flipped, and cluster setup takes many minutes. Re-read the worker
+    # configuration so an edit made in that window is not silently dropped:
+    # the post_save hook cannot recreate a nodegroup that does not exist yet,
+    # so this is the only place that edit can still be applied.
+    try:
+        challenge_obj = Challenge.objects.get(pk=challenge_obj.pk)
+    except (Challenge.DoesNotExist, DatabaseError) as e:
+        logger.exception(e)
+
     nodegroup_name = get_nodegroup_name_for_challenge(challenge_obj)
     challenge_aws_keys = get_aws_credentials_for_challenge(challenge_obj.pk)
     client = get_boto3_client("eks", challenge_aws_keys)

--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -2592,28 +2592,45 @@ def delete_log_group(log_group_name):
             logger.exception(e)
 
 
-@app.task
-def create_eks_nodegroup(challenge, cluster_name):
+def get_nodegroup_name_for_challenge(challenge_obj):
     """
-    Creates a nodegroup when a EKS cluster is created by the EvalAI admin
-    Arguments:
-        instance {<class 'django.db.models.query.QuerySet'>} -- instance of the model calling the post hook
-        cluster_name {str} -- name of eks cluster
-    """
-    from .models import ChallengeEvaluationCluster
-    from .utils import get_aws_credentials_for_challenge
+    Build the deterministic nodegroup name for a challenge.
 
-    for obj in serializers.deserialize("json", challenge):
-        challenge_obj = obj.object
+    The name is derived from the challenge rather than stored, so recreating a
+    nodegroup reuses the same name and leaves
+    ChallengeEvaluationCluster.nodegroup_name (which autoscaling targets) valid.
+
+    Arguments:
+        challenge_obj {<class 'apps.challenges.models.Challenge'>} -- challenge instance
+    Returns:
+        {str} -- nodegroup name
+    """
     environment_suffix = "{}-{}".format(challenge_obj.pk, settings.ENVIRONMENT)
-    nodegroup_name = "{}-{}-nodegroup".format(
+    return "{}-{}-nodegroup".format(
         challenge_obj.title.replace(" ", "-")[:20], environment_suffix
     )
-    challenge_aws_keys = get_aws_credentials_for_challenge(challenge_obj.pk)
-    client = get_boto3_client("eks", challenge_aws_keys)
+
+
+def create_nodegroup_for_challenge(
+    client, challenge_obj, cluster_name, nodegroup_name
+):
+    """
+    Issue the create_nodegroup call for a challenge and record the name.
+
+    Shared by initial cluster setup and by recreation after an immutable
+    nodegroup field changes, so both paths always send the same argument set.
+
+    Arguments:
+        client -- boto3 EKS client authenticated for the challenge
+        challenge_obj {<class 'apps.challenges.models.Challenge'>} -- challenge instance
+        cluster_name {str} -- name of eks cluster
+        nodegroup_name {str} -- name of the nodegroup to create
+    Returns:
+        {dict or None} -- the create_nodegroup response, or None on failure
+    """
+    from .models import ChallengeEvaluationCluster
+
     cluster_meta = get_code_upload_setup_meta_for_challenge(challenge_obj.pk)
-    # TODO: Move the hardcoded cluster configuration such as the
-    # instance_type, subnets, AMI to challenge configuration later.
     try:
         response = client.create_nodegroup(
             clusterName=cluster_name,
@@ -2632,7 +2649,7 @@ def create_eks_nodegroup(challenge, cluster_name):
         logger.info("Nodegroup create: {}".format(response))
     except ClientError as e:
         logger.exception(e)
-        return
+        return None
 
     # Record the name so autoscaling targets this nodegroup explicitly.
     try:
@@ -2644,11 +2661,363 @@ def create_eks_nodegroup(challenge, cluster_name):
 
     waiter = client.get_waiter("nodegroup_active")
     waiter.wait(clusterName=cluster_name, nodegroupName=nodegroup_name)
+    return response
+
+
+@app.task
+def create_eks_nodegroup(challenge, cluster_name):
+    """
+    Creates a nodegroup when a EKS cluster is created by the EvalAI admin
+    Arguments:
+        instance {<class 'django.db.models.query.QuerySet'>} -- instance of the model calling the post hook
+        cluster_name {str} -- name of eks cluster
+    """
+    from .utils import get_aws_credentials_for_challenge
+
+    for obj in serializers.deserialize("json", challenge):
+        challenge_obj = obj.object
+    nodegroup_name = get_nodegroup_name_for_challenge(challenge_obj)
+    challenge_aws_keys = get_aws_credentials_for_challenge(challenge_obj.pk)
+    client = get_boto3_client("eks", challenge_aws_keys)
+    response = create_nodegroup_for_challenge(
+        client, challenge_obj, cluster_name, nodegroup_name
+    )
+    if response is None:
+        return
+
     construct_and_send_eks_cluster_creation_mail(challenge_obj)
     # starting the code-upload-worker
     client = get_boto3_client("ecs", aws_keys)
     client_token = client_token_generator(challenge_obj.pk)
     create_service_by_challenge_pk(client, challenge_obj, client_token)
+
+
+def validate_eks_nodegroup_config(challenge_obj, eks_client, cluster_name):
+    """
+    Check a challenge's nodegroup configuration before it is applied to AWS.
+
+    Recreating a nodegroup deletes the existing one first, so an invalid
+    configuration would leave the challenge with no capacity at all. Every
+    problem that can be detected up front is detected here instead.
+
+    Arguments:
+        challenge_obj {<class 'apps.challenges.models.Challenge'>} -- challenge instance
+        eks_client -- boto3 EKS client authenticated for the challenge
+        cluster_name {str} -- name of eks cluster
+    Returns:
+        {list} -- human readable problems, empty when the config is usable
+    """
+    from .utils import get_aws_credentials_for_challenge
+
+    errors = []
+
+    instance_type = challenge_obj.worker_instance_type
+    if not instance_type:
+        errors.append("worker_instance_type is empty.")
+    else:
+        try:
+            ec2_client = get_boto3_client(
+                "ec2", get_aws_credentials_for_challenge(challenge_obj.pk)
+            )
+            offerings = ec2_client.describe_instance_type_offerings(
+                LocationType="region",
+                Filters=[{"Name": "instance-type", "Values": [instance_type]}],
+            )
+            if not offerings.get("InstanceTypeOfferings"):
+                errors.append(
+                    "Instance type {} is not offered in this region.".format(
+                        instance_type
+                    )
+                )
+        except (ClientError, BotoCoreError) as e:
+            logger.exception(e)
+            errors.append(
+                "Could not verify instance type {}: {}".format(
+                    instance_type, e
+                )
+            )
+
+    ami_type = challenge_obj.worker_ami_type
+    if ami_type not in settings.EKS_SUPPORTED_AMI_TYPES:
+        errors.append("Unknown worker_ami_type {}.".format(ami_type))
+    else:
+        if (
+            not challenge_obj.cpu_only_jobs
+            and ami_type not in settings.EKS_GPU_AMI_TYPES
+        ):
+            errors.append(
+                "AMI type {} has no GPU driver, but cpu_only_jobs is "
+                "disabled.".format(ami_type)
+            )
+        try:
+            cluster_version = eks_client.describe_cluster(name=cluster_name)[
+                "cluster"
+            ]["version"]
+            if ami_type.startswith("AL2_") and _version_at_least(
+                cluster_version, settings.EKS_AL2_REMOVED_IN_VERSION
+            ):
+                errors.append(
+                    "AMI type {} is not available on Kubernetes {}. Use an "
+                    "AL2023 or Bottlerocket AMI type.".format(
+                        ami_type, cluster_version
+                    )
+                )
+        except (ClientError, BotoCoreError, KeyError) as e:
+            logger.exception(e)
+            errors.append("Could not read cluster version: {}".format(e))
+
+    disk_size = challenge_obj.worker_disk_size
+    if not isinstance(disk_size, int) or disk_size <= 0:
+        errors.append("worker_disk_size must be a positive integer.")
+
+    return errors
+
+
+def _version_at_least(version, minimum):
+    """
+    Compare two dotted Kubernetes version strings.
+
+    Arguments:
+        version {str} -- version reported by EKS, e.g. "1.36"
+        minimum {str} -- version to compare against, e.g. "1.33"
+    Returns:
+        {bool} -- True when version >= minimum, False when unparseable
+    """
+    try:
+        parsed = tuple(int(part) for part in str(version).split(".")[:2])
+        floor = tuple(int(part) for part in str(minimum).split(".")[:2])
+    except (TypeError, ValueError):
+        return False
+    return parsed >= floor
+
+
+def _get_challenge_nodegroup(challenge_pk):
+    """
+    Resolve the challenge, cluster name and nodegroup name for a sync task.
+
+    Arguments:
+        challenge_pk {int} -- challenge primary key
+    Returns:
+        {tuple} -- (challenge, cluster_name, nodegroup_name), or
+            (None, None, None) when the challenge has no nodegroup yet
+    """
+    from .models import ChallengeEvaluationCluster
+
+    try:
+        cluster = ChallengeEvaluationCluster.objects.select_related(
+            "challenge"
+        ).get(challenge_id=challenge_pk)
+    except ChallengeEvaluationCluster.DoesNotExist:
+        logger.info(
+            "Challenge %s has no evaluation cluster yet. Skipping nodegroup "
+            "sync.",
+            challenge_pk,
+        )
+        return None, None, None
+    except DatabaseError as e:
+        logger.exception(e)
+        return None, None, None
+
+    challenge = cluster.challenge
+    nodegroup_name = cluster.nodegroup_name or (
+        get_nodegroup_name_for_challenge(challenge)
+    )
+    return challenge, cluster.name, nodegroup_name
+
+
+@app.task
+def recreate_eks_nodegroup(challenge_pk):
+    """
+    Replace a challenge's EKS nodegroup so immutable config changes take effect.
+
+    instanceTypes, amiType and diskSize cannot be changed on an existing
+    managed nodegroup, so editing those fields on the challenge has no effect
+    on AWS until the nodegroup is recreated. The configuration is validated
+    before the old nodegroup is deleted, because deletion is not reversible.
+
+    Deleting the nodegroup terminates any nodes currently running submissions.
+
+    Arguments:
+        challenge_pk {int} -- challenge primary key
+    Returns:
+        {dict} -- {"message": ...} on success, {"error": ...} otherwise
+    """
+    from .utils import get_aws_credentials_for_challenge
+
+    challenge, cluster_name, nodegroup_name = _get_challenge_nodegroup(
+        challenge_pk
+    )
+    if challenge is None:
+        return {"error": "No nodegroup to recreate."}
+
+    client = get_boto3_client(
+        "eks", get_aws_credentials_for_challenge(challenge_pk)
+    )
+
+    errors = validate_eks_nodegroup_config(challenge, client, cluster_name)
+    if errors:
+        message = (
+            "Refusing to recreate nodegroup {} for challenge {}. The existing "
+            "nodegroup was left untouched. Problems: {}".format(
+                nodegroup_name, challenge_pk, "; ".join(errors)
+            )
+        )
+        logger.error(message)
+        return {"error": message}
+
+    logger.warning(
+        "Recreating nodegroup %s for challenge %s. Any submissions running on "
+        "its nodes will be terminated.",
+        nodegroup_name,
+        challenge_pk,
+    )
+
+    try:
+        client.delete_nodegroup(
+            clusterName=cluster_name, nodegroupName=nodegroup_name
+        )
+        client.get_waiter("nodegroup_deleted").wait(
+            clusterName=cluster_name, nodegroupName=nodegroup_name
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] != "ResourceNotFoundException":
+            logger.exception(e)
+            return {"error": str(e)}
+        # Nothing to delete; fall through and create the nodegroup.
+        logger.info("Nodegroup %s did not exist. Creating it.", nodegroup_name)
+    except BotoCoreError as e:
+        # Covers WaiterError when deletion outlasts the poll budget. Creating
+        # over a half-deleted nodegroup would fail, so stop here.
+        logger.exception(e)
+        return {"error": str(e)}
+
+    response = create_nodegroup_for_challenge(
+        client, challenge, cluster_name, nodegroup_name
+    )
+    if response is None:
+        message = (
+            "Deleted nodegroup {} for challenge {} but could not recreate it. "
+            "The challenge has no worker capacity until this is "
+            "resolved.".format(nodegroup_name, challenge_pk)
+        )
+        logger.error(message)
+        return {"error": message}
+
+    message = "Recreated nodegroup {} for challenge {}.".format(
+        nodegroup_name, challenge_pk
+    )
+    logger.info(message)
+    return {"message": message}
+
+
+@app.task
+def update_eks_nodegroup_scaling(challenge_pk):
+    """
+    Push a challenge's scaling bounds to its existing EKS nodegroup.
+
+    Unlike instance type, scaling config is mutable, so this needs no
+    recreation. The autoscale Lambda rewrites minSize and desiredSize from the
+    pending submission count on its next run; maxSize is the durable one, since
+    the Lambda caps scale-up at the challenge's max_worker_instance.
+
+    Arguments:
+        challenge_pk {int} -- challenge primary key
+    Returns:
+        {dict} -- {"message": ...} on success, {"error": ...} otherwise
+    """
+    from .utils import get_aws_credentials_for_challenge
+
+    challenge, cluster_name, nodegroup_name = _get_challenge_nodegroup(
+        challenge_pk
+    )
+    if challenge is None:
+        return {"error": "No nodegroup to update."}
+
+    client = get_boto3_client(
+        "eks", get_aws_credentials_for_challenge(challenge_pk)
+    )
+    try:
+        client.update_nodegroup_config(
+            clusterName=cluster_name,
+            nodegroupName=nodegroup_name,
+            scalingConfig={
+                "minSize": challenge.min_worker_instance,
+                "maxSize": challenge.max_worker_instance,
+                "desiredSize": challenge.desired_worker_instance,
+            },
+        )
+    except (ClientError, BotoCoreError) as e:
+        logger.exception(e)
+        return {"error": str(e)}
+
+    message = (
+        "Updated scaling config for nodegroup {} of challenge {}.".format(
+            nodegroup_name, challenge_pk
+        )
+    )
+    logger.info(message)
+    return {"message": message}
+
+
+def eks_nodegroup_config_change_callback(instance):
+    """
+    Dispatch nodegroup work when a challenge's worker configuration changes.
+
+    Called from the Challenge post_save hook. Immutable fields require a full
+    recreate; scaling fields only need an update. When both changed, the
+    recreate already applies the new scaling config, so only it is dispatched.
+
+    Arguments:
+        instance {<class 'apps.challenges.models.Challenge'>} -- challenge instance
+    Returns:
+        {str or None} -- the action dispatched, for logging and tests
+    """
+    from base.utils import is_model_field_changed
+
+    if settings.DEBUG or settings.TEST:
+        return None
+
+    if not instance.is_docker_based or instance.remote_evaluation:
+        return None
+
+    immutable_changed = [
+        field
+        for field in settings.EKS_NODEGROUP_IMMUTABLE_FIELDS
+        if is_model_field_changed(instance, field)
+    ]
+    scaling_changed = [
+        field
+        for field in settings.EKS_NODEGROUP_SCALING_FIELDS
+        if is_model_field_changed(instance, field)
+    ]
+
+    if not immutable_changed and not scaling_changed:
+        return None
+
+    for field in (
+        settings.EKS_NODEGROUP_IMMUTABLE_FIELDS
+        + settings.EKS_NODEGROUP_SCALING_FIELDS
+    ):
+        setattr(
+            instance, "_original_{}".format(field), getattr(instance, field)
+        )
+
+    if immutable_changed:
+        logger.info(
+            "Challenge %s changed %s. Recreating its EKS nodegroup.",
+            instance.pk,
+            ", ".join(immutable_changed),
+        )
+        recreate_eks_nodegroup.delay(instance.pk)
+        return "recreate"
+
+    logger.info(
+        "Challenge %s changed %s. Updating its EKS nodegroup scaling.",
+        instance.pk,
+        ", ".join(scaling_changed),
+    )
+    update_eks_nodegroup_scaling.delay(instance.pk)
+    return "scale"
 
 
 def setup_eks_autoscale_cross_account_role(iam_client, challenge_obj):

--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -3097,7 +3097,8 @@ def update_eks_nodegroup_scaling(self, challenge_pk):
         except MaxRetriesExceededError:
             logger.error(
                 "Nodegroup %s for challenge %s never became ACTIVE. Its "
-                "scaling change was not applied.",
+                "scaling change was not applied; use the 'Recreate EKS "
+                "nodegroup' admin action to retry.",
                 nodegroup_name,
                 challenge_pk,
             )

--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -2800,6 +2800,57 @@ def validate_eks_nodegroup_config(challenge_obj, eks_client, cluster_name):
     if not isinstance(disk_size, int) or disk_size <= 0:
         errors.append("worker_disk_size must be a positive integer.")
 
+    errors.extend(_validate_nodegroup_scaling(challenge_obj))
+
+    return errors
+
+
+def _validate_nodegroup_scaling(challenge_obj):
+    """
+    Check the scaling bounds CreateNodegroup will be given.
+
+    All three fields are nullable on the model and nothing stops an admin
+    saving a minimum above the maximum. Left unchecked, an invalid combination
+    passes validation, the live nodegroup is deleted, and only then does
+    CreateNodegroup reject it, leaving the challenge with no workers at all.
+
+    Arguments:
+        challenge_obj {<class 'apps.challenges.models.Challenge'>} -- challenge instance
+    Returns:
+        {list} -- human readable problems, empty when the bounds are usable
+    """
+    errors = []
+    bounds = {}
+    for field in settings.EKS_NODEGROUP_SCALING_FIELDS:
+        value = getattr(challenge_obj, field)
+        # bool is an int subclass, and True would silently become 1.
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            errors.append("{} must be a non-negative integer.".format(field))
+        else:
+            bounds[field] = value
+
+    if len(bounds) != len(settings.EKS_NODEGROUP_SCALING_FIELDS):
+        return errors
+
+    min_size = bounds["min_worker_instance"]
+    max_size = bounds["max_worker_instance"]
+    desired_size = bounds["desired_worker_instance"]
+
+    if max_size < 1:
+        errors.append("max_worker_instance must be at least 1.")
+    if min_size > max_size:
+        errors.append(
+            "min_worker_instance ({}) cannot exceed max_worker_instance "
+            "({}).".format(min_size, max_size)
+        )
+    if not min_size <= desired_size <= max_size:
+        errors.append(
+            "desired_worker_instance ({}) must be between "
+            "min_worker_instance ({}) and max_worker_instance ({}).".format(
+                desired_size, min_size, max_size
+            )
+        )
+
     return errors
 
 
@@ -2872,7 +2923,30 @@ def _resolve_nodegroup_name(client, challenge_pk, cluster):
     from .models import ChallengeEvaluationCluster
 
     if cluster.nodegroup_name:
-        return cluster.nodegroup_name
+        # A recorded name can still be wrong: the nodegroup may have been
+        # replaced by hand under a different name. Trusting it blindly would
+        # make every sync fail on describe_nodegroup until someone edited the
+        # database, so confirm it exists and re-resolve when it does not.
+        try:
+            client.describe_nodegroup(
+                clusterName=cluster.name,
+                nodegroupName=cluster.nodegroup_name,
+            )
+            return cluster.nodegroup_name
+        except ClientError as e:
+            if e.response["Error"]["Code"] != "ResourceNotFoundException":
+                logger.exception(e)
+                return None
+            logger.warning(
+                "Recorded nodegroup %s no longer exists on cluster %s for "
+                "challenge %s. Re-resolving from AWS.",
+                cluster.nodegroup_name,
+                cluster.name,
+                challenge_pk,
+            )
+        except BotoCoreError as e:
+            logger.exception(e)
+            return None
 
     try:
         nodegroups = client.list_nodegroups(clusterName=cluster.name).get(

--- a/apps/challenges/aws_utils.py
+++ b/apps/challenges/aws_utils.py
@@ -2659,8 +2659,16 @@ def create_nodegroup_for_challenge(
     except DatabaseError as e:
         logger.exception(e)
 
-    waiter = client.get_waiter("nodegroup_active")
-    waiter.wait(clusterName=cluster_name, nodegroupName=nodegroup_name)
+    try:
+        waiter = client.get_waiter("nodegroup_active")
+        waiter.wait(clusterName=cluster_name, nodegroupName=nodegroup_name)
+    except (ClientError, BotoCoreError) as e:
+        # WaiterError is a BotoCoreError. Without this the exception escapes
+        # to the caller, which would skip both the failure logging here and
+        # the code-upload worker start in create_eks_nodegroup.
+        logger.exception(e)
+        return None
+
     return response
 
 
@@ -2791,15 +2799,15 @@ def _version_at_least(version, minimum):
     return parsed >= floor
 
 
-def _get_challenge_nodegroup(challenge_pk):
+def _get_challenge_cluster(challenge_pk):
     """
-    Resolve the challenge, cluster name and nodegroup name for a sync task.
+    Resolve the challenge and its evaluation cluster for a sync task.
 
     Arguments:
         challenge_pk {int} -- challenge primary key
     Returns:
-        {tuple} -- (challenge, cluster_name, nodegroup_name), or
-            (None, None, None) when the challenge has no nodegroup yet
+        {tuple} -- (challenge, cluster), or (None, None) when the challenge
+            has no evaluation cluster
     """
     from .models import ChallengeEvaluationCluster
 
@@ -2813,16 +2821,74 @@ def _get_challenge_nodegroup(challenge_pk):
             "sync.",
             challenge_pk,
         )
-        return None, None, None
+        return None, None
     except DatabaseError as e:
         logger.exception(e)
-        return None, None, None
+        return None, None
 
-    challenge = cluster.challenge
-    nodegroup_name = cluster.nodegroup_name or (
-        get_nodegroup_name_for_challenge(challenge)
-    )
-    return challenge, cluster.name, nodegroup_name
+    return cluster.challenge, cluster
+
+
+def _resolve_nodegroup_name(client, challenge_pk, cluster):
+    """
+    Find the name of a challenge's live nodegroup.
+
+    nodegroup_name is nullable and was only added recently, so clusters
+    provisioned before then have none recorded. The name cannot be re-derived
+    from the challenge, because it embeds the title as it was at creation time:
+    a renamed challenge would derive a name that matches nothing, delete
+    nothing, and then create a second nodegroup alongside the live one.
+    Ask AWS instead.
+
+    Arguments:
+        client -- boto3 EKS client authenticated for the challenge
+        challenge_pk {int} -- challenge primary key
+        cluster {<class 'apps.challenges.models.ChallengeEvaluationCluster'>}
+    Returns:
+        {str or None} -- nodegroup name, or None when it cannot be pinned down
+    """
+    from .models import ChallengeEvaluationCluster
+
+    if cluster.nodegroup_name:
+        return cluster.nodegroup_name
+
+    try:
+        nodegroups = client.list_nodegroups(clusterName=cluster.name).get(
+            "nodegroups", []
+        )
+    except (ClientError, BotoCoreError) as e:
+        logger.exception(e)
+        return None
+
+    if not nodegroups:
+        # Also the state during initial cluster setup, before
+        # create_eks_nodegroup has run. Nothing to replace yet.
+        logger.info(
+            "Cluster %s for challenge %s has no nodegroup yet. Skipping.",
+            cluster.name,
+            challenge_pk,
+        )
+        return None
+
+    if len(nodegroups) > 1:
+        logger.error(
+            "Cluster %s for challenge %s has %s nodegroups and none recorded. "
+            "Refusing to guess which one to replace.",
+            cluster.name,
+            challenge_pk,
+            len(nodegroups),
+        )
+        return None
+
+    nodegroup_name = nodegroups[0]
+    try:
+        ChallengeEvaluationCluster.objects.filter(
+            challenge_id=challenge_pk
+        ).update(nodegroup_name=nodegroup_name)
+    except DatabaseError as e:
+        logger.exception(e)
+
+    return nodegroup_name
 
 
 @app.task
@@ -2844,15 +2910,37 @@ def recreate_eks_nodegroup(challenge_pk):
     """
     from .utils import get_aws_credentials_for_challenge
 
-    challenge, cluster_name, nodegroup_name = _get_challenge_nodegroup(
-        challenge_pk
-    )
+    challenge, cluster = _get_challenge_cluster(challenge_pk)
     if challenge is None:
         return {"error": "No nodegroup to recreate."}
 
+    cluster_name = cluster.name
     client = get_boto3_client(
         "eks", get_aws_credentials_for_challenge(challenge_pk)
     )
+    nodegroup_name = _resolve_nodegroup_name(client, challenge_pk, cluster)
+    if nodegroup_name is None:
+        return {"error": "No nodegroup to recreate."}
+
+    # A nodegroup that is not ACTIVE is being created, updated or deleted by
+    # someone else, most likely the initial setup_eks_cluster chain still in
+    # flight. Deleting it here would make create_eks_nodegroup fail on a
+    # duplicate name and skip starting the code-upload worker.
+    try:
+        status = client.describe_nodegroup(
+            clusterName=cluster_name, nodegroupName=nodegroup_name
+        )["nodegroup"]["status"]
+    except (ClientError, BotoCoreError, KeyError) as e:
+        logger.exception(e)
+        return {"error": str(e)}
+
+    if status != "ACTIVE":
+        message = (
+            "Nodegroup {} for challenge {} is {}, not ACTIVE. Skipping "
+            "recreate.".format(nodegroup_name, challenge_pk, status)
+        )
+        logger.warning(message)
+        return {"error": message}
 
     errors = validate_eks_nodegroup_config(challenge, client, cluster_name)
     if errors:
@@ -2916,9 +3004,13 @@ def update_eks_nodegroup_scaling(challenge_pk):
     Push a challenge's scaling bounds to its existing EKS nodegroup.
 
     Unlike instance type, scaling config is mutable, so this needs no
-    recreation. The autoscale Lambda rewrites minSize and desiredSize from the
-    pending submission count on its next run; maxSize is the durable one, since
-    the Lambda caps scale-up at the challenge's max_worker_instance.
+    recreation. Only the bounds are pushed: the live desiredSize is preserved,
+    because the autoscale Lambda owns it and will have raised it for pending
+    submissions. Sending the challenge's stored desired_worker_instance instead
+    would shrink a busy nodegroup and kill running submissions.
+
+    maxSize is the durable field here, since the Lambda caps scale-up at the
+    challenge's max_worker_instance.
 
     Arguments:
         challenge_pk {int} -- challenge primary key
@@ -2927,23 +3019,41 @@ def update_eks_nodegroup_scaling(challenge_pk):
     """
     from .utils import get_aws_credentials_for_challenge
 
-    challenge, cluster_name, nodegroup_name = _get_challenge_nodegroup(
-        challenge_pk
-    )
+    challenge, cluster = _get_challenge_cluster(challenge_pk)
     if challenge is None:
         return {"error": "No nodegroup to update."}
 
+    cluster_name = cluster.name
     client = get_boto3_client(
         "eks", get_aws_credentials_for_challenge(challenge_pk)
     )
+    nodegroup_name = _resolve_nodegroup_name(client, challenge_pk, cluster)
+    if nodegroup_name is None:
+        return {"error": "No nodegroup to update."}
+
+    min_size = challenge.min_worker_instance
+    max_size = challenge.max_worker_instance
+    try:
+        current = client.describe_nodegroup(
+            clusterName=cluster_name, nodegroupName=nodegroup_name
+        )["nodegroup"]["scalingConfig"]
+        # Keep whatever the Lambda last decided, but inside the new bounds so
+        # AWS does not reject the update.
+        desired_size = min(
+            max(int(current["desiredSize"]), min_size), max_size
+        )
+    except (ClientError, BotoCoreError, KeyError, TypeError, ValueError) as e:
+        logger.exception(e)
+        return {"error": str(e)}
+
     try:
         client.update_nodegroup_config(
             clusterName=cluster_name,
             nodegroupName=nodegroup_name,
             scalingConfig={
-                "minSize": challenge.min_worker_instance,
-                "maxSize": challenge.max_worker_instance,
-                "desiredSize": challenge.desired_worker_instance,
+                "minSize": min_size,
+                "maxSize": max_size,
+                "desiredSize": desired_size,
             },
         )
     except (ClientError, BotoCoreError) as e:

--- a/apps/challenges/models.py
+++ b/apps/challenges/models.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from base.models import TimeStampedModel, model_field_name
 from base.utils import RandomFileName, get_slug, is_model_field_changed
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.postgres.fields import ArrayField, JSONField
 from django.core import serializers
@@ -38,6 +39,11 @@ class Challenge(TimeStampedModel):
         self._original_approved_by_admin = self.approved_by_admin
         self._original_sqs_retention_period = self.sqs_retention_period
         self._original_end_date = self.end_date
+        for field in (
+            settings.EKS_NODEGROUP_IMMUTABLE_FIELDS
+            + settings.EKS_NODEGROUP_SCALING_FIELDS
+        ):
+            setattr(self, "_original_{}".format(field), getattr(self, field))
 
     title = models.CharField(
         max_length=100,
@@ -840,6 +846,24 @@ def create_eks_cluster_or_ec2_for_challenge(
             serialized_obj = serializers.serialize("json", [instance])
             aws.setup_ec2.delay(serialized_obj)
     aws.challenge_approval_callback(sender, instance, field_name, **kwargs)
+
+
+@receiver(signals.post_save, sender="challenges.Challenge")
+def sync_eks_nodegroup_config_for_challenge(
+    sender, instance, created, **kwargs
+):
+    """
+    Keep a challenge's EKS nodegroup in sync with its worker configuration.
+
+    instanceTypes, amiType and diskSize are fixed at nodegroup creation, so
+    without this hook editing them changes only the database while AWS keeps
+    running the old hardware.
+    """
+    import challenges.aws_utils as aws
+
+    if created:
+        return
+    aws.eks_nodegroup_config_change_callback(instance)
 
 
 @receiver(signals.post_save, sender="challenges.Challenge")

--- a/docs/superpowers/specs/2026-08-10-eks-nodegroup-config-sync-design.md
+++ b/docs/superpowers/specs/2026-08-10-eks-nodegroup-config-sync-design.md
@@ -1,0 +1,161 @@
+# EKS nodegroup config sync
+
+Date: 2026-08-10
+
+## Problem
+
+A challenge's `worker_instance_type`, `worker_ami_type` and `worker_disk_size`
+reach AWS exactly once, in `create_eks_nodegroup`, and that task runs on a
+snapshot of the challenge serialized at the moment `approved_by_admin` flipped
+to `True`. The serialized blob is threaded unchanged through
+`setup_eks_cluster` → `create_eks_cluster_subnets` → `create_eks_cluster` →
+`create_eks_nodegroup`; no task re-reads the database.
+
+Two consequences:
+
+1. Editing any of those three fields after approval changes only the database.
+   AWS keeps running the old hardware, with nothing to surface the mismatch.
+2. Even before the nodegroup exists, an edit made after approval is ignored,
+   because the snapshot was taken at approval time.
+
+AWS offers no in-place fix: `UpdateNodegroupConfig` accepts only scaling
+config, labels, taints and update config. `instanceTypes`, `amiType` and
+`diskSize` are fixed for the life of a managed nodegroup. The console's Edit
+button does not expose them either. The only way to change them is to delete
+the nodegroup and create a new one.
+
+Observed case: challenge 2319 runs `g5.4xlarge` nodes. Neither the Django admin
+nor the AWS console can change that.
+
+## Goals
+
+- Editing a worker configuration field on a Challenge makes AWS match, with no
+  shell access and no manual AWS work.
+- A misconfiguration cannot leave a challenge without worker capacity.
+- An operator can retry a failed sync without having to fake a field change.
+
+## Non-goals
+
+- Changing how the initial cluster and nodegroup are created.
+- Draining or rescheduling submissions before replacing a nodegroup.
+- Reconciling drift that predates this change; existing nodegroups are only
+  touched when someone edits a field or runs the admin action.
+
+## Design
+
+### Field groups
+
+Two tuples in `settings/common.py` name the fields that matter:
+
+- `EKS_NODEGROUP_IMMUTABLE_FIELDS` — `worker_instance_type`,
+  `worker_ami_type`, `worker_disk_size`. Changing one requires a recreate.
+- `EKS_NODEGROUP_SCALING_FIELDS` — `min_worker_instance`,
+  `max_worker_instance`, `desired_worker_instance`. These map to
+  `scalingConfig`, which `UpdateNodegroupConfig` can change in place.
+
+`Challenge.__init__` snapshots all six as `_original_<field>`, extending the
+pattern already used for `approved_by_admin` and `sqs_retention_period`.
+
+### Trigger
+
+A `post_save` receiver, `sync_eks_nodegroup_config_for_challenge`, delegates to
+`eks_nodegroup_config_change_callback` in `aws_utils`. The callback:
+
+1. Returns early when `settings.DEBUG or settings.TEST`. The hook fires on
+   every Challenge save, so without this the test suite would dispatch Celery
+   tasks at a broker that is not running.
+2. Returns early for challenges that are not code-upload
+   (`is_docker_based` false, or `remote_evaluation` true).
+3. Diffs the two field groups with `is_model_field_changed`.
+4. Refreshes every `_original_` snapshot, so a second save of the same value is
+   not a second recreate.
+5. Dispatches `recreate_eks_nodegroup` when an immutable field changed,
+   otherwise `update_eks_nodegroup_scaling` when only scaling changed.
+
+When both groups changed, only the recreate is dispatched: `create_nodegroup`
+already sends the new `scalingConfig`, so an update as well would be a
+redundant AWS call.
+
+### Validation gate
+
+`validate_eks_nodegroup_config` runs before anything is deleted and returns a
+list of human-readable problems:
+
+- `worker_instance_type` is set, and offered in the challenge's region
+  (`describe_instance_type_offerings`).
+- `worker_ami_type` is one of `EKS_SUPPORTED_AMI_TYPES`.
+- The AMI type ships NVIDIA drivers (`EKS_GPU_AMI_TYPES`) unless
+  `cpu_only_jobs` is set. A GPU challenge on a standard AMI schedules pods that
+  can never see a GPU.
+- AL2 AMI types are rejected on Kubernetes >= `EKS_AL2_REMOVED_IN_VERSION`
+  (1.33), where they no longer exist. The cluster version comes from
+  `describe_cluster`.
+- `worker_disk_size` is a positive integer.
+
+A non-empty result aborts the recreate with a logged error and leaves the
+existing nodegroup untouched.
+
+### Recreate
+
+`recreate_eks_nodegroup(challenge_pk)` takes a primary key rather than a
+serialized challenge, so it always reads current database state. This is the
+same staleness that caused the original problem.
+
+1. Resolve challenge, cluster name and nodegroup name via
+   `_get_challenge_nodegroup`. No `ChallengeEvaluationCluster` means no-op.
+2. Validate; abort on any error.
+3. Log a warning that submissions on the nodegroup's nodes will be terminated.
+4. `delete_nodegroup`, then wait on `nodegroup_deleted`.
+   `ResourceNotFoundException` falls through to create; any other error aborts
+   before create, since creating over a half-deleted nodegroup would fail.
+5. `create_nodegroup_for_challenge`, extracted from `create_eks_nodegroup` so
+   both paths always send the same argument set.
+6. On create failure, log that the challenge now has no worker capacity.
+
+The nodegroup name is derived from title, pk and environment by
+`get_nodegroup_name_for_challenge`, so a recreate reuses the same name and
+`ChallengeEvaluationCluster.nodegroup_name` — which the autoscale Lambda
+targets — stays valid.
+
+The recreate path does not send
+`construct_and_send_eks_cluster_creation_mail`; that stays on initial creation
+only, so hosts do not get a second "cluster created" email per edit.
+
+### Scaling update
+
+`update_eks_nodegroup_scaling(challenge_pk)` calls `update_nodegroup_config`
+with the challenge's three scaling values. The autoscale Lambda rewrites
+`minSize` and `desiredSize` from the pending submission count on its next run.
+`maxSize` is the durable one: the Lambda caps scale-up at the challenge's
+`max_worker_instance`, read through the autoscale meta endpoint.
+
+### Admin action
+
+`recreate_selected_eks_nodegroups` on `ChallengeAdmin` enqueues
+`recreate_eks_nodegroup` for each selected code-upload challenge and reports
+how many were queued and skipped. This is the retry path when a validation
+failure has left the database and AWS out of step — re-saving the same value is
+a no-op, because the snapshot was already refreshed.
+
+## Accepted risk
+
+Recreation is immediate and unconditional. Deleting a nodegroup terminates any
+node currently running a submission, and nothing checks the node count first.
+An admin editing `worker_instance_type` on a busy challenge will kill its
+running evaluations. This was chosen deliberately over an idle-only or
+deferred-until-idle policy; the mitigation is a warning log before the delete
+and the narrow trigger conditions.
+
+## Testing
+
+`tests/unit/challenges/test_aws_utils.py` adds 24 tests:
+
+- `TestValidateEKSNodegroupConfig` — each rejection reason, plus the AL2 and
+  CPU-only cases that must still pass.
+- `TestRecreateEKSNodegroup` — delete-then-create ordering, abort before delete
+  on invalid config, missing nodegroup still creates, delete error aborts
+  before create, failed create reports lost capacity, missing cluster no-op.
+- `TestUpdateEKSNodegroupScaling` — scaling config sent, client error reported.
+- `TestEKSNodegroupConfigChangeCallback` — no dispatch when nothing changed,
+  recreate on immutable change, scale on scaling change, recreate wins when
+  both change, non-code-upload ignored, DEBUG and TEST guards.

--- a/docs/superpowers/specs/2026-08-10-eks-nodegroup-config-sync-design.md
+++ b/docs/superpowers/specs/2026-08-10-eks-nodegroup-config-sync-design.md
@@ -91,6 +91,11 @@ list of human-readable problems:
   (1.33), where they no longer exist. The cluster version comes from
   `describe_cluster`.
 - `worker_disk_size` is a positive integer.
+- The scaling bounds are usable: all three fields are non-negative integers
+  (they are nullable on the model), `max_worker_instance` is at least 1, and
+  `min <= desired <= max`. Nothing stops an admin saving a minimum above the
+  maximum, and `CreateNodegroup` only rejects that after the live nodegroup has
+  already been deleted.
 
 A non-empty result aborts the recreate with a logged error and leaves the
 existing nodegroup untouched.
@@ -104,12 +109,14 @@ the staleness that caused the original problem.
 1. Resolve the challenge and cluster via `_get_challenge_cluster`. No
    `ChallengeEvaluationCluster` means no-op.
 2. Resolve the nodegroup name via `_resolve_nodegroup_name`: the recorded
-   `nodegroup_name` when set, otherwise the cluster's single nodegroup from
-   `list_nodegroups`. The name is never re-derived from the challenge, because
-   it embeds the title as it was at creation time — a renamed challenge would
-   derive a name matching nothing, delete nothing, and then create a second
-   nodegroup alongside the live one. Zero nodegroups or more than one is a
-   no-op.
+   `nodegroup_name` when it is set *and* still exists in AWS, otherwise the
+   cluster's single nodegroup from `list_nodegroups`. A recorded name that no
+   longer resolves is re-resolved rather than trusted, since a nodegroup
+   replaced by hand would otherwise break every sync until the row was edited
+   manually. The name is never re-derived from the challenge, because it embeds
+   the title as it was at creation time — a renamed challenge would derive a
+   name matching nothing, delete nothing, and then create a second nodegroup
+   alongside the live one. Zero nodegroups or more than one is a no-op.
 3. Require the nodegroup to be `ACTIVE`. Any other status means someone else is
    working on it, most likely the initial `setup_eks_cluster` chain still in
    flight; deleting it there would make `create_eks_nodegroup` fail on a

--- a/docs/superpowers/specs/2026-08-10-eks-nodegroup-config-sync-design.md
+++ b/docs/superpowers/specs/2026-08-10-eks-nodegroup-config-sync-design.md
@@ -141,6 +141,19 @@ building the nodegroup, falling back to the serialized snapshot if the row has
 since been deleted. Cluster setup takes many minutes, which is ample time for an
 edit to land in that window.
 
+That re-read alone is not enough. An edit can still land after the read and
+before `CreateNodegroup` is sent, and more importantly anywhere in the several
+minutes a new nodegroup spends `CREATING`. In both cases the callback dispatches
+a sync, the sync finds a nodegroup that is not `ACTIVE`, and the snapshots have
+already been refreshed — so simply returning would lose the edit permanently,
+with no second dispatch to recover it.
+
+Both sync tasks therefore retry rather than abandon: a non-`ACTIVE` nodegroup
+schedules another attempt `EKS_NODEGROUP_SYNC_RETRY_SECONDS` later, up to
+`EKS_NODEGROUP_SYNC_MAX_RETRIES`. Each attempt re-reads the challenge, so the
+newest configuration is the one that lands. Exhausting the retries logs an error
+naming the admin action as the manual recovery path.
+
 A recreate reuses the resolved name, so
 `ChallengeEvaluationCluster.nodegroup_name` — which the autoscale Lambda
 targets — stays valid.

--- a/docs/superpowers/specs/2026-08-10-eks-nodegroup-config-sync-design.md
+++ b/docs/superpowers/specs/2026-08-10-eks-nodegroup-config-sync-design.md
@@ -98,22 +98,32 @@ existing nodegroup untouched.
 ### Recreate
 
 `recreate_eks_nodegroup(challenge_pk)` takes a primary key rather than a
-serialized challenge, so it always reads current database state. This is the
-same staleness that caused the original problem.
+serialized challenge, so it always reads current database state. This avoids
+the staleness that caused the original problem.
 
-1. Resolve challenge, cluster name and nodegroup name via
-   `_get_challenge_nodegroup`. No `ChallengeEvaluationCluster` means no-op.
-2. Validate; abort on any error.
-3. Log a warning that submissions on the nodegroup's nodes will be terminated.
-4. `delete_nodegroup`, then wait on `nodegroup_deleted`.
+1. Resolve the challenge and cluster via `_get_challenge_cluster`. No
+   `ChallengeEvaluationCluster` means no-op.
+2. Resolve the nodegroup name via `_resolve_nodegroup_name`: the recorded
+   `nodegroup_name` when set, otherwise the cluster's single nodegroup from
+   `list_nodegroups`. The name is never re-derived from the challenge, because
+   it embeds the title as it was at creation time — a renamed challenge would
+   derive a name matching nothing, delete nothing, and then create a second
+   nodegroup alongside the live one. Zero nodegroups or more than one is a
+   no-op.
+3. Require the nodegroup to be `ACTIVE`. Any other status means someone else is
+   working on it, most likely the initial `setup_eks_cluster` chain still in
+   flight; deleting it there would make `create_eks_nodegroup` fail on a
+   duplicate name and skip starting the code-upload worker.
+4. Validate; abort on any error.
+5. Log a warning that submissions on the nodegroup's nodes will be terminated.
+6. `delete_nodegroup`, then wait on `nodegroup_deleted`.
    `ResourceNotFoundException` falls through to create; any other error aborts
    before create, since creating over a half-deleted nodegroup would fail.
-5. `create_nodegroup_for_challenge`, extracted from `create_eks_nodegroup` so
+7. `create_nodegroup_for_challenge`, extracted from `create_eks_nodegroup` so
    both paths always send the same argument set.
-6. On create failure, log that the challenge now has no worker capacity.
+8. On create failure, log that the challenge now has no worker capacity.
 
-The nodegroup name is derived from title, pk and environment by
-`get_nodegroup_name_for_challenge`, so a recreate reuses the same name and
+A recreate reuses the resolved name, so
 `ChallengeEvaluationCluster.nodegroup_name` — which the autoscale Lambda
 targets — stays valid.
 
@@ -123,11 +133,16 @@ only, so hosts do not get a second "cluster created" email per edit.
 
 ### Scaling update
 
-`update_eks_nodegroup_scaling(challenge_pk)` calls `update_nodegroup_config`
-with the challenge's three scaling values. The autoscale Lambda rewrites
-`minSize` and `desiredSize` from the pending submission count on its next run.
-`maxSize` is the durable one: the Lambda caps scale-up at the challenge's
-`max_worker_instance`, read through the autoscale meta endpoint.
+`update_eks_nodegroup_scaling(challenge_pk)` pushes only the bounds. It reads
+the live `scalingConfig` first and preserves the current `desiredSize`, clamped
+into the new `[minSize, maxSize]` so AWS does not reject the update.
+
+The autoscale Lambda owns `desiredSize` and will have raised it for pending
+submissions. Sending the challenge's stored `desired_worker_instance` instead
+would shrink a busy nodegroup and kill running submissions the moment an
+unrelated scaling field was edited. `maxSize` is the durable field: the Lambda
+caps scale-up at the challenge's `max_worker_instance`, read through the
+autoscale meta endpoint.
 
 ### Admin action
 

--- a/docs/superpowers/specs/2026-08-10-eks-nodegroup-config-sync-design.md
+++ b/docs/superpowers/specs/2026-08-10-eks-nodegroup-config-sync-design.md
@@ -123,6 +123,24 @@ the staleness that caused the original problem.
    both paths always send the same argument set.
 8. On create failure, log that the challenge now has no worker capacity.
 
+`create_nodegroup_for_challenge` returns `None` only when the nodegroup was not
+created. A `create_nodegroup` that succeeds but whose `nodegroup_active` waiter
+times out still returns the response: the nodegroup exists, and reporting it as
+missing would both produce a false "no worker capacity" log and invite the next
+recreate to delete a nodegroup that was merely still `CREATING`.
+
+### Edits during initial cluster setup
+
+The post_save hook cannot recreate a nodegroup that does not exist yet, so an
+edit landing while `setup_eks_cluster` is still running would otherwise be
+consumed by the snapshot refresh and lost — the chain would go on to create the
+nodegroup from the approval-time snapshot, leaving AWS permanently out of sync.
+
+`create_eks_nodegroup` therefore re-reads the challenge from the database before
+building the nodegroup, falling back to the serialized snapshot if the row has
+since been deleted. Cluster setup takes many minutes, which is ample time for an
+edit to land in that window.
+
 A recreate reuses the resolved name, so
 `ChallengeEvaluationCluster.nodegroup_name` — which the autoscale Lambda
 targets — stays valid.

--- a/settings/common.py
+++ b/settings/common.py
@@ -553,7 +553,10 @@ EKS_NODEGROUP_SCALING_FIELDS = (
     "desired_worker_instance",
 )
 
-# amiType values accepted by the EKS CreateNodegroup API.
+# amiType values accepted by the EKS CreateNodegroup API. CUSTOM is
+# deliberately excluded: it requires a launch template, which
+# create_nodegroup_for_challenge does not use, so it would fail at create time
+# after the old nodegroup had already been deleted.
 EKS_SUPPORTED_AMI_TYPES = (
     "AL2_x86_64",
     "AL2_x86_64_GPU",
@@ -565,12 +568,18 @@ EKS_SUPPORTED_AMI_TYPES = (
     "AL2023_ARM_64_NVIDIA",
     "BOTTLEROCKET_ARM_64",
     "BOTTLEROCKET_x86_64",
+    "BOTTLEROCKET_ARM_64_FIPS",
+    "BOTTLEROCKET_x86_64_FIPS",
     "BOTTLEROCKET_ARM_64_NVIDIA",
     "BOTTLEROCKET_x86_64_NVIDIA",
+    "BOTTLEROCKET_ARM_64_NVIDIA_FIPS",
+    "BOTTLEROCKET_x86_64_NVIDIA_FIPS",
     "WINDOWS_CORE_2019_x86_64",
     "WINDOWS_FULL_2019_x86_64",
     "WINDOWS_CORE_2022_x86_64",
     "WINDOWS_FULL_2022_x86_64",
+    "WINDOWS_CORE_2025_x86_64",
+    "WINDOWS_FULL_2025_x86_64",
 )
 
 # Subset of the above that ships NVIDIA drivers. A GPU challenge on any other
@@ -581,6 +590,8 @@ EKS_GPU_AMI_TYPES = (
     "AL2023_ARM_64_NVIDIA",
     "BOTTLEROCKET_ARM_64_NVIDIA",
     "BOTTLEROCKET_x86_64_NVIDIA",
+    "BOTTLEROCKET_ARM_64_NVIDIA_FIPS",
+    "BOTTLEROCKET_x86_64_NVIDIA_FIPS",
 )
 
 # First Kubernetes version that no longer offers Amazon Linux 2 AMIs.

--- a/settings/common.py
+++ b/settings/common.py
@@ -597,5 +597,14 @@ EKS_GPU_AMI_TYPES = (
 # First Kubernetes version that no longer offers Amazon Linux 2 AMIs.
 EKS_AL2_REMOVED_IN_VERSION = "1.33"
 
+# A nodegroup sync can only run against an ACTIVE nodegroup, and a worker
+# config edit made while one is still being created would otherwise be lost:
+# the post_save hook refreshes its snapshots on dispatch, so saving the same
+# value again does nothing. The sync tasks retry instead. The defaults cover a
+# nodegroup creation comfortably, which usually settles within a few minutes.
+EKS_NODEGROUP_SYNC_RETRY_SECONDS = 60
+
+EKS_NODEGROUP_SYNC_MAX_RETRIES = 20
+
 # SQS Queue Message Retention Period
 SQS_RETENTION_PERIOD = "345600"

--- a/settings/common.py
+++ b/settings/common.py
@@ -536,5 +536,55 @@ EKS_AUTOSCALE_CROSS_ACCOUNT_POLICY_DOCUMENT = {
     ],
 }
 
+# Challenge fields that map to create_nodegroup arguments AWS cannot change on
+# an existing managed nodegroup. Editing one of these requires deleting and
+# recreating the nodegroup for the change to reach AWS.
+EKS_NODEGROUP_IMMUTABLE_FIELDS = (
+    "worker_instance_type",
+    "worker_ami_type",
+    "worker_disk_size",
+)
+
+# Challenge fields that map to the nodegroup's scalingConfig, which
+# UpdateNodegroupConfig can change in place.
+EKS_NODEGROUP_SCALING_FIELDS = (
+    "min_worker_instance",
+    "max_worker_instance",
+    "desired_worker_instance",
+)
+
+# amiType values accepted by the EKS CreateNodegroup API.
+EKS_SUPPORTED_AMI_TYPES = (
+    "AL2_x86_64",
+    "AL2_x86_64_GPU",
+    "AL2_ARM_64",
+    "AL2023_x86_64_STANDARD",
+    "AL2023_ARM_64_STANDARD",
+    "AL2023_x86_64_NEURON",
+    "AL2023_x86_64_NVIDIA",
+    "AL2023_ARM_64_NVIDIA",
+    "BOTTLEROCKET_ARM_64",
+    "BOTTLEROCKET_x86_64",
+    "BOTTLEROCKET_ARM_64_NVIDIA",
+    "BOTTLEROCKET_x86_64_NVIDIA",
+    "WINDOWS_CORE_2019_x86_64",
+    "WINDOWS_FULL_2019_x86_64",
+    "WINDOWS_CORE_2022_x86_64",
+    "WINDOWS_FULL_2022_x86_64",
+)
+
+# Subset of the above that ships NVIDIA drivers. A GPU challenge on any other
+# AMI type schedules pods that can never see a GPU.
+EKS_GPU_AMI_TYPES = (
+    "AL2_x86_64_GPU",
+    "AL2023_x86_64_NVIDIA",
+    "AL2023_ARM_64_NVIDIA",
+    "BOTTLEROCKET_ARM_64_NVIDIA",
+    "BOTTLEROCKET_x86_64_NVIDIA",
+)
+
+# First Kubernetes version that no longer offers Amazon Linux 2 AMIs.
+EKS_AL2_REMOVED_IN_VERSION = "1.33"
+
 # SQS Queue Message Retention Period
 SQS_RETENTION_PERIOD = "345600"

--- a/tests/unit/challenges/test_admin.py
+++ b/tests/unit/challenges/test_admin.py
@@ -1,9 +1,11 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from challenges.admin import ChallengeAdmin
 from challenges.models import Challenge
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
+from django.contrib.messages import constants as message_constants
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test import RequestFactory, TestCase
 from hosts.models import ChallengeHostTeam
@@ -237,13 +239,25 @@ class TestChallengeAdminActions(TestCase):
         messages = list(self.request._messages)
         assert any("successfully unfrozen" in str(m) for m in messages)
 
+    # A plain MagicMock would invent any attribute asked of it, so a renamed
+    # field on Challenge would keep these tests green while the action silently
+    # stopped filtering. Only the fields the action reads are provided.
     @staticmethod
-    def _code_upload_challenge(pk):
-        challenge = MagicMock()
-        challenge.pk = pk
-        challenge.is_docker_based = True
-        challenge.remote_evaluation = False
-        return challenge
+    def _code_upload_challenge(pk, is_docker_based=True, remote=False):
+        return SimpleNamespace(
+            pk=pk,
+            is_docker_based=is_docker_based,
+            remote_evaluation=remote,
+        )
+
+    def _sent_messages(self):
+        return [(m.level, str(m)) for m in list(self.request._messages)]
+
+    QUEUED_2 = (
+        "Queued nodegroup recreation for 2 challenge(s). Nodes running "
+        "submissions will be terminated. Check the worker logs for the "
+        "outcome."
+    )
 
     @patch("challenges.admin.recreate_eks_nodegroup")
     def test_recreate_selected_eks_nodegroups_queues_each_challenge(
@@ -257,44 +271,61 @@ class TestChallengeAdminActions(TestCase):
         self.assertEqual(mock_recreate.delay.call_count, 2)
         mock_recreate.delay.assert_any_call(1)
         mock_recreate.delay.assert_any_call(2)
-        messages = list(self.request._messages)
-        assert any(
-            "Queued nodegroup recreation for 2" in str(m) for m in messages
+        # Exact text, so a wrong count cannot pass as a substring, and the
+        # destructive warning has to reach the operator.
+        self.assertEqual(
+            self._sent_messages(),
+            [(message_constants.SUCCESS, self.QUEUED_2)],
         )
-        # The action destroys running work, so the warning must be surfaced.
-        assert any("will be terminated" in str(m) for m in messages)
 
     @patch("challenges.admin.recreate_eks_nodegroup")
     def test_recreate_selected_eks_nodegroups_skips_non_code_upload(
         self, mock_recreate
     ):
-        remote = self._code_upload_challenge(2)
-        remote.remote_evaluation = True
-        non_docker = self._code_upload_challenge(3)
-        non_docker.is_docker_based = False
-
         self.admin.recreate_selected_eks_nodegroups(
             self.request,
-            [self._code_upload_challenge(1), remote, non_docker],
+            [
+                self._code_upload_challenge(1),
+                self._code_upload_challenge(2, remote=True),
+                self._code_upload_challenge(3, is_docker_based=False),
+            ],
         )
 
         mock_recreate.delay.assert_called_once_with(1)
-        messages = list(self.request._messages)
-        assert any("2 challenge(s) skipped" in str(m) for m in messages)
+        self.assertEqual(
+            self._sent_messages(),
+            [
+                (
+                    message_constants.SUCCESS,
+                    "Queued nodegroup recreation for 1 challenge(s). Nodes "
+                    "running submissions will be terminated. Check the worker "
+                    "logs for the outcome.",
+                ),
+                (
+                    message_constants.WARNING,
+                    "2 challenge(s) skipped: not code-upload challenges.",
+                ),
+            ],
+        )
 
     @patch("challenges.admin.recreate_eks_nodegroup")
     def test_recreate_selected_eks_nodegroups_all_skipped(self, mock_recreate):
-        non_docker = self._code_upload_challenge(1)
-        non_docker.is_docker_based = False
-
-        self.admin.recreate_selected_eks_nodegroups(self.request, [non_docker])
+        self.admin.recreate_selected_eks_nodegroups(
+            self.request,
+            [self._code_upload_challenge(1, is_docker_based=False)],
+        )
 
         mock_recreate.delay.assert_not_called()
-        messages = list(self.request._messages)
-        assert not any(
-            "Queued nodegroup recreation" in str(m) for m in messages
+        # No success message at all, rather than one reporting zero.
+        self.assertEqual(
+            self._sent_messages(),
+            [
+                (
+                    message_constants.WARNING,
+                    "1 challenge(s) skipped: not code-upload challenges.",
+                )
+            ],
         )
-        assert any("1 challenge(s) skipped" in str(m) for m in messages)
 
 
 class TestChallengeAdminListDisplay(TestCase):

--- a/tests/unit/challenges/test_admin.py
+++ b/tests/unit/challenges/test_admin.py
@@ -237,6 +237,65 @@ class TestChallengeAdminActions(TestCase):
         messages = list(self.request._messages)
         assert any("successfully unfrozen" in str(m) for m in messages)
 
+    @staticmethod
+    def _code_upload_challenge(pk):
+        challenge = MagicMock()
+        challenge.pk = pk
+        challenge.is_docker_based = True
+        challenge.remote_evaluation = False
+        return challenge
+
+    @patch("challenges.admin.recreate_eks_nodegroup")
+    def test_recreate_selected_eks_nodegroups_queues_each_challenge(
+        self, mock_recreate
+    ):
+        self.admin.recreate_selected_eks_nodegroups(
+            self.request,
+            [self._code_upload_challenge(1), self._code_upload_challenge(2)],
+        )
+
+        self.assertEqual(mock_recreate.delay.call_count, 2)
+        mock_recreate.delay.assert_any_call(1)
+        mock_recreate.delay.assert_any_call(2)
+        messages = list(self.request._messages)
+        assert any(
+            "Queued nodegroup recreation for 2" in str(m) for m in messages
+        )
+        # The action destroys running work, so the warning must be surfaced.
+        assert any("will be terminated" in str(m) for m in messages)
+
+    @patch("challenges.admin.recreate_eks_nodegroup")
+    def test_recreate_selected_eks_nodegroups_skips_non_code_upload(
+        self, mock_recreate
+    ):
+        remote = self._code_upload_challenge(2)
+        remote.remote_evaluation = True
+        non_docker = self._code_upload_challenge(3)
+        non_docker.is_docker_based = False
+
+        self.admin.recreate_selected_eks_nodegroups(
+            self.request,
+            [self._code_upload_challenge(1), remote, non_docker],
+        )
+
+        mock_recreate.delay.assert_called_once_with(1)
+        messages = list(self.request._messages)
+        assert any("2 challenge(s) skipped" in str(m) for m in messages)
+
+    @patch("challenges.admin.recreate_eks_nodegroup")
+    def test_recreate_selected_eks_nodegroups_all_skipped(self, mock_recreate):
+        non_docker = self._code_upload_challenge(1)
+        non_docker.is_docker_based = False
+
+        self.admin.recreate_selected_eks_nodegroups(self.request, [non_docker])
+
+        mock_recreate.delay.assert_not_called()
+        messages = list(self.request._messages)
+        assert not any(
+            "Queued nodegroup recreation" in str(m) for m in messages
+        )
+        assert any("1 challenge(s) skipped" in str(m) for m in messages)
+
 
 class TestChallengeAdminListDisplay(TestCase):
     """Tests for ChallengeAdmin list_display configuration."""

--- a/tests/unit/challenges/test_aws_utils.py
+++ b/tests/unit/challenges/test_aws_utils.py
@@ -81,6 +81,7 @@ from challenges.worker_utils import (
     ensure_challenge_worker_python_version,
     normalize_worker_python_version,
 )
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import serializers
 from django.db import DatabaseError
@@ -8519,7 +8520,13 @@ class TestRecreateEKSNodegroup(unittest.TestCase):
             }
             result = recreate_eks_nodegroup(1)
 
-        mock_retry.assert_called_once()
+        mock_retry.assert_called_once_with(
+            countdown=settings.EKS_NODEGROUP_SYNC_RETRY_SECONDS
+        )
+        self.assertEqual(
+            recreate_eks_nodegroup.max_retries,
+            settings.EKS_NODEGROUP_SYNC_MAX_RETRIES,
+        )
         self.client.delete_nodegroup.assert_not_called()
         mock_create.assert_not_called()
         self.assertIn("error", result)
@@ -8543,7 +8550,7 @@ class TestRecreateEKSNodegroup(unittest.TestCase):
             recreate_eks_nodegroup,
             "retry",
             side_effect=MaxRetriesExceededError,
-        ):
+        ), patch("challenges.aws_utils.logger") as mock_logger:
             self.client.describe_nodegroup.return_value = {
                 "nodegroup": {"status": "CREATING"}
             }
@@ -8552,6 +8559,10 @@ class TestRecreateEKSNodegroup(unittest.TestCase):
         self.client.delete_nodegroup.assert_not_called()
         mock_create.assert_not_called()
         self.assertIn("error", result)
+        # The edit is lost at this point, so the log must say how to recover.
+        self.assertIn(
+            "Recreate EKS nodegroup", mock_logger.error.call_args.args[0]
+        )
 
     @patch("challenges.aws_utils.create_nodegroup_for_challenge")
     @patch("challenges.aws_utils.get_boto3_client")
@@ -8853,7 +8864,13 @@ class TestUpdateEKSNodegroupScaling(unittest.TestCase):
         ) as mock_retry:
             result = update_eks_nodegroup_scaling(1)
 
-        mock_retry.assert_called_once()
+        mock_retry.assert_called_once_with(
+            countdown=settings.EKS_NODEGROUP_SYNC_RETRY_SECONDS
+        )
+        self.assertEqual(
+            update_eks_nodegroup_scaling.max_retries,
+            settings.EKS_NODEGROUP_SYNC_MAX_RETRIES,
+        )
         self.client.update_nodegroup_config.assert_not_called()
         self.assertIn("error", result)
 
@@ -8874,11 +8891,14 @@ class TestUpdateEKSNodegroupScaling(unittest.TestCase):
             update_eks_nodegroup_scaling,
             "retry",
             side_effect=MaxRetriesExceededError,
-        ):
+        ), patch("challenges.aws_utils.logger") as mock_logger:
             result = update_eks_nodegroup_scaling(1)
 
         self.client.update_nodegroup_config.assert_not_called()
         self.assertIn("error", result)
+        self.assertIn(
+            "Recreate EKS nodegroup", mock_logger.error.call_args.args[0]
+        )
 
     @patch("challenges.aws_utils.get_boto3_client")
     @patch("challenges.utils.get_aws_credentials_for_challenge")

--- a/tests/unit/challenges/test_aws_utils.py
+++ b/tests/unit/challenges/test_aws_utils.py
@@ -3801,6 +3801,17 @@ class TestGetLogsFromCloudwatch(TestCase):
 
 
 class TestCreateEKSNodegroup(unittest.TestCase):
+    def setUp(self):
+        # create_eks_nodegroup re-reads the challenge so a config edit made
+        # while cluster setup is still running is not lost. These tests supply
+        # the challenge through the serialized snapshot, so make that lookup
+        # miss and fall back to it.
+        patcher = patch("challenges.models.Challenge")
+        mock_model = patcher.start()
+        mock_model.DoesNotExist = Challenge.DoesNotExist
+        mock_model.objects.get.side_effect = Challenge.DoesNotExist
+        self.addCleanup(patcher.stop)
+
     @patch("challenges.models.ChallengeEvaluationCluster")
     @patch("challenges.aws_utils.get_boto3_client")
     @patch("challenges.aws_utils.get_code_upload_setup_meta_for_challenge")
@@ -8571,12 +8582,16 @@ class TestRecreateEKSNodegroup(unittest.TestCase):
 class TestCreateNodegroupForChallenge(unittest.TestCase):
     @patch("challenges.models.ChallengeEvaluationCluster")
     @patch("challenges.aws_utils.get_code_upload_setup_meta_for_challenge")
-    def test_active_waiter_failure_returns_none(
+    def test_active_waiter_failure_still_reports_the_nodegroup(
         self, mock_meta, mock_evaluation_cluster
     ):
         """
-        WaiterError escaping here would skip the caller's failure handling and,
-        in create_eks_nodegroup, silently stop the code-upload worker start.
+        The nodegroup exists once create_nodegroup succeeds. Returning None on
+        a waiter timeout would make callers report it as missing, and the next
+        recreate would delete a nodegroup that was merely still CREATING.
+
+        WaiterError must also not escape, or the caller's error handling and
+        the code-upload worker start in create_eks_nodegroup are both skipped.
         """
         mock_meta.return_value = {
             "SUBNET_1": "subnet-123",
@@ -8586,6 +8601,7 @@ class TestCreateNodegroupForChallenge(unittest.TestCase):
         challenge = MagicMock()
         challenge.pk = 1
         client = MagicMock()
+        client.create_nodegroup.return_value = {"nodegroup": "created"}
         client.get_waiter.return_value.wait.side_effect = WaiterError(
             name="nodegroup_active",
             reason="max attempts exceeded",
@@ -8596,7 +8612,109 @@ class TestCreateNodegroupForChallenge(unittest.TestCase):
             client, challenge, "test-cluster", "test-nodegroup"
         )
 
+        self.assertEqual(result, {"nodegroup": "created"})
+
+    @patch("challenges.models.ChallengeEvaluationCluster")
+    @patch("challenges.aws_utils.get_code_upload_setup_meta_for_challenge")
+    def test_create_failure_returns_none(
+        self, mock_meta, mock_evaluation_cluster
+    ):
+        mock_meta.return_value = {
+            "SUBNET_1": "subnet-123",
+            "SUBNET_2": "subnet-456",
+            "EKS_NODEGROUP_ROLE_ARN": "arn:aws:iam::123456789012:role/ng",
+        }
+        challenge = MagicMock()
+        challenge.pk = 1
+        client = MagicMock()
+        client.create_nodegroup.side_effect = ClientError(
+            {"Error": {"Code": "InvalidParameterException", "Message": "bad"}},
+            "CreateNodegroup",
+        )
+
+        result = create_nodegroup_for_challenge(
+            client, challenge, "test-cluster", "test-nodegroup"
+        )
+
         self.assertIsNone(result)
+
+
+class TestCreateEKSNodegroupReadsCurrentConfig(unittest.TestCase):
+    """
+    Cluster setup takes many minutes, and the chain carries a challenge
+    serialized at approval time. An edit landing in that window cannot be
+    applied by the post_save hook, because there is no nodegroup to recreate
+    yet, so the create must read the current row instead of the snapshot.
+    """
+
+    @patch("challenges.aws_utils.create_service_by_challenge_pk")
+    @patch("challenges.aws_utils.client_token_generator")
+    @patch("challenges.aws_utils.construct_and_send_eks_cluster_creation_mail")
+    @patch("challenges.aws_utils.create_nodegroup_for_challenge")
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    @patch("challenges.aws_utils.serializers.deserialize")
+    @patch("challenges.models.Challenge")
+    def test_uses_database_row_not_serialized_snapshot(
+        self,
+        mock_challenge_model,
+        mock_deserialize,
+        mock_credentials,
+        mock_get_boto3_client,
+        mock_create,
+        mock_mail,
+        mock_token,
+        mock_service,
+    ):
+        stale = MagicMock()
+        stale.pk = 1
+        stale.title = "Test Challenge"
+        stale.worker_instance_type = "g5.4xlarge"
+        mock_deserialize.return_value = [MagicMock(object=stale)]
+
+        current = MagicMock()
+        current.pk = 1
+        current.title = "Test Challenge"
+        current.worker_instance_type = "g5.xlarge"
+        mock_challenge_model.DoesNotExist = Challenge.DoesNotExist
+        mock_challenge_model.objects.get.return_value = current
+        mock_create.return_value = {"nodegroup": "created"}
+
+        create_eks_nodegroup("[]", "test-cluster")
+
+        mock_challenge_model.objects.get.assert_called_once_with(pk=1)
+        self.assertIs(mock_create.call_args.args[1], current)
+
+    @patch("challenges.aws_utils.create_service_by_challenge_pk")
+    @patch("challenges.aws_utils.client_token_generator")
+    @patch("challenges.aws_utils.construct_and_send_eks_cluster_creation_mail")
+    @patch("challenges.aws_utils.create_nodegroup_for_challenge")
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    @patch("challenges.aws_utils.serializers.deserialize")
+    @patch("challenges.models.Challenge")
+    def test_falls_back_to_snapshot_when_row_is_gone(
+        self,
+        mock_challenge_model,
+        mock_deserialize,
+        mock_credentials,
+        mock_get_boto3_client,
+        mock_create,
+        mock_mail,
+        mock_token,
+        mock_service,
+    ):
+        stale = MagicMock()
+        stale.pk = 1
+        stale.title = "Test Challenge"
+        mock_deserialize.return_value = [MagicMock(object=stale)]
+        mock_challenge_model.DoesNotExist = Challenge.DoesNotExist
+        mock_challenge_model.objects.get.side_effect = Challenge.DoesNotExist
+        mock_create.return_value = {"nodegroup": "created"}
+
+        create_eks_nodegroup("[]", "test-cluster")
+
+        self.assertIs(mock_create.call_args.args[1], stale)
 
 
 class TestUpdateEKSNodegroupScaling(unittest.TestCase):
@@ -8664,6 +8782,20 @@ class TestUpdateEKSNodegroupScaling(unittest.TestCase):
 
         sent = self.client.update_nodegroup_config.call_args.kwargs
         self.assertEqual(sent["scalingConfig"]["desiredSize"], 4)
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_live_desired_size_raised_to_new_minimum(
+        self, mock_credentials, mock_get_boto3_client
+    ):
+        mock_get_boto3_client.return_value = self.client
+        self.challenge.min_worker_instance = 3
+
+        with self._patch_lookup():
+            update_eks_nodegroup_scaling(1)
+
+        sent = self.client.update_nodegroup_config.call_args.kwargs
+        self.assertEqual(sent["scalingConfig"]["desiredSize"], 3)
 
     @patch("challenges.aws_utils.get_boto3_client")
     @patch("challenges.utils.get_aws_credentials_for_challenge")

--- a/tests/unit/challenges/test_aws_utils.py
+++ b/tests/unit/challenges/test_aws_utils.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 from botocore.exceptions import ClientError, NoCredentialsError, WaiterError
+from celery.exceptions import MaxRetriesExceededError
 from challenges.aws_utils import (
     _file_content_changed,
     _get_challenge_cluster,
@@ -8493,7 +8494,7 @@ class TestRecreateEKSNodegroup(unittest.TestCase):
     @patch("challenges.aws_utils.validate_eks_nodegroup_config")
     @patch("challenges.aws_utils.get_boto3_client")
     @patch("challenges.utils.get_aws_credentials_for_challenge")
-    def test_non_active_nodegroup_is_left_alone(
+    def test_non_active_nodegroup_is_retried_not_dropped(
         self,
         mock_credentials,
         mock_get_boto3_client,
@@ -8503,12 +8504,46 @@ class TestRecreateEKSNodegroup(unittest.TestCase):
         """
         A CREATING nodegroup means setup_eks_cluster is still in flight.
         Deleting it would make create_eks_nodegroup fail on a duplicate name
-        and never start the code-upload worker.
+        and never start the code-upload worker. Abandoning the task instead
+        would lose the edit for good, because the callback has already
+        refreshed its snapshots, so the task must retry.
         """
         mock_get_boto3_client.return_value = self.client
         mock_validate.return_value = []
 
-        with self._patch_lookup():
+        with self._patch_lookup(), patch.object(
+            recreate_eks_nodegroup, "retry"
+        ) as mock_retry:
+            self.client.describe_nodegroup.return_value = {
+                "nodegroup": {"status": "CREATING"}
+            }
+            result = recreate_eks_nodegroup(1)
+
+        mock_retry.assert_called_once()
+        self.client.delete_nodegroup.assert_not_called()
+        mock_create.assert_not_called()
+        self.assertIn("error", result)
+        self.assertIn("not ACTIVE", result["error"])
+
+    @patch("challenges.aws_utils.create_nodegroup_for_challenge")
+    @patch("challenges.aws_utils.validate_eks_nodegroup_config")
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_exhausted_retries_do_not_touch_the_nodegroup(
+        self,
+        mock_credentials,
+        mock_get_boto3_client,
+        mock_validate,
+        mock_create,
+    ):
+        mock_get_boto3_client.return_value = self.client
+        mock_validate.return_value = []
+
+        with self._patch_lookup(), patch.object(
+            recreate_eks_nodegroup,
+            "retry",
+            side_effect=MaxRetriesExceededError,
+        ):
             self.client.describe_nodegroup.return_value = {
                 "nodegroup": {"status": "CREATING"}
             }
@@ -8517,7 +8552,6 @@ class TestRecreateEKSNodegroup(unittest.TestCase):
         self.client.delete_nodegroup.assert_not_called()
         mock_create.assert_not_called()
         self.assertIn("error", result)
-        self.assertIn("not ACTIVE", result["error"])
 
     @patch("challenges.aws_utils.create_nodegroup_for_challenge")
     @patch("challenges.aws_utils.get_boto3_client")
@@ -8732,11 +8766,12 @@ class TestUpdateEKSNodegroupScaling(unittest.TestCase):
         self.client = MagicMock()
         self.client.describe_nodegroup.return_value = {
             "nodegroup": {
+                "status": "ACTIVE",
                 "scalingConfig": {
                     "minSize": 1,
                     "maxSize": 2,
                     "desiredSize": 2,
-                }
+                },
             }
         }
 
@@ -8774,7 +8809,10 @@ class TestUpdateEKSNodegroupScaling(unittest.TestCase):
     ):
         mock_get_boto3_client.return_value = self.client
         self.client.describe_nodegroup.return_value = {
-            "nodegroup": {"scalingConfig": {"desiredSize": 9}}
+            "nodegroup": {
+                "status": "ACTIVE",
+                "scalingConfig": {"desiredSize": 9},
+            }
         }
 
         with self._patch_lookup():
@@ -8796,6 +8834,51 @@ class TestUpdateEKSNodegroupScaling(unittest.TestCase):
 
         sent = self.client.update_nodegroup_config.call_args.kwargs
         self.assertEqual(sent["scalingConfig"]["desiredSize"], 3)
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_non_active_nodegroup_is_retried(
+        self, mock_credentials, mock_get_boto3_client
+    ):
+        mock_get_boto3_client.return_value = self.client
+        self.client.describe_nodegroup.return_value = {
+            "nodegroup": {
+                "status": "CREATING",
+                "scalingConfig": {"desiredSize": 1},
+            }
+        }
+
+        with self._patch_lookup(), patch.object(
+            update_eks_nodegroup_scaling, "retry"
+        ) as mock_retry:
+            result = update_eks_nodegroup_scaling(1)
+
+        mock_retry.assert_called_once()
+        self.client.update_nodegroup_config.assert_not_called()
+        self.assertIn("error", result)
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_exhausted_retries_skip_the_update(
+        self, mock_credentials, mock_get_boto3_client
+    ):
+        mock_get_boto3_client.return_value = self.client
+        self.client.describe_nodegroup.return_value = {
+            "nodegroup": {
+                "status": "CREATING",
+                "scalingConfig": {"desiredSize": 1},
+            }
+        }
+
+        with self._patch_lookup(), patch.object(
+            update_eks_nodegroup_scaling,
+            "retry",
+            side_effect=MaxRetriesExceededError,
+        ):
+            result = update_eks_nodegroup_scaling(1)
+
+        self.client.update_nodegroup_config.assert_not_called()
+        self.assertIn("error", result)
 
     @patch("challenges.aws_utils.get_boto3_client")
     @patch("challenges.utils.get_aws_credentials_for_challenge")

--- a/tests/unit/challenges/test_aws_utils.py
+++ b/tests/unit/challenges/test_aws_utils.py
@@ -25,6 +25,7 @@ from challenges.aws_utils import (
     delete_service_by_challenge_pk,
     delete_workers,
     describe_ec2_instance,
+    eks_nodegroup_config_change_callback,
     ensure_workers_for_submission,
     get_capacity_provider_strategy,
     get_code_upload_setup_meta_for_challenge,
@@ -39,6 +40,7 @@ from challenges.aws_utils import (
     get_worker_image_for_challenge,
     is_evalai_managed_submission_worker_image,
     load_aws_api_kwargs,
+    recreate_eks_nodegroup,
     refresh_task_definition_for_challenge,
     refresh_worker_task_definitions,
     register_task_def_by_challenge_pk,
@@ -62,10 +64,12 @@ from challenges.aws_utils import (
     terminate_ec2_instance,
     trigger_eks_node_autoscale,
     update_challenge_cleanup_schedule,
+    update_eks_nodegroup_scaling,
     update_evalai_worker_image_tag,
     update_service_by_challenge_pk,
     update_sqs_retention_period,
     update_sqs_retention_period_task,
+    validate_eks_nodegroup_config,
 )
 from challenges.models import Challenge, ChallengeEvaluationCluster
 from challenges.worker_utils import (
@@ -8087,3 +8091,556 @@ class TestWorkerImageHelpers(TestCase):
             "evalai-production-worker-py",
             next(iter(prefixes)),
         )
+
+
+class TestValidateEKSNodegroupConfig(unittest.TestCase):
+    """
+    The validation gate runs before the old nodegroup is deleted, so a false
+    negative here destroys a challenge's capacity.
+    """
+
+    def setUp(self):
+        self.challenge = MagicMock()
+        self.challenge.pk = 1
+        self.challenge.worker_instance_type = "g5.xlarge"
+        self.challenge.worker_ami_type = "AL2023_x86_64_NVIDIA"
+        self.challenge.worker_disk_size = 100
+        self.challenge.cpu_only_jobs = False
+
+        self.eks_client = MagicMock()
+        self.eks_client.describe_cluster.return_value = {
+            "cluster": {"version": "1.36"}
+        }
+
+        self.ec2_client = MagicMock()
+        self.ec2_client.describe_instance_type_offerings.return_value = {
+            "InstanceTypeOfferings": [{"InstanceType": "g5.xlarge"}]
+        }
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_valid_config_returns_no_errors(
+        self, mock_credentials, mock_get_boto3_client
+    ):
+        mock_get_boto3_client.return_value = self.ec2_client
+
+        errors = validate_eks_nodegroup_config(
+            self.challenge, self.eks_client, "test-cluster"
+        )
+
+        self.assertEqual(errors, [])
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_instance_type_not_offered_in_region(
+        self, mock_credentials, mock_get_boto3_client
+    ):
+        self.ec2_client.describe_instance_type_offerings.return_value = {
+            "InstanceTypeOfferings": []
+        }
+        mock_get_boto3_client.return_value = self.ec2_client
+
+        errors = validate_eks_nodegroup_config(
+            self.challenge, self.eks_client, "test-cluster"
+        )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("not offered in this region", errors[0])
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_unknown_ami_type_rejected(
+        self, mock_credentials, mock_get_boto3_client
+    ):
+        mock_get_boto3_client.return_value = self.ec2_client
+        self.challenge.worker_ami_type = "NOT_A_REAL_AMI"
+
+        errors = validate_eks_nodegroup_config(
+            self.challenge, self.eks_client, "test-cluster"
+        )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("Unknown worker_ami_type", errors[0])
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_al2_ami_rejected_on_modern_kubernetes(
+        self, mock_credentials, mock_get_boto3_client
+    ):
+        """
+        AL2 AMIs no longer exist on Kubernetes 1.33+, so create_nodegroup would
+        fail after the old nodegroup had already been deleted.
+        """
+        mock_get_boto3_client.return_value = self.ec2_client
+        self.challenge.worker_ami_type = "AL2_x86_64_GPU"
+
+        errors = validate_eks_nodegroup_config(
+            self.challenge, self.eks_client, "test-cluster"
+        )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("not available on Kubernetes 1.36", errors[0])
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_al2_ami_allowed_on_old_kubernetes(
+        self, mock_credentials, mock_get_boto3_client
+    ):
+        mock_get_boto3_client.return_value = self.ec2_client
+        self.challenge.worker_ami_type = "AL2_x86_64_GPU"
+        self.eks_client.describe_cluster.return_value = {
+            "cluster": {"version": "1.29"}
+        }
+
+        errors = validate_eks_nodegroup_config(
+            self.challenge, self.eks_client, "test-cluster"
+        )
+
+        self.assertEqual(errors, [])
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_gpu_challenge_on_non_gpu_ami_rejected(
+        self, mock_credentials, mock_get_boto3_client
+    ):
+        mock_get_boto3_client.return_value = self.ec2_client
+        self.challenge.worker_ami_type = "AL2023_x86_64_STANDARD"
+
+        errors = validate_eks_nodegroup_config(
+            self.challenge, self.eks_client, "test-cluster"
+        )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("has no GPU driver", errors[0])
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_cpu_only_challenge_on_non_gpu_ami_allowed(
+        self, mock_credentials, mock_get_boto3_client
+    ):
+        mock_get_boto3_client.return_value = self.ec2_client
+        self.challenge.worker_ami_type = "AL2023_x86_64_STANDARD"
+        self.challenge.cpu_only_jobs = True
+
+        errors = validate_eks_nodegroup_config(
+            self.challenge, self.eks_client, "test-cluster"
+        )
+
+        self.assertEqual(errors, [])
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_invalid_disk_size_rejected(
+        self, mock_credentials, mock_get_boto3_client
+    ):
+        mock_get_boto3_client.return_value = self.ec2_client
+        self.challenge.worker_disk_size = 0
+
+        errors = validate_eks_nodegroup_config(
+            self.challenge, self.eks_client, "test-cluster"
+        )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("worker_disk_size", errors[0])
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_empty_instance_type_rejected(
+        self, mock_credentials, mock_get_boto3_client
+    ):
+        mock_get_boto3_client.return_value = self.ec2_client
+        self.challenge.worker_instance_type = None
+
+        errors = validate_eks_nodegroup_config(
+            self.challenge, self.eks_client, "test-cluster"
+        )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("worker_instance_type is empty", errors[0])
+
+
+class TestRecreateEKSNodegroup(unittest.TestCase):
+    def setUp(self):
+        self.challenge = MagicMock()
+        self.challenge.pk = 1
+        self.challenge.title = "Test Challenge"
+
+        self.cluster = MagicMock()
+        self.cluster.name = "test-cluster"
+        self.cluster.nodegroup_name = "test-nodegroup"
+
+        self.client = MagicMock()
+
+    def _patch_lookup(self):
+        return patch(
+            "challenges.aws_utils._get_challenge_nodegroup",
+            return_value=(self.challenge, "test-cluster", "test-nodegroup"),
+        )
+
+    @patch("challenges.aws_utils.create_nodegroup_for_challenge")
+    @patch("challenges.aws_utils.validate_eks_nodegroup_config")
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_deletes_then_creates_on_valid_config(
+        self,
+        mock_credentials,
+        mock_get_boto3_client,
+        mock_validate,
+        mock_create,
+    ):
+        mock_get_boto3_client.return_value = self.client
+        mock_validate.return_value = []
+        mock_create.return_value = {"nodegroup": "created"}
+
+        with self._patch_lookup():
+            result = recreate_eks_nodegroup(1)
+
+        self.client.delete_nodegroup.assert_called_once_with(
+            clusterName="test-cluster", nodegroupName="test-nodegroup"
+        )
+        self.client.get_waiter.assert_called_once_with("nodegroup_deleted")
+        mock_create.assert_called_once_with(
+            self.client, self.challenge, "test-cluster", "test-nodegroup"
+        )
+        self.assertIn("message", result)
+
+    @patch("challenges.aws_utils.create_nodegroup_for_challenge")
+    @patch("challenges.aws_utils.validate_eks_nodegroup_config")
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_invalid_config_leaves_nodegroup_untouched(
+        self,
+        mock_credentials,
+        mock_get_boto3_client,
+        mock_validate,
+        mock_create,
+    ):
+        """
+        A failed precheck must abort before delete_nodegroup, otherwise the
+        challenge is left with no capacity at all.
+        """
+        mock_get_boto3_client.return_value = self.client
+        mock_validate.return_value = ["Instance type bogus.type is not valid."]
+
+        with self._patch_lookup():
+            result = recreate_eks_nodegroup(1)
+
+        self.client.delete_nodegroup.assert_not_called()
+        mock_create.assert_not_called()
+        self.assertIn("error", result)
+        self.assertIn("left untouched", result["error"])
+
+    @patch("challenges.aws_utils.create_nodegroup_for_challenge")
+    @patch("challenges.aws_utils.validate_eks_nodegroup_config")
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_missing_nodegroup_still_creates(
+        self,
+        mock_credentials,
+        mock_get_boto3_client,
+        mock_validate,
+        mock_create,
+    ):
+        mock_get_boto3_client.return_value = self.client
+        mock_validate.return_value = []
+        mock_create.return_value = {"nodegroup": "created"}
+        self.client.delete_nodegroup.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "ResourceNotFoundException",
+                    "Message": "gone",
+                }
+            },
+            "DeleteNodegroup",
+        )
+
+        with self._patch_lookup():
+            result = recreate_eks_nodegroup(1)
+
+        mock_create.assert_called_once()
+        self.assertIn("message", result)
+
+    @patch("challenges.aws_utils.create_nodegroup_for_challenge")
+    @patch("challenges.aws_utils.validate_eks_nodegroup_config")
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_delete_error_aborts_before_create(
+        self,
+        mock_credentials,
+        mock_get_boto3_client,
+        mock_validate,
+        mock_create,
+    ):
+        mock_get_boto3_client.return_value = self.client
+        mock_validate.return_value = []
+        self.client.delete_nodegroup.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "nope"}},
+            "DeleteNodegroup",
+        )
+
+        with self._patch_lookup():
+            result = recreate_eks_nodegroup(1)
+
+        mock_create.assert_not_called()
+        self.assertIn("error", result)
+
+    @patch("challenges.aws_utils.create_nodegroup_for_challenge")
+    @patch("challenges.aws_utils.validate_eks_nodegroup_config")
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_failed_create_reports_lost_capacity(
+        self,
+        mock_credentials,
+        mock_get_boto3_client,
+        mock_validate,
+        mock_create,
+    ):
+        mock_get_boto3_client.return_value = self.client
+        mock_validate.return_value = []
+        mock_create.return_value = None
+
+        with self._patch_lookup():
+            result = recreate_eks_nodegroup(1)
+
+        self.assertIn("error", result)
+        self.assertIn("no worker capacity", result["error"])
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    def test_no_cluster_is_a_noop(self, mock_get_boto3_client):
+        with patch(
+            "challenges.aws_utils._get_challenge_nodegroup",
+            return_value=(None, None, None),
+        ):
+            result = recreate_eks_nodegroup(1)
+
+        mock_get_boto3_client.assert_not_called()
+        self.assertIn("error", result)
+
+
+class TestUpdateEKSNodegroupScaling(unittest.TestCase):
+    def setUp(self):
+        self.challenge = MagicMock()
+        self.challenge.pk = 1
+        self.challenge.min_worker_instance = 0
+        self.challenge.max_worker_instance = 4
+        self.challenge.desired_worker_instance = 0
+        self.client = MagicMock()
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_pushes_scaling_config(
+        self, mock_credentials, mock_get_boto3_client
+    ):
+        mock_get_boto3_client.return_value = self.client
+
+        with patch(
+            "challenges.aws_utils._get_challenge_nodegroup",
+            return_value=(self.challenge, "test-cluster", "test-nodegroup"),
+        ):
+            result = update_eks_nodegroup_scaling(1)
+
+        self.client.update_nodegroup_config.assert_called_once_with(
+            clusterName="test-cluster",
+            nodegroupName="test-nodegroup",
+            scalingConfig={"minSize": 0, "maxSize": 4, "desiredSize": 0},
+        )
+        self.assertIn("message", result)
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_client_error_is_reported(
+        self, mock_credentials, mock_get_boto3_client
+    ):
+        mock_get_boto3_client.return_value = self.client
+        self.client.update_nodegroup_config.side_effect = ClientError(
+            {"Error": {"Code": "InvalidParameterException", "Message": "bad"}},
+            "UpdateNodegroupConfig",
+        )
+
+        with patch(
+            "challenges.aws_utils._get_challenge_nodegroup",
+            return_value=(self.challenge, "test-cluster", "test-nodegroup"),
+        ):
+            result = update_eks_nodegroup_scaling(1)
+
+        self.assertIn("error", result)
+
+
+class TestEKSNodegroupConfigChangeCallback(unittest.TestCase):
+    def setUp(self):
+        self.challenge = MagicMock()
+        self.challenge.pk = 1
+        self.challenge.is_docker_based = True
+        self.challenge.remote_evaluation = False
+        # Start with every tracked field unchanged.
+        for field in (
+            "worker_instance_type",
+            "worker_ami_type",
+            "worker_disk_size",
+            "min_worker_instance",
+            "max_worker_instance",
+            "desired_worker_instance",
+        ):
+            value = "unchanged-{}".format(field)
+            setattr(self.challenge, field, value)
+            setattr(self.challenge, "_original_{}".format(field), value)
+
+    @patch("challenges.aws_utils.update_eks_nodegroup_scaling")
+    @patch("challenges.aws_utils.recreate_eks_nodegroup")
+    @patch("challenges.aws_utils.settings", DEBUG=False, TEST=False)
+    def test_no_change_dispatches_nothing(
+        self, mock_settings, mock_recreate, mock_scale
+    ):
+        mock_settings.EKS_NODEGROUP_IMMUTABLE_FIELDS = (
+            "worker_instance_type",
+            "worker_ami_type",
+            "worker_disk_size",
+        )
+        mock_settings.EKS_NODEGROUP_SCALING_FIELDS = (
+            "min_worker_instance",
+            "max_worker_instance",
+            "desired_worker_instance",
+        )
+
+        action = eks_nodegroup_config_change_callback(self.challenge)
+
+        self.assertIsNone(action)
+        mock_recreate.delay.assert_not_called()
+        mock_scale.delay.assert_not_called()
+
+    @patch("challenges.aws_utils.update_eks_nodegroup_scaling")
+    @patch("challenges.aws_utils.recreate_eks_nodegroup")
+    @patch("challenges.aws_utils.settings", DEBUG=False, TEST=False)
+    def test_instance_type_change_triggers_recreate(
+        self, mock_settings, mock_recreate, mock_scale
+    ):
+        mock_settings.EKS_NODEGROUP_IMMUTABLE_FIELDS = (
+            "worker_instance_type",
+            "worker_ami_type",
+            "worker_disk_size",
+        )
+        mock_settings.EKS_NODEGROUP_SCALING_FIELDS = (
+            "min_worker_instance",
+            "max_worker_instance",
+            "desired_worker_instance",
+        )
+        self.challenge.worker_instance_type = "g5.xlarge"
+
+        action = eks_nodegroup_config_change_callback(self.challenge)
+
+        self.assertEqual(action, "recreate")
+        mock_recreate.delay.assert_called_once_with(1)
+        mock_scale.delay.assert_not_called()
+        # The snapshot is refreshed so a second save is not a second recreate.
+        self.assertEqual(
+            self.challenge._original_worker_instance_type, "g5.xlarge"
+        )
+
+    @patch("challenges.aws_utils.update_eks_nodegroup_scaling")
+    @patch("challenges.aws_utils.recreate_eks_nodegroup")
+    @patch("challenges.aws_utils.settings", DEBUG=False, TEST=False)
+    def test_scaling_change_triggers_update_only(
+        self, mock_settings, mock_recreate, mock_scale
+    ):
+        mock_settings.EKS_NODEGROUP_IMMUTABLE_FIELDS = (
+            "worker_instance_type",
+            "worker_ami_type",
+            "worker_disk_size",
+        )
+        mock_settings.EKS_NODEGROUP_SCALING_FIELDS = (
+            "min_worker_instance",
+            "max_worker_instance",
+            "desired_worker_instance",
+        )
+        self.challenge.max_worker_instance = 8
+
+        action = eks_nodegroup_config_change_callback(self.challenge)
+
+        self.assertEqual(action, "scale")
+        mock_scale.delay.assert_called_once_with(1)
+        mock_recreate.delay.assert_not_called()
+
+    @patch("challenges.aws_utils.update_eks_nodegroup_scaling")
+    @patch("challenges.aws_utils.recreate_eks_nodegroup")
+    @patch("challenges.aws_utils.settings", DEBUG=False, TEST=False)
+    def test_recreate_wins_when_both_change(
+        self, mock_settings, mock_recreate, mock_scale
+    ):
+        """
+        create_nodegroup already sends the new scalingConfig, so dispatching an
+        update as well would be a redundant AWS call.
+        """
+        mock_settings.EKS_NODEGROUP_IMMUTABLE_FIELDS = (
+            "worker_instance_type",
+            "worker_ami_type",
+            "worker_disk_size",
+        )
+        mock_settings.EKS_NODEGROUP_SCALING_FIELDS = (
+            "min_worker_instance",
+            "max_worker_instance",
+            "desired_worker_instance",
+        )
+        self.challenge.worker_instance_type = "g5.xlarge"
+        self.challenge.max_worker_instance = 8
+
+        action = eks_nodegroup_config_change_callback(self.challenge)
+
+        self.assertEqual(action, "recreate")
+        mock_recreate.delay.assert_called_once_with(1)
+        mock_scale.delay.assert_not_called()
+
+    @patch("challenges.aws_utils.update_eks_nodegroup_scaling")
+    @patch("challenges.aws_utils.recreate_eks_nodegroup")
+    @patch("challenges.aws_utils.settings", DEBUG=False, TEST=False)
+    def test_non_code_upload_challenge_ignored(
+        self, mock_settings, mock_recreate, mock_scale
+    ):
+        mock_settings.EKS_NODEGROUP_IMMUTABLE_FIELDS = (
+            "worker_instance_type",
+            "worker_ami_type",
+            "worker_disk_size",
+        )
+        mock_settings.EKS_NODEGROUP_SCALING_FIELDS = (
+            "min_worker_instance",
+            "max_worker_instance",
+            "desired_worker_instance",
+        )
+        self.challenge.is_docker_based = False
+        self.challenge.worker_instance_type = "g5.xlarge"
+
+        action = eks_nodegroup_config_change_callback(self.challenge)
+
+        self.assertIsNone(action)
+        mock_recreate.delay.assert_not_called()
+
+    @patch("challenges.aws_utils.update_eks_nodegroup_scaling")
+    @patch("challenges.aws_utils.recreate_eks_nodegroup")
+    @patch("challenges.aws_utils.settings", DEBUG=True, TEST=False)
+    def test_debug_mode_dispatches_nothing(
+        self, mock_settings, mock_recreate, mock_scale
+    ):
+        self.challenge.worker_instance_type = "g5.xlarge"
+
+        action = eks_nodegroup_config_change_callback(self.challenge)
+
+        self.assertIsNone(action)
+        mock_recreate.delay.assert_not_called()
+        mock_scale.delay.assert_not_called()
+
+    @patch("challenges.aws_utils.update_eks_nodegroup_scaling")
+    @patch("challenges.aws_utils.recreate_eks_nodegroup")
+    @patch("challenges.aws_utils.settings", DEBUG=False, TEST=True)
+    def test_test_mode_dispatches_nothing(
+        self, mock_settings, mock_recreate, mock_scale
+    ):
+        """
+        The hook fires on every Challenge save, so without this guard the whole
+        test suite would dispatch Celery tasks at a broker that is not running.
+        """
+        self.challenge.worker_instance_type = "g5.xlarge"
+
+        action = eks_nodegroup_config_change_callback(self.challenge)
+
+        self.assertIsNone(action)
+        mock_recreate.delay.assert_not_called()
+        mock_scale.delay.assert_not_called()

--- a/tests/unit/challenges/test_aws_utils.py
+++ b/tests/unit/challenges/test_aws_utils.py
@@ -8123,6 +8123,9 @@ class TestValidateEKSNodegroupConfig(unittest.TestCase):
         self.challenge.worker_ami_type = "AL2023_x86_64_NVIDIA"
         self.challenge.worker_disk_size = 100
         self.challenge.cpu_only_jobs = False
+        self.challenge.min_worker_instance = 0
+        self.challenge.max_worker_instance = 4
+        self.challenge.desired_worker_instance = 1
 
         self.eks_client = MagicMock()
         self.eks_client.describe_cluster.return_value = {
@@ -8286,6 +8289,9 @@ class TestValidateEKSNodegroupConfigErrors(unittest.TestCase):
         self.challenge.worker_ami_type = "AL2023_x86_64_NVIDIA"
         self.challenge.worker_disk_size = 100
         self.challenge.cpu_only_jobs = False
+        self.challenge.min_worker_instance = 0
+        self.challenge.max_worker_instance = 4
+        self.challenge.desired_worker_instance = 1
         self.eks_client = MagicMock()
         self.eks_client.describe_cluster.return_value = {
             "cluster": {"version": "1.36"}
@@ -8329,6 +8335,108 @@ class TestValidateEKSNodegroupConfigErrors(unittest.TestCase):
 
         self.assertEqual(len(errors), 1)
         self.assertIn("Could not read cluster version", errors[0])
+
+
+class TestValidateNodegroupScaling(unittest.TestCase):
+    """
+    Scaling bounds are sent to CreateNodegroup after the live nodegroup has
+    already been deleted, so an invalid combination must be caught up front.
+    """
+
+    def setUp(self):
+        self.challenge = MagicMock()
+        self.challenge.pk = 1
+        self.challenge.worker_instance_type = "g5.xlarge"
+        self.challenge.worker_ami_type = "AL2023_x86_64_NVIDIA"
+        self.challenge.worker_disk_size = 100
+        self.challenge.cpu_only_jobs = False
+        self.challenge.min_worker_instance = 0
+        self.challenge.max_worker_instance = 4
+        self.challenge.desired_worker_instance = 1
+
+        self.eks_client = MagicMock()
+        self.eks_client.describe_cluster.return_value = {
+            "cluster": {"version": "1.36"}
+        }
+        self.ec2_client = MagicMock()
+        self.ec2_client.describe_instance_type_offerings.return_value = {
+            "InstanceTypeOfferings": [{"InstanceType": "g5.xlarge"}]
+        }
+
+    def _validate(self):
+        with patch(
+            "challenges.aws_utils.get_boto3_client",
+            return_value=self.ec2_client,
+        ), patch("challenges.utils.get_aws_credentials_for_challenge"):
+            return validate_eks_nodegroup_config(
+                self.challenge, self.eks_client, "test-cluster"
+            )
+
+    def test_valid_bounds_pass(self):
+        self.assertEqual(self._validate(), [])
+
+    def test_min_above_max_is_rejected(self):
+        self.challenge.min_worker_instance = 5
+
+        errors = self._validate()
+
+        self.assertTrue(
+            any("cannot exceed max_worker_instance" in e for e in errors)
+        )
+
+    def test_desired_outside_bounds_is_rejected(self):
+        self.challenge.desired_worker_instance = 9
+
+        errors = self._validate()
+
+        self.assertTrue(any("must be between" in e for e in errors))
+
+    def test_zero_max_is_rejected(self):
+        self.challenge.max_worker_instance = 0
+        self.challenge.desired_worker_instance = 0
+
+        errors = self._validate()
+
+        self.assertTrue(
+            any("max_worker_instance must be at least 1" in e for e in errors)
+        )
+
+    def test_null_scaling_field_is_rejected(self):
+        """All three fields are nullable on the model."""
+        self.challenge.desired_worker_instance = None
+
+        errors = self._validate()
+
+        self.assertTrue(
+            any(
+                "desired_worker_instance must be a non-negative integer" in e
+                for e in errors
+            )
+        )
+
+    def test_negative_scaling_field_is_rejected(self):
+        self.challenge.min_worker_instance = -1
+
+        errors = self._validate()
+
+        self.assertTrue(
+            any(
+                "min_worker_instance must be a non-negative integer" in e
+                for e in errors
+            )
+        )
+
+    def test_boolean_is_not_accepted_as_an_integer(self):
+        self.challenge.max_worker_instance = True
+
+        errors = self._validate()
+
+        self.assertTrue(
+            any(
+                "max_worker_instance must be a non-negative integer" in e
+                for e in errors
+            )
+        )
 
 
 class TestRecreateEKSNodegroup(unittest.TestCase):
@@ -8577,6 +8685,27 @@ class TestRecreateEKSNodegroup(unittest.TestCase):
                 {"Error": {"Code": "AccessDeniedException", "Message": "no"}},
                 "DescribeNodegroup",
             )
+            result = recreate_eks_nodegroup(1)
+
+        self.client.delete_nodegroup.assert_not_called()
+        mock_create.assert_not_called()
+        self.assertIn("error", result)
+
+    @patch("challenges.aws_utils.create_nodegroup_for_challenge")
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_malformed_describe_response_aborts_before_delete(
+        self, mock_credentials, mock_get_boto3_client, mock_create
+    ):
+        mock_get_boto3_client.return_value = self.client
+
+        with self._patch_lookup():
+            # Resolution succeeds, then the status lookup comes back without
+            # the key the task needs.
+            self.client.describe_nodegroup.side_effect = [
+                {"nodegroup": {"status": "ACTIVE"}},
+                {"nodegroup": {}},
+            ]
             result = recreate_eks_nodegroup(1)
 
         self.client.delete_nodegroup.assert_not_called()
@@ -8906,10 +9035,15 @@ class TestUpdateEKSNodegroupScaling(unittest.TestCase):
         self, mock_credentials, mock_get_boto3_client
     ):
         mock_get_boto3_client.return_value = self.client
-        self.client.describe_nodegroup.side_effect = ClientError(
-            {"Error": {"Code": "ResourceNotFoundException", "Message": "no"}},
-            "DescribeNodegroup",
-        )
+        # The first call resolves the nodegroup name; the task's own lookup is
+        # the second one.
+        self.client.describe_nodegroup.side_effect = [
+            {"nodegroup": {"status": "ACTIVE"}},
+            ClientError(
+                {"Error": {"Code": "AccessDeniedException", "Message": "no"}},
+                "DescribeNodegroup",
+            ),
+        ]
 
         with self._patch_lookup():
             result = update_eks_nodegroup_scaling(1)
@@ -9019,14 +9153,6 @@ class TestResolveNodegroupName(unittest.TestCase):
         self.cluster.nodegroup_name = None
         self.client = MagicMock()
 
-    def test_recorded_name_is_used_without_calling_aws(self):
-        self.cluster.nodegroup_name = "recorded-nodegroup"
-
-        name = _resolve_nodegroup_name(self.client, 1, self.cluster)
-
-        self.assertEqual(name, "recorded-nodegroup")
-        self.client.list_nodegroups.assert_not_called()
-
     @patch("challenges.models.ChallengeEvaluationCluster")
     def test_single_nodegroup_is_resolved_and_recorded(self, mock_cluster):
         self.client.list_nodegroups.return_value = {
@@ -9039,6 +9165,62 @@ class TestResolveNodegroupName(unittest.TestCase):
         mock_cluster.objects.filter.return_value.update.assert_called_once_with(
             nodegroup_name="live-nodegroup"
         )
+
+    @patch("challenges.models.ChallengeEvaluationCluster")
+    def test_stale_recorded_name_is_re_resolved(self, mock_cluster):
+        """
+        A nodegroup replaced by hand leaves the recorded name pointing at
+        nothing. Trusting it would break every sync until the row was edited.
+        """
+        self.cluster.nodegroup_name = "stale-nodegroup"
+        self.client.describe_nodegroup.side_effect = ClientError(
+            {"Error": {"Code": "ResourceNotFoundException", "Message": "no"}},
+            "DescribeNodegroup",
+        )
+        self.client.list_nodegroups.return_value = {
+            "nodegroups": ["live-nodegroup"]
+        }
+
+        name = _resolve_nodegroup_name(self.client, 1, self.cluster)
+
+        self.assertEqual(name, "live-nodegroup")
+        mock_cluster.objects.filter.return_value.update.assert_called_once_with(
+            nodegroup_name="live-nodegroup"
+        )
+
+    def test_recorded_name_is_verified_before_use(self):
+        self.cluster.nodegroup_name = "recorded-nodegroup"
+
+        name = _resolve_nodegroup_name(self.client, 1, self.cluster)
+
+        self.assertEqual(name, "recorded-nodegroup")
+        self.client.describe_nodegroup.assert_called_once_with(
+            clusterName="test-cluster", nodegroupName="recorded-nodegroup"
+        )
+        self.client.list_nodegroups.assert_not_called()
+
+    def test_describe_boto_error_returns_none(self):
+        self.cluster.nodegroup_name = "recorded-nodegroup"
+        self.client.describe_nodegroup.side_effect = WaiterError(
+            name="describe", reason="connection reset", last_response={}
+        )
+
+        self.assertIsNone(
+            _resolve_nodegroup_name(self.client, 1, self.cluster)
+        )
+        self.client.list_nodegroups.assert_not_called()
+
+    def test_describe_error_other_than_missing_returns_none(self):
+        self.cluster.nodegroup_name = "recorded-nodegroup"
+        self.client.describe_nodegroup.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "no"}},
+            "DescribeNodegroup",
+        )
+
+        self.assertIsNone(
+            _resolve_nodegroup_name(self.client, 1, self.cluster)
+        )
+        self.client.list_nodegroups.assert_not_called()
 
     def test_no_nodegroup_returns_none(self):
         """Also the state during initial setup, before the nodegroup exists."""

--- a/tests/unit/challenges/test_aws_utils.py
+++ b/tests/unit/challenges/test_aws_utils.py
@@ -9,9 +9,12 @@ import pytest
 from botocore.exceptions import ClientError, NoCredentialsError, WaiterError
 from challenges.aws_utils import (
     _file_content_changed,
+    _get_challenge_cluster,
     _get_ecs_service_task_definition_arn,
     _is_inactive_task_definition_error,
+    _resolve_nodegroup_name,
     _sync_challenge_task_def_from_service,
+    _version_at_least,
     build_task_definition_dict,
     challenge_approval_callback,
     cleanup_auto_scaling_for_service,
@@ -19,6 +22,7 @@ from challenges.aws_utils import (
     create_eks_cluster,
     create_eks_cluster_subnets,
     create_eks_nodegroup,
+    create_nodegroup_for_challenge,
     create_service_by_challenge_pk,
     delete_challenge_cleanup_schedule,
     delete_log_group,
@@ -8259,6 +8263,61 @@ class TestValidateEKSNodegroupConfig(unittest.TestCase):
         self.assertIn("worker_instance_type is empty", errors[0])
 
 
+class TestValidateEKSNodegroupConfigErrors(unittest.TestCase):
+    """AWS lookups inside validation must degrade to an error, not an abort."""
+
+    def setUp(self):
+        self.challenge = MagicMock()
+        self.challenge.pk = 1
+        self.challenge.worker_instance_type = "g5.xlarge"
+        self.challenge.worker_ami_type = "AL2023_x86_64_NVIDIA"
+        self.challenge.worker_disk_size = 100
+        self.challenge.cpu_only_jobs = False
+        self.eks_client = MagicMock()
+        self.eks_client.describe_cluster.return_value = {
+            "cluster": {"version": "1.36"}
+        }
+        self.ec2_client = MagicMock()
+        self.ec2_client.describe_instance_type_offerings.return_value = {
+            "InstanceTypeOfferings": [{"InstanceType": "g5.xlarge"}]
+        }
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_instance_type_lookup_failure_is_an_error(
+        self, mock_credentials, mock_get_boto3_client
+    ):
+        self.ec2_client.describe_instance_type_offerings.side_effect = (
+            ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "no"}},
+                "DescribeInstanceTypeOfferings",
+            )
+        )
+        mock_get_boto3_client.return_value = self.ec2_client
+
+        errors = validate_eks_nodegroup_config(
+            self.challenge, self.eks_client, "test-cluster"
+        )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("Could not verify instance type", errors[0])
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_cluster_version_lookup_failure_is_an_error(
+        self, mock_credentials, mock_get_boto3_client
+    ):
+        mock_get_boto3_client.return_value = self.ec2_client
+        self.eks_client.describe_cluster.return_value = {}
+
+        errors = validate_eks_nodegroup_config(
+            self.challenge, self.eks_client, "test-cluster"
+        )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("Could not read cluster version", errors[0])
+
+
 class TestRecreateEKSNodegroup(unittest.TestCase):
     def setUp(self):
         self.challenge = MagicMock()
@@ -8272,9 +8331,12 @@ class TestRecreateEKSNodegroup(unittest.TestCase):
         self.client = MagicMock()
 
     def _patch_lookup(self):
+        self.client.describe_nodegroup.return_value = {
+            "nodegroup": {"status": "ACTIVE"}
+        }
         return patch(
-            "challenges.aws_utils._get_challenge_nodegroup",
-            return_value=(self.challenge, "test-cluster", "test-nodegroup"),
+            "challenges.aws_utils._get_challenge_cluster",
+            return_value=(self.challenge, self.cluster),
         )
 
     @patch("challenges.aws_utils.create_nodegroup_for_challenge")
@@ -8408,13 +8470,133 @@ class TestRecreateEKSNodegroup(unittest.TestCase):
     @patch("challenges.aws_utils.get_boto3_client")
     def test_no_cluster_is_a_noop(self, mock_get_boto3_client):
         with patch(
-            "challenges.aws_utils._get_challenge_nodegroup",
-            return_value=(None, None, None),
+            "challenges.aws_utils._get_challenge_cluster",
+            return_value=(None, None),
         ):
             result = recreate_eks_nodegroup(1)
 
         mock_get_boto3_client.assert_not_called()
         self.assertIn("error", result)
+
+    @patch("challenges.aws_utils.create_nodegroup_for_challenge")
+    @patch("challenges.aws_utils.validate_eks_nodegroup_config")
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_non_active_nodegroup_is_left_alone(
+        self,
+        mock_credentials,
+        mock_get_boto3_client,
+        mock_validate,
+        mock_create,
+    ):
+        """
+        A CREATING nodegroup means setup_eks_cluster is still in flight.
+        Deleting it would make create_eks_nodegroup fail on a duplicate name
+        and never start the code-upload worker.
+        """
+        mock_get_boto3_client.return_value = self.client
+        mock_validate.return_value = []
+
+        with self._patch_lookup():
+            self.client.describe_nodegroup.return_value = {
+                "nodegroup": {"status": "CREATING"}
+            }
+            result = recreate_eks_nodegroup(1)
+
+        self.client.delete_nodegroup.assert_not_called()
+        mock_create.assert_not_called()
+        self.assertIn("error", result)
+        self.assertIn("not ACTIVE", result["error"])
+
+    @patch("challenges.aws_utils.create_nodegroup_for_challenge")
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_describe_error_aborts_before_delete(
+        self, mock_credentials, mock_get_boto3_client, mock_create
+    ):
+        mock_get_boto3_client.return_value = self.client
+
+        with self._patch_lookup():
+            self.client.describe_nodegroup.side_effect = ClientError(
+                {"Error": {"Code": "AccessDeniedException", "Message": "no"}},
+                "DescribeNodegroup",
+            )
+            result = recreate_eks_nodegroup(1)
+
+        self.client.delete_nodegroup.assert_not_called()
+        mock_create.assert_not_called()
+        self.assertIn("error", result)
+
+    @patch("challenges.aws_utils._resolve_nodegroup_name", return_value=None)
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_unresolvable_nodegroup_is_a_noop(
+        self, mock_credentials, mock_get_boto3_client, mock_resolve
+    ):
+        mock_get_boto3_client.return_value = self.client
+
+        with self._patch_lookup():
+            result = recreate_eks_nodegroup(1)
+
+        self.client.delete_nodegroup.assert_not_called()
+        self.assertIn("error", result)
+
+    @patch("challenges.aws_utils.create_nodegroup_for_challenge")
+    @patch("challenges.aws_utils.validate_eks_nodegroup_config")
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_delete_waiter_timeout_aborts_before_create(
+        self,
+        mock_credentials,
+        mock_get_boto3_client,
+        mock_validate,
+        mock_create,
+    ):
+        """Creating over a half-deleted nodegroup would fail."""
+        mock_get_boto3_client.return_value = self.client
+        mock_validate.return_value = []
+
+        with self._patch_lookup():
+            self.client.get_waiter.return_value.wait.side_effect = WaiterError(
+                name="nodegroup_deleted",
+                reason="max attempts exceeded",
+                last_response={},
+            )
+            result = recreate_eks_nodegroup(1)
+
+        mock_create.assert_not_called()
+        self.assertIn("error", result)
+
+
+class TestCreateNodegroupForChallenge(unittest.TestCase):
+    @patch("challenges.models.ChallengeEvaluationCluster")
+    @patch("challenges.aws_utils.get_code_upload_setup_meta_for_challenge")
+    def test_active_waiter_failure_returns_none(
+        self, mock_meta, mock_evaluation_cluster
+    ):
+        """
+        WaiterError escaping here would skip the caller's failure handling and,
+        in create_eks_nodegroup, silently stop the code-upload worker start.
+        """
+        mock_meta.return_value = {
+            "SUBNET_1": "subnet-123",
+            "SUBNET_2": "subnet-456",
+            "EKS_NODEGROUP_ROLE_ARN": "arn:aws:iam::123456789012:role/ng",
+        }
+        challenge = MagicMock()
+        challenge.pk = 1
+        client = MagicMock()
+        client.get_waiter.return_value.wait.side_effect = WaiterError(
+            name="nodegroup_active",
+            reason="max attempts exceeded",
+            last_response={},
+        )
+
+        result = create_nodegroup_for_challenge(
+            client, challenge, "test-cluster", "test-nodegroup"
+        )
+
+        self.assertIsNone(result)
 
 
 class TestUpdateEKSNodegroupScaling(unittest.TestCase):
@@ -8424,27 +8606,81 @@ class TestUpdateEKSNodegroupScaling(unittest.TestCase):
         self.challenge.min_worker_instance = 0
         self.challenge.max_worker_instance = 4
         self.challenge.desired_worker_instance = 0
+
+        self.cluster = MagicMock()
+        self.cluster.name = "test-cluster"
+        self.cluster.nodegroup_name = "test-nodegroup"
+
         self.client = MagicMock()
+        self.client.describe_nodegroup.return_value = {
+            "nodegroup": {
+                "scalingConfig": {
+                    "minSize": 1,
+                    "maxSize": 2,
+                    "desiredSize": 2,
+                }
+            }
+        }
+
+    def _patch_lookup(self):
+        return patch(
+            "challenges.aws_utils._get_challenge_cluster",
+            return_value=(self.challenge, self.cluster),
+        )
 
     @patch("challenges.aws_utils.get_boto3_client")
     @patch("challenges.utils.get_aws_credentials_for_challenge")
-    def test_pushes_scaling_config(
+    def test_pushes_bounds_and_preserves_live_desired_size(
         self, mock_credentials, mock_get_boto3_client
     ):
+        """
+        The autoscale Lambda owns desiredSize. Pushing the challenge's stored
+        value would shrink a busy nodegroup and kill running submissions.
+        """
         mock_get_boto3_client.return_value = self.client
 
-        with patch(
-            "challenges.aws_utils._get_challenge_nodegroup",
-            return_value=(self.challenge, "test-cluster", "test-nodegroup"),
-        ):
+        with self._patch_lookup():
             result = update_eks_nodegroup_scaling(1)
 
         self.client.update_nodegroup_config.assert_called_once_with(
             clusterName="test-cluster",
             nodegroupName="test-nodegroup",
-            scalingConfig={"minSize": 0, "maxSize": 4, "desiredSize": 0},
+            scalingConfig={"minSize": 0, "maxSize": 4, "desiredSize": 2},
         )
         self.assertIn("message", result)
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_live_desired_size_clamped_into_new_bounds(
+        self, mock_credentials, mock_get_boto3_client
+    ):
+        mock_get_boto3_client.return_value = self.client
+        self.client.describe_nodegroup.return_value = {
+            "nodegroup": {"scalingConfig": {"desiredSize": 9}}
+        }
+
+        with self._patch_lookup():
+            update_eks_nodegroup_scaling(1)
+
+        sent = self.client.update_nodegroup_config.call_args.kwargs
+        self.assertEqual(sent["scalingConfig"]["desiredSize"], 4)
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_describe_error_is_reported(
+        self, mock_credentials, mock_get_boto3_client
+    ):
+        mock_get_boto3_client.return_value = self.client
+        self.client.describe_nodegroup.side_effect = ClientError(
+            {"Error": {"Code": "ResourceNotFoundException", "Message": "no"}},
+            "DescribeNodegroup",
+        )
+
+        with self._patch_lookup():
+            result = update_eks_nodegroup_scaling(1)
+
+        self.client.update_nodegroup_config.assert_not_called()
+        self.assertIn("error", result)
 
     @patch("challenges.aws_utils.get_boto3_client")
     @patch("challenges.utils.get_aws_credentials_for_challenge")
@@ -8457,13 +8693,158 @@ class TestUpdateEKSNodegroupScaling(unittest.TestCase):
             "UpdateNodegroupConfig",
         )
 
-        with patch(
-            "challenges.aws_utils._get_challenge_nodegroup",
-            return_value=(self.challenge, "test-cluster", "test-nodegroup"),
-        ):
+        with self._patch_lookup():
             result = update_eks_nodegroup_scaling(1)
 
         self.assertIn("error", result)
+
+    @patch("challenges.aws_utils.get_boto3_client")
+    def test_no_cluster_is_a_noop(self, mock_get_boto3_client):
+        with patch(
+            "challenges.aws_utils._get_challenge_cluster",
+            return_value=(None, None),
+        ):
+            result = update_eks_nodegroup_scaling(1)
+
+        mock_get_boto3_client.assert_not_called()
+        self.assertIn("error", result)
+
+    @patch("challenges.aws_utils._resolve_nodegroup_name", return_value=None)
+    @patch("challenges.aws_utils.get_boto3_client")
+    @patch("challenges.utils.get_aws_credentials_for_challenge")
+    def test_unresolvable_nodegroup_is_a_noop(
+        self, mock_credentials, mock_get_boto3_client, mock_resolve
+    ):
+        mock_get_boto3_client.return_value = self.client
+
+        with self._patch_lookup():
+            result = update_eks_nodegroup_scaling(1)
+
+        self.client.update_nodegroup_config.assert_not_called()
+        self.assertIn("error", result)
+
+
+class TestGetChallengeCluster(unittest.TestCase):
+    @patch("challenges.models.ChallengeEvaluationCluster")
+    def test_missing_cluster_returns_nothing(self, mock_cluster):
+        mock_cluster.DoesNotExist = ChallengeEvaluationCluster.DoesNotExist
+        mock_cluster.objects.select_related.return_value.get.side_effect = (
+            ChallengeEvaluationCluster.DoesNotExist
+        )
+
+        self.assertEqual(_get_challenge_cluster(1), (None, None))
+
+    @patch("challenges.models.ChallengeEvaluationCluster")
+    def test_database_error_returns_nothing(self, mock_cluster):
+        mock_cluster.DoesNotExist = ChallengeEvaluationCluster.DoesNotExist
+        mock_cluster.objects.select_related.return_value.get.side_effect = (
+            DatabaseError("connection lost")
+        )
+
+        self.assertEqual(_get_challenge_cluster(1), (None, None))
+
+    @patch("challenges.models.ChallengeEvaluationCluster")
+    def test_returns_challenge_and_cluster(self, mock_cluster):
+        cluster = MagicMock()
+        mock_cluster.DoesNotExist = ChallengeEvaluationCluster.DoesNotExist
+        mock_cluster.objects.select_related.return_value.get.return_value = (
+            cluster
+        )
+
+        self.assertEqual(
+            _get_challenge_cluster(1), (cluster.challenge, cluster)
+        )
+
+
+class TestVersionAtLeast(unittest.TestCase):
+    def test_compares_dotted_versions(self):
+        self.assertTrue(_version_at_least("1.36", "1.33"))
+        self.assertTrue(_version_at_least("1.33", "1.33"))
+        self.assertFalse(_version_at_least("1.29", "1.33"))
+
+    def test_unparseable_version_is_not_at_least(self):
+        """
+        An unreadable cluster version must not be treated as modern, or a valid
+        AL2 nodegroup would be rejected on an old cluster.
+        """
+        self.assertFalse(_version_at_least("unknown", "1.33"))
+        self.assertFalse(_version_at_least(None, "1.33"))
+
+
+class TestResolveNodegroupName(unittest.TestCase):
+    """
+    The name must never be re-derived from the challenge title: a renamed
+    challenge would derive a name matching nothing, delete nothing, and then
+    create a second nodegroup beside the live one.
+    """
+
+    def setUp(self):
+        self.cluster = MagicMock()
+        self.cluster.name = "test-cluster"
+        self.cluster.nodegroup_name = None
+        self.client = MagicMock()
+
+    def test_recorded_name_is_used_without_calling_aws(self):
+        self.cluster.nodegroup_name = "recorded-nodegroup"
+
+        name = _resolve_nodegroup_name(self.client, 1, self.cluster)
+
+        self.assertEqual(name, "recorded-nodegroup")
+        self.client.list_nodegroups.assert_not_called()
+
+    @patch("challenges.models.ChallengeEvaluationCluster")
+    def test_single_nodegroup_is_resolved_and_recorded(self, mock_cluster):
+        self.client.list_nodegroups.return_value = {
+            "nodegroups": ["live-nodegroup"]
+        }
+
+        name = _resolve_nodegroup_name(self.client, 1, self.cluster)
+
+        self.assertEqual(name, "live-nodegroup")
+        mock_cluster.objects.filter.return_value.update.assert_called_once_with(
+            nodegroup_name="live-nodegroup"
+        )
+
+    def test_no_nodegroup_returns_none(self):
+        """Also the state during initial setup, before the nodegroup exists."""
+        self.client.list_nodegroups.return_value = {"nodegroups": []}
+
+        self.assertIsNone(
+            _resolve_nodegroup_name(self.client, 1, self.cluster)
+        )
+
+    def test_multiple_nodegroups_refuses_to_guess(self):
+        self.client.list_nodegroups.return_value = {
+            "nodegroups": ["one", "two"]
+        }
+
+        self.assertIsNone(
+            _resolve_nodegroup_name(self.client, 1, self.cluster)
+        )
+
+    @patch("challenges.models.ChallengeEvaluationCluster")
+    def test_recording_failure_still_returns_name(self, mock_cluster):
+        """Persisting the name is a convenience; the recreate must go ahead."""
+        self.client.list_nodegroups.return_value = {
+            "nodegroups": ["live-nodegroup"]
+        }
+        mock_cluster.objects.filter.return_value.update.side_effect = (
+            DatabaseError("connection lost")
+        )
+
+        name = _resolve_nodegroup_name(self.client, 1, self.cluster)
+
+        self.assertEqual(name, "live-nodegroup")
+
+    def test_list_error_returns_none(self):
+        self.client.list_nodegroups.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "no"}},
+            "ListNodegroups",
+        )
+
+        self.assertIsNone(
+            _resolve_nodegroup_name(self.client, 1, self.cluster)
+        )
 
 
 class TestEKSNodegroupConfigChangeCallback(unittest.TestCase):


### PR DESCRIPTION
## Problem

A challenge's `worker_instance_type`, `worker_ami_type` and `worker_disk_size` reach AWS exactly once — in `create_eks_nodegroup`, from a challenge snapshot serialized at the moment `approved_by_admin` flipped to `True`. That serialized blob is threaded unchanged through `setup_eks_cluster` → `create_eks_cluster_subnets` → `create_eks_cluster` → `create_eks_nodegroup`; no task re-reads the database.

So editing any of those fields in Django admin changes only the database. The nodegroup keeps running the old hardware and nothing surfaces the mismatch.

AWS offers no in-place fix. `UpdateNodegroupConfig` accepts only scaling config, labels, taints and update config — `instanceTypes`, `amiType` and `diskSize` are fixed for the life of a managed nodegroup, and the console's Edit button doesn't expose them either. The only way to change them is delete + create.

Concretely: challenge 2319 runs `g5.4xlarge` nodes, and today there is no way to move it to `g5.xlarge` short of manual AWS work plus a Django shell.

## What this does

A `post_save` hook on `Challenge` diffs two field groups:

| Group | Fields | Action |
|---|---|---|
| Immutable | `worker_instance_type`, `worker_ami_type`, `worker_disk_size` | `recreate_eks_nodegroup` |
| Scaling | `min_worker_instance`, `max_worker_instance`, `desired_worker_instance` | `update_eks_nodegroup_scaling` |

When both changed, only the recreate is dispatched — `create_nodegroup` already sends the new `scalingConfig`.

Both tasks take a challenge **pk** rather than a serialized blob, so they always read current state. That staleness is what caused the original problem.

### Validation before anything is destroyed

`validate_eks_nodegroup_config` runs before `delete_nodegroup` and checks:

- instance type is set, and offered in the challenge's region
- AMI type is one AWS actually accepts
- the AMI ships NVIDIA drivers unless `cpu_only_jobs` is set — a GPU challenge on a standard AMI schedules pods that can never see a GPU
- AL2 AMI types are rejected on Kubernetes ≥ 1.33, where they no longer exist
- disk size is a positive integer

Any failure aborts with a logged error and leaves the existing nodegroup untouched, so a typo can't leave a challenge with zero capacity.

### Other details

- Nodegroup name is derived from title + pk + environment, so a recreate reuses the same name and `ChallengeEvaluationCluster.nodegroup_name` — which the autoscale Lambda targets — stays valid.
- The recreate path does **not** send `construct_and_send_eks_cluster_creation_mail`, so hosts don't get a second "cluster created" email per edit.
- `create_nodegroup_for_challenge` is extracted from `create_eks_nodegroup` so initial setup and recreation always send the same argument set.
- Guarded by `settings.DEBUG or settings.TEST`, matching the existing idiom, and skipped entirely for non-code-upload challenges.
- Adds a **Recreate EKS nodegroup** admin action. This is the retry path: after a validation failure the `_original_` snapshot has already been refreshed, so re-saving the same value is a no-op.

## Deliberate risk

**Recreation is immediate and does not check for running work.** Deleting a nodegroup terminates any node currently running a submission, so editing `worker_instance_type` on a busy challenge will kill its running evaluations. This was chosen over an idle-only or defer-until-idle policy; mitigation is a warning log before the delete plus the narrow trigger conditions. Flagging it explicitly for review.

## Testing

24 new tests in `tests/unit/challenges/test_aws_utils.py` covering each validation rejection, delete-then-create ordering, abort-before-delete on invalid config, missing-nodegroup and delete-error paths, lost-capacity reporting, scaling update, and every dispatch branch of the callback.

```
24 passed  (new tests)
27 passed  (including the 3 existing TestCreateEKSNodegroup tests that cover the refactor)
```

Locally I could only run the mock-based tests — this machine has no Postgres, so the DB-backed tests in that module error at setup on both this branch and a clean `master` worktree. CI covers those.

`black`, `isort`, `flake8` and `pylint` pass via pre-commit.

Design notes: `docs/superpowers/specs/2026-08-10-eks-nodegroup-config-sync-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes touch production EKS capacity: nodegroup recreation deletes workers and can terminate running evaluations; failed recreate after delete can leave a challenge with no workers until manual recovery.
> 
> **Overview**
> **EKS nodegroup worker settings now follow Challenge edits in Django**, instead of staying frozen at the approval-time snapshot used during initial cluster setup.
> 
> A new **`Challenge` post_save hook** diffs immutable fields (`worker_instance_type`, `worker_ami_type`, `worker_disk_size`) vs scaling fields and queues **`recreate_eks_nodegroup`** or **`update_eks_nodegroup_scaling`**. Tasks load the challenge by **pk** (not serialized JSON). **`create_eks_nodegroup`** is refactored to share **`create_nodegroup_for_challenge`** and **re-reads the DB** before create so edits during long initial setup still apply.
> 
> **`recreate_eks_nodegroup`** validates config (region instance type, AMI/GPU/K8s rules, disk, scaling bounds) **before** delete, resolves the live nodegroup name safely, retries while status is not `ACTIVE`, and warns that running submission nodes are terminated. Scaling updates push min/max but **preserve live `desiredSize`** (clamped) so autoscale-driven capacity is not wiped.
> 
> **Settings** add field-group tuples, supported AMI lists, and sync retry tuning. **Challenge admin** gains **Recreate EKS nodegroup** for code-upload challenges. Design doc and broad unit tests cover validation, recreate/update paths, and callback dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43133c6658468a23a3caa60cccf4ecd9d03fee99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * EKS nodegroup settings now synchronize automatically when challenge configuration changes.
  * Immutable changes trigger nodegroup recreation, while scaling updates preserve available capacity where possible.
  * Added an admin action to retry nodegroup recreation for eligible challenges, with clear queued and skipped results.
* **Bug Fixes**
  * Added validation for instance, AMI, Kubernetes version, GPU, disk, and scaling compatibility.
  * Improved handling of provisioning failures, unsupported configurations, retries, and capacity limits.
* **Documentation**
  * Added design documentation covering nodegroup synchronization and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->