### PR TITLE
fix(cloud-agent): start Docker daemon in environment start command

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,4 +1,4 @@
 {
   "install": "bash cloud-agent/install.sh && sudo docker compose build db sqs django",
-  "start": "sudo docker compose up -d db sqs django"
+  "start": "bash cloud-agent/install.sh && sudo docker compose up -d db sqs django"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a Cloud Agent boots from a prebuilt environment build, only the `start` command runs — `install` executes at build time and is not re-run per boot. The Docker daemon is a process, so it is **not** running when `start` executes on a fresh boot. The previous `start` (`sudo docker compose up -d db sqs django`) therefore failed with `Cannot connect to the Docker daemon` until `cloud-agent/install.sh` was run manually to launch `dockerd`.

This was confirmed by booting a fresh Cloud Agent from a prebuilt build of this environment: the daemon socket was missing on boot and `cloud-agent/install.sh` had to be run by hand before any service could start.

## Change

Prefix the `start` command with `bash cloud-agent/install.sh`, which is idempotent (installs Docker only if missing and starts/reconciles the daemon), so backend services come up cleanly on every boot with no manual intervention.

```diff
-  "start": "sudo docker compose up -d db sqs django"
+  "start": "bash cloud-agent/install.sh && sudo docker compose up -d db sqs django"
```

## Validation

- Simulated a fresh boot on the VM: killed `dockerd`, removed all app containers and the `postgres_data` bind mount, then ran the new `start`. Result: the daemon started and `db`, `sqs`, and `django` were created and came up (`START_RC=0`) with no manual steps.
- `cloud-agent/install.sh` remains idempotent when the daemon is already running (reports "Docker daemon is already running").

Scope is intentionally limited to the `start` command; `install` and the `nodejs` frontend manual-start flow (documented in `AGENTS.md`) are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b02b216f-560c-4e48-9839-3705ec864fbc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b02b216f-560c-4e48-9839-3705ec864fbc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * The startup process now automatically installs the cloud agent before launching Docker Compose services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->