### PR TITLE
fix(settings): suppress challenge-script logger noise in Sentry

### DIFF
--- a/settings/prod.py
+++ b/settings/prod.py
@@ -17,7 +17,21 @@ if (
 
 
 def _sentry_before_send(event, hint):
-    """Filter out OSError: write error (broken pipe) - harmless client disconnects."""
+    """Drop noise before it becomes a Sentry issue.
+
+    1. OSError write/broken-pipe errors - harmless client disconnects.
+    2. Log records emitted by challenge evaluation scripts. The submission
+       worker imports and runs host-uploaded scripts in-process under the
+       ``challenge_data.challenge_<id>`` logger namespace, so any
+       ``logger.error(...)`` a challenge host leaves in their code would
+       otherwise surface as a high-priority EvalAI issue we cannot fix.
+       Genuine evaluate() failures still reach Sentry via the worker's own
+       ``logger.exception(...)`` wrappers and the ``evaluation_module_error``
+       field on the Challenge.
+    """
+    if str(event.get("logger", "")).startswith("challenge_data"):
+        return None
+
     exc_info = hint.get("exc_info")
     if exc_info:
         exc_type, exc_value = exc_info[0], exc_info[1]


### PR DESCRIPTION
## What

Drop Sentry events whose originating logger starts with `challenge_data` in `_sentry_before_send` (`settings/prod.py`).

## Why

The submission worker imports and runs **host-uploaded** challenge evaluation scripts in-process, under the `challenge_data.challenge_<id>` logger namespace. Sentry's default `LoggingIntegration` promotes any `ERROR`-level log record to an event. So when a challenge host leaves a `logger.error(...)` in their script (e.g. a debug `os.listdir('/')` dump), it surfaces as a **High priority** EvalAI Sentry issue with no traceback — noise we cannot fix, because the code lives in the uploaded challenge, not this repo.

Observed example (Sentry): logger `challenge_data.challenge_2319.main`, message `Checking root: ['lib', 'boot', ... 'code']`, level Error, no exception.

## What is preserved

- Genuine `evaluate()` failures still reach Sentry via the worker's own `logger.exception(...)` wrappers (`scripts.workers.*`) and the `evaluation_module_error` field on the Challenge.
- Django/app errors are untouched.
- The existing broken-pipe `OSError` filter is untouched.
- Breadcrumbs are preserved — `before_send` runs on events only, so challenge `info` logs still attach as context to real worker exceptions.

## Notes for reviewer

- Chose `before_send` over `ignore_logger("challenge_data.*")` deliberately: `ignore_logger` suppresses breadcrumbs too, whereas `before_send` only drops the standalone event.
- Only affects **new** events; existing issues should be resolved/ignored in the Sentry UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow production-only Sentry noise filter; genuine evaluation failures are still reported via worker exception logging.
> 
> **Overview**
> **Production Sentry filtering** in `_sentry_before_send` now drops events when the event’s `logger` starts with `challenge_data`, so `ERROR` logs from in-process host evaluation scripts no longer open standalone high-priority issues.
> 
> The hook’s docstring is expanded to document this alongside the existing broken-pipe `OSError` filter. **Unchanged:** worker `logger.exception` paths, `evaluation_module_error`, Django errors, and breadcrumbs from challenge logs on real exceptions (events only are filtered).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9cefd2b7286293b2113f484772fa03c899d8761. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noise from harmless logging events in error monitoring.
  * Continued reporting genuine challenge evaluation failures for investigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->