### PR TITLE
Treat challenge and phase PUT as partial updates so form-encoded requests stop clearing boolean flags

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -1269,10 +1269,15 @@ def challenge_phase_detail(request, challenge_pk, pk):
                     partial=True,
                 )
         else:
+            # Partial for the same reason as challenge_detail: a non-partial
+            # form-encoded payload makes DRF write False for every BooleanField
+            # it omits, so a PUT that renamed a phase also took it private and
+            # cleared its submission settings.
             serializer = ChallengePhaseCreateSerializer(
                 challenge_phase,
                 data=request.data.copy(),
                 context={"challenge": challenge},
+                partial=True,
             )
         if serializer.is_valid():
             serializer.save()

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -349,6 +349,12 @@ def challenge_detail(request, challenge_host_team_pk, challenge_pk):
                     partial=True,
                 )
         else:
+            # PUT is treated as a partial update on purpose. Callers only ever
+            # send the fields they are changing, and an HTML form body cannot
+            # represent a missing checkbox: DRF substitutes False for every
+            # BooleanField absent from a non-partial form-encoded payload, so a
+            # PUT that renamed a challenge also closed its registration, forum
+            # and every other flag.
             serializer = ZipChallengeSerializer(
                 challenge,
                 data=request.data,
@@ -356,6 +362,7 @@ def challenge_detail(request, challenge_host_team_pk, challenge_pk):
                     "challenge_host_team": challenge_host_team,
                     "request": request,
                 },
+                partial=True,
             )
         if serializer.is_valid():
             serializer.save()

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -279,14 +279,19 @@ def challenge_detail(request, challenge_host_team_pk, challenge_pk):
                     response_data, status=status.HTTP_403_FORBIDDEN
                 )
 
+        # A form body is an immutable QueryDict unless the request carried an
+        # upload, and both this view and ChallengeSerializer.__init__ write to
+        # it. Copy once so a file-less form body does not raise.
+        data = request.data.copy()
+
         if request.method == "PATCH":
             if "overview_file" in request.FILES:
                 overview_file = request.FILES["overview_file"]
                 overview = overview_file.read()
-                request.data["description"] = overview
+                data["description"] = overview
                 serializer = ZipChallengeSerializer(
                     challenge,
-                    data=request.data,
+                    data=data,
                     context={
                         "challenge_host_team": challenge_host_team,
                         "request": request,
@@ -298,10 +303,10 @@ def challenge_detail(request, challenge_host_team_pk, challenge_pk):
                     "terms_and_conditions_file"
                 ]
                 terms_and_conditions = terms_and_conditions_file.read()
-                request.data["terms_and_conditions"] = terms_and_conditions
+                data["terms_and_conditions"] = terms_and_conditions
                 serializer = ZipChallengeSerializer(
                     challenge,
-                    data=request.data,
+                    data=data,
                     context={
                         "challenge_host_team": challenge_host_team,
                         "request": request,
@@ -313,10 +318,10 @@ def challenge_detail(request, challenge_host_team_pk, challenge_pk):
                     "submission_guidelines_file"
                 ]
                 submission_guidelines = submission_guidelines_file.read()
-                request.data["submission_guidelines"] = submission_guidelines
+                data["submission_guidelines"] = submission_guidelines
                 serializer = ZipChallengeSerializer(
                     challenge,
-                    data=request.data,
+                    data=data,
                     context={
                         "challenge_host_team": challenge_host_team,
                         "request": request,
@@ -328,10 +333,10 @@ def challenge_detail(request, challenge_host_team_pk, challenge_pk):
                     "evaluation_criteria_file"
                 ]
                 evaluation_criteria = evaluation_criteria_file.read()
-                request.data["evaluation_details"] = evaluation_criteria
+                data["evaluation_details"] = evaluation_criteria
                 serializer = ZipChallengeSerializer(
                     challenge,
-                    data=request.data,
+                    data=data,
                     context={
                         "challenge_host_team": challenge_host_team,
                         "request": request,
@@ -341,7 +346,7 @@ def challenge_detail(request, challenge_host_team_pk, challenge_pk):
             else:
                 serializer = ZipChallengeSerializer(
                     challenge,
-                    data=request.data,
+                    data=data,
                     context={
                         "challenge_host_team": challenge_host_team,
                         "request": request,
@@ -357,7 +362,7 @@ def challenge_detail(request, challenge_host_team_pk, challenge_pk):
             # and every other flag.
             serializer = ZipChallengeSerializer(
                 challenge,
-                data=request.data,
+                data=data,
                 context={
                     "challenge_host_team": challenge_host_team,
                     "request": request,

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -281,8 +281,15 @@ def challenge_detail(request, challenge_host_team_pk, challenge_pk):
 
         # A form body is an immutable QueryDict unless the request carried an
         # upload, and both this view and ChallengeSerializer.__init__ write to
-        # it. Copy once so a file-less form body does not raise.
-        data = request.data.copy()
+        # it. Copy the fields and re-attach any uploads by reference:
+        # request.data.copy() deep-copies its values, which raises
+        # "cannot pickle 'BufferedRandom' instances" for a file big enough to
+        # have been spooled to a TemporaryUploadedFile.
+        if request.FILES:
+            data = request.POST.copy()
+            data.update(request.FILES)
+        else:
+            data = request.data.copy()
 
         if request.method == "PATCH":
             if "overview_file" in request.FILES:
@@ -1253,23 +1260,32 @@ def challenge_phase_detail(request, challenge_pk, pk):
             return Response(response_data, status=status.HTTP_200_OK)
 
     elif request.method in ["PUT", "PATCH"]:
+        # See challenge_detail: request.data.copy() deep-copies uploads, which
+        # raises once a file is large enough to be spooled to disk. Annotation
+        # files routinely are.
+        if request.FILES:
+            data = request.POST.copy()
+            data.update(request.FILES)
+        else:
+            data = request.data.copy()
+
         if request.method == "PATCH":
             if "phase_description_file" in request.FILES:
                 phase_description_file = request.FILES[
                     "phase_description_file"
                 ]
                 phase_description = phase_description_file.read()
-                request.data["description"] = phase_description
+                data["description"] = phase_description
                 serializer = ChallengePhaseCreateSerializer(
                     challenge_phase,
-                    data=request.data.copy(),
+                    data=data,
                     context={"challenge": challenge},
                     partial=True,
                 )
             else:
                 serializer = ChallengePhaseCreateSerializer(
                     challenge_phase,
-                    data=request.data.copy(),
+                    data=data,
                     context={"challenge": challenge},
                     partial=True,
                 )
@@ -1280,7 +1296,7 @@ def challenge_phase_detail(request, challenge_pk, pk):
             # cleared its submission settings.
             serializer = ChallengePhaseCreateSerializer(
                 challenge_phase,
-                data=request.data.copy(),
+                data=data,
                 context={"challenge": challenge},
                 partial=True,
             )

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -4806,6 +4806,24 @@ class UpdateParticularChallengePhase(
 
         self.assert_only_the_sent_fields_changed(response)
 
+    @override_settings(MEDIA_ROOT="/tmp/evalai", FILE_UPLOAD_MAX_MEMORY_SIZE=0)
+    def test_update_accepts_an_annotation_spooled_to_disk(self):
+        """Annotation files are routinely too big to hold in memory.
+
+        Django then hands the view a TemporaryUploadedFile wrapping an open
+        file handle, which cannot be deep-copied, so the view has to carry
+        uploads by reference.
+        """
+        self.data["test_annotation"] = SimpleUploadedFile(
+            "update_test_sample_file.txt",
+            b"Dummy update file content",
+            content_type="text/plain",
+        )
+
+        response = self.client.put(self.url, self.data, format="multipart")
+
+        self.assert_only_the_sent_fields_changed(response)
+
     def test_particular_challenge_update_with_no_data(self):
         self.data = {"name": ""}
         response = self.client.put(self.url, self.data)

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -4823,6 +4823,13 @@ class UpdateParticularChallengePhase(
         response = self.client.put(self.url, self.data, format="multipart")
 
         self.assert_only_the_sent_fields_changed(response)
+        # A 200 alone would not prove the upload survived the view, so read
+        # the stored file back. upload_to is RandomFileName, which replaces
+        # the name with a uuid and keeps only the extension.
+        annotation = self.challenge_phase.test_annotation
+        self.assertTrue(annotation.name.endswith(".txt"))
+        with annotation.open("rb") as stored:
+            self.assertEqual(stored.read(), b"Dummy update file content")
 
     def test_particular_challenge_update_with_no_data(self):
         self.data = {"name": ""}

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -4747,6 +4747,34 @@ class UpdateParticularChallengePhase(
         response = self.client.put(self.url, self.data, format="multipart")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @override_settings(MEDIA_ROOT="/tmp/evalai")
+    def test_form_encoded_update_keeps_flags_the_host_did_not_send(self):
+        """A form-encoded update must not silently flip boolean flags.
+
+        Same defect as the challenge endpoint: an HTML form body cannot
+        represent a missing checkbox, so DRF fills in False for every
+        BooleanField absent from the payload. On a non-partial update that
+        took a public phase private and dropped its submission restrictions
+        without the host asking for either.
+        """
+        self.data["test_annotation"] = SimpleUploadedFile(
+            "update_test_sample_file.txt",
+            b"Dummy update file content",
+            content_type="text/plain",
+        )
+
+        response = self.client.put(self.url, self.data, format="multipart")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.challenge_phase.refresh_from_db()
+        self.assertEqual(
+            self.challenge_phase.name, self.update_challenge_phase_title
+        )
+        self.assertTrue(self.challenge_phase.is_public)
+        self.assertTrue(
+            self.challenge_phase.is_restricted_to_select_one_submission
+        )
+
     def test_particular_challenge_update_with_no_data(self):
         self.data = {"name": ""}
         response = self.client.put(self.url, self.data)

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -8,6 +8,7 @@ import zipfile
 from datetime import timedelta
 from os.path import join
 from smtplib import SMTPException
+from urllib.parse import urlencode
 
 import boto3
 import mock
@@ -1010,30 +1011,42 @@ class UpdateParticularChallenge(BaseAPITestClass):
         response = self.client.put(self.url, self.data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_form_encoded_update_keeps_flags_the_host_did_not_send(self):
-        """A form-encoded update must not silently flip boolean flags.
+    def assert_only_the_title_changed(self, response):
+        """The renamed challenge keeps every flag the request left out.
 
         Hosts and host tooling send only the fields they are changing. An
         HTML form body cannot represent a missing checkbox, so DRF fills in
         False for every BooleanField absent from the payload. On a
         non-partial update that turned off registration, the forum and every
         other flag behind the host's back.
-
-        The suite sends JSON by default (TEST_REQUEST_DEFAULT_FORMAT), which
-        takes the safe code path, so this case has to ask for multipart
-        explicitly.
         """
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.challenge.refresh_from_db()
+        self.assertEqual(self.challenge.title, self.update_challenge_title)
+        self.assertTrue(self.challenge.is_registration_open)
+        self.assertTrue(self.challenge.enable_forum)
+
+    def test_multipart_update_keeps_flags_the_host_did_not_send(self):
+        # The suite sends JSON by default (TEST_REQUEST_DEFAULT_FORMAT),
+        # which takes the safe code path, so ask for multipart explicitly.
         response = self.client.put(
             self.url,
             {"title": self.update_challenge_title},
             format="multipart",
         )
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.challenge.refresh_from_db()
-        self.assertEqual(self.challenge.title, self.update_challenge_title)
-        self.assertTrue(self.challenge.is_registration_open)
-        self.assertTrue(self.challenge.enable_forum)
+        self.assert_only_the_title_changed(response)
+
+    def test_urlencoded_update_keeps_flags_the_host_did_not_send(self):
+        # Same QueryDict handling as multipart, reached through FormParser
+        # rather than MultiPartParser.
+        response = self.client.put(
+            self.url,
+            urlencode({"title": self.update_challenge_title}),
+            content_type="application/x-www-form-urlencoded",
+        )
+
+        self.assert_only_the_title_changed(response)
 
 
 class FrozenChallengeTest(BaseAPITestClass):
@@ -4747,9 +4760,8 @@ class UpdateParticularChallengePhase(
         response = self.client.put(self.url, self.data, format="multipart")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    @override_settings(MEDIA_ROOT="/tmp/evalai")
-    def test_form_encoded_update_keeps_flags_the_host_did_not_send(self):
-        """A form-encoded update must not silently flip boolean flags.
+    def assert_only_the_sent_fields_changed(self, response):
+        """The renamed phase keeps every flag the request left out.
 
         Same defect as the challenge endpoint: an HTML form body cannot
         represent a missing checkbox, so DRF fills in False for every
@@ -4757,6 +4769,21 @@ class UpdateParticularChallengePhase(
         took a public phase private and dropped its submission restrictions
         without the host asking for either.
         """
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.challenge_phase.refresh_from_db()
+        self.assertEqual(
+            self.challenge_phase.name, self.update_challenge_phase_title
+        )
+        self.assertEqual(
+            self.challenge_phase.description, self.update_description
+        )
+        self.assertTrue(self.challenge_phase.is_public)
+        self.assertTrue(
+            self.challenge_phase.is_restricted_to_select_one_submission
+        )
+
+    @override_settings(MEDIA_ROOT="/tmp/evalai")
+    def test_multipart_update_keeps_flags_the_host_did_not_send(self):
         self.data["test_annotation"] = SimpleUploadedFile(
             "update_test_sample_file.txt",
             b"Dummy update file content",
@@ -4765,15 +4792,19 @@ class UpdateParticularChallengePhase(
 
         response = self.client.put(self.url, self.data, format="multipart")
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.challenge_phase.refresh_from_db()
-        self.assertEqual(
-            self.challenge_phase.name, self.update_challenge_phase_title
+        self.assert_only_the_sent_fields_changed(response)
+
+    def test_urlencoded_update_keeps_flags_the_host_did_not_send(self):
+        # Same QueryDict handling as multipart, reached through FormParser
+        # rather than MultiPartParser. No annotation file, so this one needs
+        # no media root.
+        response = self.client.put(
+            self.url,
+            urlencode(self.data),
+            content_type="application/x-www-form-urlencoded",
         )
-        self.assertTrue(self.challenge_phase.is_public)
-        self.assertTrue(
-            self.challenge_phase.is_restricted_to_select_one_submission
-        )
+
+        self.assert_only_the_sent_fields_changed(response)
 
     def test_particular_challenge_update_with_no_data(self):
         self.data = {"name": ""}

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -1010,6 +1010,31 @@ class UpdateParticularChallenge(BaseAPITestClass):
         response = self.client.put(self.url, self.data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_form_encoded_update_keeps_flags_the_host_did_not_send(self):
+        """A form-encoded update must not silently flip boolean flags.
+
+        Hosts and host tooling send only the fields they are changing. An
+        HTML form body cannot represent a missing checkbox, so DRF fills in
+        False for every BooleanField absent from the payload. On a
+        non-partial update that turned off registration, the forum and every
+        other flag behind the host's back.
+
+        The suite sends JSON by default (TEST_REQUEST_DEFAULT_FORMAT), which
+        takes the safe code path, so this case has to ask for multipart
+        explicitly.
+        """
+        response = self.client.put(
+            self.url,
+            {"title": self.update_challenge_title},
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.challenge.refresh_from_db()
+        self.assertEqual(self.challenge.title, self.update_challenge_title)
+        self.assertTrue(self.challenge.is_registration_open)
+        self.assertTrue(self.challenge.enable_forum)
+
 
 class FrozenChallengeTest(BaseAPITestClass):
     def setUp(self):


### PR DESCRIPTION
## What

`challenge_detail` and `challenge_phase_detail` both handled `PUT` as a non-partial update:

```python
serializer = ZipChallengeSerializer(
    challenge,
    data=request.data,
    context={...},
)   # no partial=True
```

An HTML form body cannot represent a missing checkbox, so DRF substitutes `False` for every `BooleanField` absent from the payload:

```python
# rest_framework/fields.py — Field.get_value
if html.is_html_input(dictionary):
    if self.field_name not in dictionary:
        if getattr(self.root, 'partial', False):
            return empty
        return self.default_empty_html   # BooleanField -> False
```

So a form-encoded `PUT` that only renamed a challenge also wrote `is_registration_open=False`, `enable_forum=False`, `anonymous_leaderboard=False` and the rest. On the phase endpoint the same request cleared `is_public`, `is_restricted_to_select_one_submission`, `leaderboard_public` and friends, taking public phases private. To a host this looks like settings reverting on their own, with nothing in the audit trail — the request never mentioned those fields.

JSON bodies are unaffected: a plain dict takes the `dictionary.get(field_name, empty)` path, and `get_default()` raises `SkipField` because the serializer has no default, so the field is left out of `validated_data` entirely.

## Second bug, found in review

Review flagged that the new URL-encoded test could not pass, which turned out to be a separate latent defect in the same view.

`request.data` is an **immutable** `QueryDict` for a form body that carries no upload — `FormParser` builds a default `QueryDict`, Django's `MultiPartParser.parse` ends with `self._post._mutable = False`, and DRF only substitutes a mutable copy when files are present:

```python
# rest_framework/request.py — _load_data_and_files
if self._files:
    self._full_data = self._data.copy()   # mutable
else:
    self._full_data = self._data          # immutable
```

`challenge_detail` writes into that dict in four upload branches, and `ChallengeSerializer.__init__` writes `data["creator"]` on every non-GET request. So a form-encoded request with no file raised `This QueryDict instance is immutable` before reaching validation at all. `challenge_phase_detail` never had this problem because it already passed `request.data.copy()`.

This narrows the first bug in practice: a **file-less** form-encoded `PUT` to `challenge_detail` was failing outright, so the requests that actually cleared flags were form bodies carrying an upload (an overview, terms, guidelines or evaluation-criteria file). Both paths are fixed here.

## Why this fix

Both `PUT` handlers are now `partial=True`, matching how every caller already uses them:

- the frontend only ever issues single-field PATCHes to these endpoints
- the existing `PUT` tests send subsets and assert every other field is preserved — i.e. they already encode partial semantics

Full-replace `PUT` has no caller to serve here, and keeping it means any client that switches to form encoding silently wipes flags.

`challenge_detail` also copies `request.data` once and writes to the copy.

## Tests

Four regression tests, multipart and URL-encoded for each endpoint, asserting the untouched flags survive in the database:

- `UpdateParticularChallenge` — `is_registration_open`, `enable_forum`
- `UpdateParticularChallengePhase` — `is_public`, `is_restricted_to_select_one_submission`, plus the description the request actually sends

The suite sets `TEST_REQUEST_DEFAULT_FORMAT: "json"`, so every existing challenge test takes the safe code path and this class of bug is structurally invisible to them. The phase suite did already have a multipart `PUT` test, but it only asserted the status code, so it passed while silently exercising the bug.

## Reviewer notes

- **Please confirm the new tests pass in CI before merging.** I could not execute the suite locally (no Postgres, and the available interpreter is Django 6 / Python 3.13 against a repo pinned to Django 2.2.20). Every DRF behaviour cited above was verified directly against the installed `rest_framework` and `django` sources, and the fixes follow from it, but the tests themselves have not been observed failing-then-passing on my machine.
- This fix stops the damage but not the cause: some client is sending full-replace `PUT`s it does not mean. Worth identifying it separately from the access logs — per the above, look for form-encoded `PUT`s carrying a file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core host configuration update paths for challenges and phases; behavior change is intentional but affects how all form-encoded PUTs are validated and saved.
> 
> **Overview**
> Fixes **challenge** and **challenge phase** `PUT` handlers so multipart and URL-encoded bodies no longer clear boolean settings the client did not send.
> 
> Both endpoints now build a **mutable copy** of the payload (merging `POST` + `FILES` when uploads are present so large spooled files are not deep-copied) and pass it to the serializers with **`partial=True`**, matching how hosts already send single-field updates. Documentation fields read from uploaded files are written on that copy instead of mutating immutable `request.data`.
> 
> Adds regression tests for multipart and `application/x-www-form-urlencoded` `PUT` on each endpoint, plus a phase test with **`FILE_UPLOAD_MAX_MEMORY_SIZE=0`** to ensure disk-spooled annotation uploads still persist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82c65bda486692eeb1fc7009d06a049de088bd67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed challenge and challenge-phase updates submitted through multipart or URL-encoded requests.
  * Omitted boolean fields now retain their existing values instead of being reset.
  * Challenge documentation and annotation uploads are saved correctly.
  * Updates to titles, names, descriptions, and annotations now apply reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->