### PR TITLE
Install Java in production submission worker images so PTBTokenizer can run

### DIFF
--- a/docker/prod/worker_py3_7/Dockerfile
+++ b/docker/prod/worker_py3_7/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && \
      libfreetype6-dev \
      liblcms2-dev \
      libwebp-dev \
+     default-jre-headless \
      git \
      cmake \
      libeigen3-dev \
@@ -48,6 +49,7 @@ RUN apt-get update && \
          libfreetype6-dev \
          liblcms2-dev \
          libwebp-dev \
+         default-jre-headless \
          git \
          cmake \
          libeigen3-dev \
@@ -102,6 +104,7 @@ ENV PYTHONUNBUFFERED=1 \
 # Note: We copy OpenCV libs from builder to avoid python3-opencv dependency issues
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+    default-jre-headless \
     libpq5 \
     libcurl4 \
     libjpeg62-turbo \

--- a/docker/prod/worker_py3_8/Dockerfile
+++ b/docker/prod/worker_py3_8/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && \
      libfreetype6-dev \
      liblcms2-dev \
      libwebp-dev \
+     default-jre-headless \
      git \
      cmake \
      libeigen3-dev \
@@ -48,6 +49,7 @@ RUN apt-get update && \
          libfreetype6-dev \
          liblcms2-dev \
          libwebp-dev \
+         default-jre-headless \
          git \
          cmake \
          libeigen3-dev \
@@ -100,6 +102,7 @@ ENV PYTHONUNBUFFERED=1 \
 # Note: We copy OpenCV libs from builder to avoid python3-opencv dependency issues
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+    default-jre-headless \
     libpq5 \
     libcurl4 \
     libjpeg62-turbo \

--- a/docker/prod/worker_py3_9/Dockerfile
+++ b/docker/prod/worker_py3_9/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && \
      libfreetype6-dev \
      liblcms2-dev \
      libwebp-dev \
+     default-jre-headless \
      git \
      cmake \
      libeigen3-dev \
@@ -49,6 +50,7 @@ RUN apt-get update && \
          libfreetype6-dev \
          liblcms2-dev \
          libwebp-dev \
+         default-jre-headless \
          git \
          cmake \
          libeigen3-dev \
@@ -105,6 +107,7 @@ ENV PYTHONUNBUFFERED=1 \
 # Note: We copy OpenCV libs from builder to avoid python3-opencv dependency issues
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+    default-jre-headless \
     libpq5 \
     libcurl4 \
     libjpeg62-turbo \


### PR DESCRIPTION
## Problem

A submission on a caption challenge (reported for NoCaps, submission 579668 / challenge 355 / phase 743) failed during evaluation with:

```
FileNotFoundError: [Errno 2] No such file or directory: 'java'
```

The input file loaded fine; the failure came from `PTBTokenizer`. `PTBTokenizer` is bundled inside `pycocoevalcap` (installed per-challenge for caption metrics like BLEU/METEOR/CIDEr/SPICE) and shells out to the `java` binary at evaluation time. The production submission worker container has no JRE, so the tokenizer subprocess cannot start.

## Root cause

The `java` runtime lives in the worker image, not the challenge requirements. The **dev** worker images already install `default-jre-headless`, but the **production** worker images do not:

```
$ grep -c jre docker/dev/worker_py3_*/Dockerfile     # 3, 3, 3
$ grep -c jre docker/prod/worker_py3_*/Dockerfile    # 0, 0, 0  (before this PR)
```

All six worker Dockerfiles were created together in #5133, but only the dev variants included the JRE — the prod variants were left without it, so any challenge that relies on `PTBTokenizer` works locally yet fails in production.

## Fix

Add `default-jre-headless` to the three production submission worker Dockerfiles, matching the existing dev images:

- `docker/prod/worker_py3_7/Dockerfile`
- `docker/prod/worker_py3_8/Dockerfile`
- `docker/prod/worker_py3_9/Dockerfile`

In each file the package is added to the runtime stage (the load-bearing change — the multi-stage build discards the builder's apt packages, and `PTBTokenizer` invokes `java` at runtime) and to both builder-stage `apt-get` blocks, keeping the prod files byte-for-byte parallel with their dev counterparts so the two do not silently diverge again.

These are the images deployed for the EvalAI-managed submission workers (`evalai-{env}-worker-py{version}`, per `docker-compose-production.yml` / `docker-compose-staging.yml`). The `remote-worker` service reuses the py3.7 image, so it inherits the fix as well. The separate `code-upload-worker` image is unaffected and does not need this.

## Testing

- `default-jre-headless` provides `/usr/bin/java`, which is what `pycocoevalcap.tokenizer.ptbtokenizer` calls; the same package already backs the dev worker images that run these challenges successfully.
- Verified prod worker Dockerfiles now match dev (`grep -c jre` returns 3 for every worker Dockerfile).
- Change is limited to Dockerfiles; no application code paths are affected. Full verification requires rebuilding and redeploying the production worker images, after which challenge 355's failed submission can be re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192WQSRHtyYtpqYXNRdDYPg

---
_Generated by [Claude Code](https://claude.ai/code/session_0192WQSRHtyYtpqYXNRdDYPg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production evaluation worker images (runtime OS packages). Low logic risk, but a rebuild/redeploy is required and image size/attack surface grow slightly with a JRE.
> 
> **Overview**
> Adds `default-jre-headless` to the production Python 3.7/3.8/3.9 submission worker images so caption evaluation (`pycocoevalcap` / `PTBTokenizer`) can invoke `java` at runtime.
> 
> The package is installed in both builder apt blocks (to stay aligned with the existing **dev** worker Dockerfiles) and in the **runtime** stage, which is the load-bearing change because the multi-stage build discards builder packages. No application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 166aab6ead05ee5ffa5fccba917424c2e6910a10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker image compatibility by including the required Java runtime in supported Python 3.7, 3.8, and 3.9 production images.
  * Ensured Java is available during both image setup and runtime execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->