### PR TITLE
Add activeDeadlineSeconds hard-timeout backstop for code-upload submission jobs

### DIFF
--- a/scripts/workers/code_upload_submission_worker.py
+++ b/scripts/workers/code_upload_submission_worker.py
@@ -52,9 +52,52 @@ script_config_map_name = "evalai-scripts-cm"
 # before Kubernetes hard-kills the Job, and also absorbs init-container setup
 # time, since activeDeadlineSeconds is measured from Job start (including init
 # containers). Kubernetes only terminates the Job if the in-pod timeout hangs.
-ACTIVE_DEADLINE_BUFFER_SECONDS = int(
-    os.environ.get("ACTIVE_DEADLINE_BUFFER_SECONDS", "300")
-)
+DEFAULT_ACTIVE_DEADLINE_BUFFER_SECONDS = 300
+
+
+def get_active_deadline_buffer_seconds():
+    """Read and validate the activeDeadlineSeconds buffer from the environment.
+
+    A malformed or negative ACTIVE_DEADLINE_BUFFER_SECONDS would otherwise
+    crash the worker at import or push a non-positive activeDeadlineSeconds to
+    the Kubernetes Job API (which rejects it, leaving the submission stuck).
+    Invalid values fall back to the default with a warning so the worker keeps
+    processing submissions.
+    """
+    raw_value = os.environ.get(
+        "ACTIVE_DEADLINE_BUFFER_SECONDS",
+        str(DEFAULT_ACTIVE_DEADLINE_BUFFER_SECONDS),
+    )
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid ACTIVE_DEADLINE_BUFFER_SECONDS=%r; falling back to %s",
+            raw_value,
+            DEFAULT_ACTIVE_DEADLINE_BUFFER_SECONDS,
+        )
+        return DEFAULT_ACTIVE_DEADLINE_BUFFER_SECONDS
+    if value < 0:
+        logger.warning(
+            "Negative ACTIVE_DEADLINE_BUFFER_SECONDS=%s; falling back to %s",
+            value,
+            DEFAULT_ACTIVE_DEADLINE_BUFFER_SECONDS,
+        )
+        return DEFAULT_ACTIVE_DEADLINE_BUFFER_SECONDS
+    return value
+
+
+ACTIVE_DEADLINE_BUFFER_SECONDS = get_active_deadline_buffer_seconds()
+
+
+def get_active_deadline_seconds(submission_time_limit):
+    """Return a strictly positive Kubernetes Job activeDeadlineSeconds value.
+
+    Combines the per-submission wall-clock limit with the configured buffer.
+    The Kubernetes Job API rejects a non-positive activeDeadlineSeconds, so the
+    result is clamped to at least 1 to guard against a zero submission limit.
+    """
+    return max(1, int(submission_time_limit) + ACTIVE_DEADLINE_BUFFER_SECONDS)
 
 
 def get_volume_mount_object(mount_path, name, read_only=False):
@@ -284,9 +327,8 @@ def create_job_object(message, environment_image, challenge):
     spec = client.V1JobSpec(
         backoff_limit=1,
         template=template,
-        active_deadline_seconds=(
-            int(submission_meta["submission_time_limit"])
-            + ACTIVE_DEADLINE_BUFFER_SECONDS
+        active_deadline_seconds=get_active_deadline_seconds(
+            submission_meta["submission_time_limit"]
         ),
     )
     # Instantiate the job object
@@ -406,12 +448,16 @@ def create_static_code_upload_submission_job_object(message, challenge):
     # Create the specification of deployment. activeDeadlineSeconds is a hard
     # backstop: Kubernetes terminates the Job if it outlives the per-submission
     # time limit (plus a buffer) even when the in-pod timeout fails to.
+    # Worst-case resource usage is active_deadline_seconds + the Pod's
+    # termination_grace_period_seconds (600 above): once the deadline is hit,
+    # Kubernetes SIGTERMs the Pod and waits up to the grace period before
+    # SIGKILL. The grace window is retained deliberately so the sidecar can PUT
+    # the "failed" status before it is torn down.
     spec = client.V1JobSpec(
         backoff_limit=1,
         template=template,
-        active_deadline_seconds=(
-            int(submission_meta["submission_time_limit"])
-            + ACTIVE_DEADLINE_BUFFER_SECONDS
+        active_deadline_seconds=get_active_deadline_seconds(
+            submission_meta["submission_time_limit"]
         ),
     )
     # Instantiate the job object

--- a/scripts/workers/code_upload_submission_worker.py
+++ b/scripts/workers/code_upload_submission_worker.py
@@ -44,6 +44,18 @@ EVALAI_API_SERVER = os.environ.get(
 QUEUE_NAME = os.environ.get("QUEUE_NAME", "evalai_submission_queue")
 script_config_map_name = "evalai-scripts-cm"
 
+# Extra seconds added on top of a challenge's submission_time_limit when
+# setting the Kubernetes Job activeDeadlineSeconds. The in-pod cooperative
+# timeout (monitor_submission.sh for static challenges, or the environment
+# image for code-upload challenges) is expected to mark the submission
+# "failed" at submission_time_limit. This buffer lets that status update land
+# before Kubernetes hard-kills the Job, and also absorbs init-container setup
+# time, since activeDeadlineSeconds is measured from Job start (including init
+# containers). Kubernetes only terminates the Job if the in-pod timeout hangs.
+ACTIVE_DEADLINE_BUFFER_SECONDS = int(
+    os.environ.get("ACTIVE_DEADLINE_BUFFER_SECONDS", "300")
+)
+
 
 def get_volume_mount_object(mount_path, name, read_only=False):
     volume_mount = client.V1VolumeMount(
@@ -266,8 +278,17 @@ def create_job_object(message, environment_image, challenge):
             volumes=volume_list,
         ),
     )
-    # Create the specification of deployment
-    spec = client.V1JobSpec(backoff_limit=1, template=template)
+    # Create the specification of deployment. activeDeadlineSeconds is a hard
+    # backstop: Kubernetes terminates the Job if it outlives the per-submission
+    # time limit (plus a buffer) even when the in-pod timeout fails to.
+    spec = client.V1JobSpec(
+        backoff_limit=1,
+        template=template,
+        active_deadline_seconds=(
+            int(submission_meta["submission_time_limit"])
+            + ACTIVE_DEADLINE_BUFFER_SECONDS
+        ),
+    )
     # Instantiate the job object
     job = get_job_object(submission_pk, spec)
     return job
@@ -382,8 +403,17 @@ def create_static_code_upload_submission_job_object(message, challenge):
             volumes=volume_list,
         ),
     )
-    # Create the specification of deployment
-    spec = client.V1JobSpec(backoff_limit=1, template=template)
+    # Create the specification of deployment. activeDeadlineSeconds is a hard
+    # backstop: Kubernetes terminates the Job if it outlives the per-submission
+    # time limit (plus a buffer) even when the in-pod timeout fails to.
+    spec = client.V1JobSpec(
+        backoff_limit=1,
+        template=template,
+        active_deadline_seconds=(
+            int(submission_meta["submission_time_limit"])
+            + ACTIVE_DEADLINE_BUFFER_SECONDS
+        ),
+    )
     # Instantiate the job object
     job = get_job_object(submission_pk, spec)
     return job

--- a/tests/unit/worker/test_code_upload_submission_worker.py
+++ b/tests/unit/worker/test_code_upload_submission_worker.py
@@ -489,7 +489,9 @@ class TestConfigFunctions(unittest.TestCase):
         )
 
         MockV1JobSpec.assert_called_once_with(
-            backoff_limit=1, template="mock-podtemplatespec"
+            backoff_limit=1,
+            template="mock-podtemplatespec",
+            active_deadline_seconds=3900,
         )
 
     @patch("scripts.workers.code_upload_submission_worker.get_job_object")
@@ -645,7 +647,9 @@ class TestConfigFunctions(unittest.TestCase):
 
         # Verify job creation
         MockV1JobSpec.assert_called_once_with(
-            backoff_limit=1, template="mock-podtemplatespec"
+            backoff_limit=1,
+            template="mock-podtemplatespec",
+            active_deadline_seconds=3900,
         )
         MockGetJobObject.assert_called_once_with(123, "mock-jobspec")
 

--- a/tests/unit/worker/test_code_upload_submission_worker.py
+++ b/tests/unit/worker/test_code_upload_submission_worker.py
@@ -1,3 +1,4 @@
+import os
 import signal
 import unittest
 from unittest.mock import MagicMock, mock_open, patch
@@ -7,6 +8,7 @@ from kubernetes import client
 from kubernetes.client.rest import ApiException
 
 from scripts.workers.code_upload_submission_worker import (
+    DEFAULT_ACTIVE_DEADLINE_BUFFER_SECONDS,
     EVALAI_API_SERVER,
     GracefulKiller,
     cleanup_submission,
@@ -17,6 +19,8 @@ from scripts.workers.code_upload_submission_worker import (
     create_script_config_map,
     create_static_code_upload_submission_job_object,
     delete_job,
+    get_active_deadline_buffer_seconds,
+    get_active_deadline_seconds,
     get_api_client,
     get_api_object,
     get_config_map_volume_object,
@@ -37,6 +41,54 @@ from scripts.workers.code_upload_submission_worker import (
     read_job,
     update_failed_jobs_and_send_logs,
 )
+
+
+class TestActiveDeadlineConfig(unittest.TestCase):
+    ENV_KEY = "ACTIVE_DEADLINE_BUFFER_SECONDS"
+    BUFFER_ATTR = (
+        "scripts.workers.code_upload_submission_worker."
+        "ACTIVE_DEADLINE_BUFFER_SECONDS"
+    )
+
+    def test_buffer_defaults_when_unset(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(self.ENV_KEY, None)
+            self.assertEqual(
+                get_active_deadline_buffer_seconds(),
+                DEFAULT_ACTIVE_DEADLINE_BUFFER_SECONDS,
+            )
+
+    def test_buffer_reads_valid_value(self):
+        with patch.dict(os.environ, {self.ENV_KEY: "120"}):
+            self.assertEqual(get_active_deadline_buffer_seconds(), 120)
+
+    def test_buffer_rejects_negative_value(self):
+        with patch.dict(os.environ, {self.ENV_KEY: "-500"}):
+            self.assertEqual(
+                get_active_deadline_buffer_seconds(),
+                DEFAULT_ACTIVE_DEADLINE_BUFFER_SECONDS,
+            )
+
+    def test_buffer_rejects_malformed_value(self):
+        with patch.dict(os.environ, {self.ENV_KEY: "not-an-int"}):
+            self.assertEqual(
+                get_active_deadline_buffer_seconds(),
+                DEFAULT_ACTIVE_DEADLINE_BUFFER_SECONDS,
+            )
+
+    def test_active_deadline_uses_default_buffer(self):
+        with patch(self.BUFFER_ATTR, 300):
+            self.assertEqual(get_active_deadline_seconds(3600), 3900)
+
+    def test_active_deadline_uses_custom_buffer(self):
+        with patch(self.BUFFER_ATTR, 120):
+            self.assertEqual(get_active_deadline_seconds(3600), 3720)
+
+    def test_active_deadline_is_clamped_positive(self):
+        # A zero submission limit with a zero buffer must not yield a
+        # non-positive activeDeadlineSeconds, which Kubernetes rejects.
+        with patch(self.BUFFER_ATTR, 0):
+            self.assertEqual(get_active_deadline_seconds(0), 1)
 
 
 class TestGracefulKiller(unittest.TestCase):

--- a/tests/unit/worker/test_code_upload_submission_worker.py
+++ b/tests/unit/worker/test_code_upload_submission_worker.py
@@ -64,17 +64,25 @@ class TestActiveDeadlineConfig(unittest.TestCase):
 
     def test_buffer_rejects_negative_value(self):
         with patch.dict(os.environ, {self.ENV_KEY: "-500"}):
-            self.assertEqual(
-                get_active_deadline_buffer_seconds(),
-                DEFAULT_ACTIVE_DEADLINE_BUFFER_SECONDS,
-            )
+            with patch(
+                "scripts.workers.code_upload_submission_worker.logger"
+            ) as mock_logger:
+                self.assertEqual(
+                    get_active_deadline_buffer_seconds(),
+                    DEFAULT_ACTIVE_DEADLINE_BUFFER_SECONDS,
+                )
+                mock_logger.warning.assert_called_once()
 
     def test_buffer_rejects_malformed_value(self):
         with patch.dict(os.environ, {self.ENV_KEY: "not-an-int"}):
-            self.assertEqual(
-                get_active_deadline_buffer_seconds(),
-                DEFAULT_ACTIVE_DEADLINE_BUFFER_SECONDS,
-            )
+            with patch(
+                "scripts.workers.code_upload_submission_worker.logger"
+            ) as mock_logger:
+                self.assertEqual(
+                    get_active_deadline_buffer_seconds(),
+                    DEFAULT_ACTIVE_DEADLINE_BUFFER_SECONDS,
+                )
+                mock_logger.warning.assert_called_once()
 
     def test_active_deadline_uses_default_buffer(self):
         with patch(self.BUFFER_ATTR, 300):

--- a/tests/unit/worker/test_code_upload_submission_worker.py
+++ b/tests/unit/worker/test_code_upload_submission_worker.py
@@ -482,7 +482,15 @@ class TestConfigFunctions(unittest.TestCase):
         MockGetJobObject.return_value = "mock-job-object"
 
         # Act
-        result = create_job_object(message, environment_image, challenge)
+        # Pin the buffer to the default so the active_deadline_seconds
+        # assertion below is independent of any ACTIVE_DEADLINE_BUFFER_SECONDS
+        # set in the host/CI environment at module import.
+        with patch(
+            "scripts.workers.code_upload_submission_worker."
+            "ACTIVE_DEADLINE_BUFFER_SECONDS",
+            300,
+        ):
+            result = create_job_object(message, environment_image, challenge)
 
         # Assert
         self.assertEqual(result, "mock-job-object")
@@ -613,9 +621,17 @@ class TestConfigFunctions(unittest.TestCase):
         MockGetJobObject.return_value = "mock-job-object"
 
         # Act
-        result = create_static_code_upload_submission_job_object(
-            message, challenge
-        )
+        # Pin the buffer to the default so the active_deadline_seconds
+        # assertion below is independent of any ACTIVE_DEADLINE_BUFFER_SECONDS
+        # set in the host/CI environment at module import.
+        with patch(
+            "scripts.workers.code_upload_submission_worker."
+            "ACTIVE_DEADLINE_BUFFER_SECONDS",
+            300,
+        ):
+            result = create_static_code_upload_submission_job_object(
+                message, challenge
+            )
 
         # Assert
         self.assertEqual(result, "mock-job-object")


### PR DESCRIPTION
## What

Set `activeDeadlineSeconds` on the Kubernetes `V1JobSpec` for both code-upload EKS job builders in `scripts/workers/code_upload_submission_worker.py`:

- `create_job_object` (code-upload challenges)
- `create_static_code_upload_submission_job_object` (static-dataset code-upload challenges)

The deadline is `submission_time_limit + ACTIVE_DEADLINE_BUFFER_SECONDS` (new module constant, default `300`, env-overridable via `ACTIVE_DEADLINE_BUFFER_SECONDS`).

## Why

Today the per-submission time limit is enforced **only** by an in-pod cooperative timeout:

- static challenges: the sidecar's `monitor_submission.sh` polls and PUTs `submission_status="failed"` ("Execution time limit exceeded") once `SUBMISSION_TIME_LIMIT` is hit;
- code-upload challenges: the challenge's environment image is expected to honor `SUBMISSION_TIME_LIMIT`.

If that in-pod timeout hangs, or the environment image ignores the env var, the EKS Job could run indefinitely — the `V1JobSpec` set no `activeDeadlineSeconds`. This adds a Kubernetes-enforced hard backstop so a runaway Job is terminated regardless of script/image cooperation.

## Why a buffer instead of the exact limit

Setting `activeDeadlineSeconds` exactly equal to `submission_time_limit` would let Kubernetes kill the pod at the same instant the cooperative path tries to PUT `failed`, risking submissions that get hard-killed and never report "Execution time limit exceeded". The buffer keeps the graceful failed-report path winning in the normal case; Kubernetes only steps in when the in-pod timeout actually fails. The buffer also absorbs init-container setup time, since `activeDeadlineSeconds` counts from Job start (including init containers) while the in-pod counter starts after init.

## Reviewer notes

- **Behavior unchanged in the happy path** — the cooperative timeout still fires first and reports the failure; this only guarantees termination when it doesn't.
- **Worker restart still required to change a challenge's limit.** `submission_time_limit` is read once at worker boot (outside the SQS loop), so editing it on the challenge needs a worker pod restart. This PR does not change that.
- **Buffer is tunable** via the `ACTIVE_DEADLINE_BUFFER_SECONDS` env var on the worker; default 300s.
- No linked issue.

## Testing

- Updated the two `V1JobSpec` unit assertions in `tests/unit/worker/test_code_upload_submission_worker.py` to expect `active_deadline_seconds` (`3600 + 300 = 3900`).
- `test_create_job_object` and `test_create_static_code_upload_submission_job_object` pass.
- Pre-existing `main()` tests that read a hardcoded `/code/...` manifest path only pass inside the Docker test container and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes submission Job lifecycle and termination timing on EKS; mis-tuned buffer could kill Jobs before graceful failure reporting, though defaults and validation aim to prevent API/job-creation failures.
> 
> **Overview**
> Adds a **Kubernetes-enforced hard timeout** on code-upload EKS submission Jobs by setting `active_deadline_seconds` on `V1JobSpec` in both `create_job_object` and `create_static_code_upload_submission_job_object`.
> 
> The deadline is **`submission_time_limit` plus a configurable buffer** (default **300s** via `ACTIVE_DEADLINE_BUFFER_SECONDS`), so in-pod cooperative timeouts can still report `failed` before the cluster kills the Job; Kubernetes only steps in when that path hangs or init time eats into the wall clock.
> 
> New helpers **`get_active_deadline_buffer_seconds`** and **`get_active_deadline_seconds`** validate the env override (malformed/negative values fall back with a warning) and **clamp the deadline to at least 1** so the API never gets a rejected zero deadline. Unit tests cover buffer parsing and pin buffer in existing job-builder tests (`3900` for a 3600s limit).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc08cd139012d1c5e2fd56c448d942cb4e3eda93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time-limit handling for code-upload jobs by adding a configurable buffer before jobs are automatically terminated.
  * Applied the buffer consistently to regular and static code-upload submissions.
  * Added validation for the buffer setting, with a safe default used when values are missing, invalid, or negative.
  * Ensured jobs always receive a positive termination deadline while preserving existing retry and termination-grace behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->