### PR TITLE
feat(deploy): add health endpoint and move release steps out of container start

### DIFF
--- a/apps/base/views.py
+++ b/apps/base/views.py
@@ -1,1 +1,14 @@
-# Create your views here.
+from django.http import JsonResponse
+
+
+def health_check(request):
+    """
+    Liveness probe for the load balancer target group.
+
+    Deliberately does not touch the database, cache or any other dependency.
+    A load balancer health check answers one question -- "is this process
+    still serving?" -- and folding dependency checks into it means an RDS or
+    ElastiCache blip drains every application target at once instead of
+    raising the alarm that actually owns that dependency.
+    """
+    return JsonResponse({"status": "ok"})

--- a/docker/prod/django/container-start.sh
+++ b/docker/prod/django/container-start.sh
@@ -9,8 +9,13 @@ if [ -z "$UWSGI_PROCESSES" ]; then
     fi
 fi
 
-python manage.py migrate --noinput  && \
-python manage.py collectstatic --noinput  && \
+# No migrate/collectstatic here on purpose. Both are release steps that must
+# run exactly once per deploy, not once per container: two containers booting
+# together race on CREATE TABLE (pg_type_typname_nsp_index), and collectstatic
+# uploads to S3, so every extra container repeats the same upload. The deploy
+# pipeline runs them as one-off tasks before starting the service -- see the
+# prepare-release operation in scripts/deployment/deploy.sh. This is also what
+# lets the service run more than one container at a time.
 if [ "$UWSGI_PROCESSES" -eq 1 ]; then
     # Don't use cheaper autoscaling when only 1 process (cheaper must be < processes)
     uwsgi --ini /code/docker/prod/django/uwsgi.ini --processes ${UWSGI_PROCESSES}

--- a/evalai/urls.py
+++ b/evalai/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 
 from accounts.views import SafePasswordResetView, SafeRegisterView
 from allauth.account.views import ConfirmEmailView
+from base.views import health_check
 from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
@@ -39,6 +40,9 @@ redoc_view = SpectacularRedocView.as_view(url_name="schema")
 
 urlpatterns = [
     url(r"^$", views.home, name="home"),
+    # Kept under /api/ so the same URL answers both a direct load balancer
+    # target check and a request routed through the CDN's /api/* behaviour.
+    url(r"^api/health/$", health_check, name="health_check"),
     url(r"^api/allauth/accounts/", include("allauth.urls")),
     url(r"^api/admin/", admin.site.urls),
     url(

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -171,11 +171,14 @@ if [[ "\${DRY_RUN_DEPLOYMENT}" == "true" ]]; then
 fi
 
 docker compose -f "docker-compose-\${TARGET_ENVIRONMENT}.yml" pull django nodejs celery memcached
-# Run migrations before starting django. container-start.sh also calls migrate on
-# startup; running both concurrently races on CREATE TABLE (pg_type_typname_nsp_index).
-# Detach stdin so compose cannot consume the remaining commands from the SSH heredoc.
+# Release steps run once here, before any application container starts, because
+# container-start.sh no longer runs them per container. Detach stdin so compose
+# cannot consume the remaining commands from the SSH heredoc.
 docker compose -f "docker-compose-\${TARGET_ENVIRONMENT}.yml" run --rm \
   django python manage.py migrate --noinput \
+  </dev/null
+docker compose -f "docker-compose-\${TARGET_ENVIRONMENT}.yml" run --rm \
+  django python manage.py collectstatic --noinput \
   </dev/null
 docker compose -f "docker-compose-\${TARGET_ENVIRONMENT}.yml" up -d --force-recreate --remove-orphans django nodejs celery memcached
 
@@ -206,8 +209,22 @@ case "${operation_name}" in
         docker compose -f "docker-compose-${target_environment}.yml" pull
         echo "Completed pull operation."
         ;;
+    prepare-release)
+        validate_target_environment
+        echo "Applying database migrations..."
+        docker compose -f "docker-compose-${target_environment}.yml" run --rm \
+            django python manage.py migrate --noinput \
+            </dev/null
+        echo "Collecting static files..."
+        docker compose -f "docker-compose-${target_environment}.yml" run --rm \
+            django python manage.py collectstatic --noinput \
+            </dev/null
+        echo "Completed prepare-release operation."
+        ;;
     deploy-django)
         validate_target_environment
+        # Run prepare-release first when the image carries new migrations or
+        # static assets; the django container no longer applies them on start.
         echo "Deploying django docker container..."
         docker compose -f "docker-compose-${target_environment}.yml" up -d django
         echo "Completed deploy operation."
@@ -347,11 +364,12 @@ case "${operation_name}" in
         ;;
     *)
         echo "EvalAI deployment utility script"
-        echo "Usage: $0 {auto_deploy|pull|deploy-django|deploy-nodejs|deploy-nodejs-v2|deploy-celery|deploy-worker|deploy-worker-py3-8|deploy-remote-worker|deploy-workers|scale|clean} [environment]"
+        echo "Usage: $0 {auto_deploy|pull|prepare-release|deploy-django|deploy-nodejs|deploy-nodejs-v2|deploy-celery|deploy-worker|deploy-worker-py3-8|deploy-remote-worker|deploy-workers|scale|clean} [environment]"
         echo
         echo "Examples:"
         echo "  ./scripts/deployment/deploy.sh auto_deploy"
         echo "  ./scripts/deployment/deploy.sh pull production"
+        echo "  ./scripts/deployment/deploy.sh prepare-release production"
         echo "  ./scripts/deployment/deploy.sh deploy-django production"
         echo "  ./scripts/deployment/deploy.sh deploy-nodejs production"
         echo "  ./scripts/deployment/deploy.sh deploy-celery production"

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -58,6 +58,29 @@ aws_login() {
         docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}.dkr.ecr.${aws_region}.amazonaws.com"
 }
 
+prepare_release_for_environment() {
+    local environment="$1"
+
+    # Pull before migrating. container-start.sh no longer runs these, so the
+    # image resolved here is the one whose migrations get applied -- and
+    # COMMIT_ID falls back to "latest", so a stale local image would otherwise
+    # write a schema nobody asked for. aws_login also fails fast when
+    # AWS_ACCOUNT_ID is unset.
+    aws_login
+    echo "Pulling django image (COMMIT_ID=${COMMIT_ID})..."
+    docker compose -f "docker-compose-${environment}.yml" pull django
+
+    # Detach stdin so compose cannot swallow the caller's remaining input.
+    echo "Applying database migrations..."
+    docker compose -f "docker-compose-${environment}.yml" run --rm \
+        django python manage.py migrate --noinput \
+        </dev/null
+    echo "Collecting static files..."
+    docker compose -f "docker-compose-${environment}.yml" run --rm \
+        django python manage.py collectstatic --noinput \
+        </dev/null
+}
+
 get_evalai_api_base_url() {
     if [[ "${target_environment}" == "staging" ]]; then
         echo "https://staging.eval.ai"
@@ -211,20 +234,15 @@ case "${operation_name}" in
         ;;
     prepare-release)
         validate_target_environment
-        echo "Applying database migrations..."
-        docker compose -f "docker-compose-${target_environment}.yml" run --rm \
-            django python manage.py migrate --noinput \
-            </dev/null
-        echo "Collecting static files..."
-        docker compose -f "docker-compose-${target_environment}.yml" run --rm \
-            django python manage.py collectstatic --noinput \
-            </dev/null
+        prepare_release_for_environment "${target_environment}"
         echo "Completed prepare-release operation."
         ;;
     deploy-django)
         validate_target_environment
-        # Run prepare-release first when the image carries new migrations or
-        # static assets; the django container no longer applies them on start.
+        # container-start.sh no longer migrates or collects static on boot, so
+        # this standalone path has to do it or it would start django against an
+        # unapplied schema and stale static assets.
+        prepare_release_for_environment "${target_environment}"
         echo "Deploying django docker container..."
         docker compose -f "docker-compose-${target_environment}.yml" up -d django
         echo "Completed deploy operation."

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -5,6 +5,12 @@ operation_name="${1:-}"
 target_environment="${2:-${DEPLOYMENT_BRANCH_NAME:-${GITHUB_REF_NAME:-}}}"
 dry_run_deployment="${DRY_RUN_DEPLOYMENT:-false}"
 aws_region="${AWS_REGION:-us-east-1}"
+# The compose files pin every image to a dkr.ecr.us-east-1 host, so ECR
+# authentication has to target that region even when AWS_REGION points
+# elsewhere. Logging in against AWS_REGION mints a token for a different
+# registry and the pull then fails to authenticate. AWS_REGION still drives
+# the CLI default region for everything else (s3, ecs, ...).
+ecr_registry_region="us-east-1"
 
 if [[ -z "${COMMIT_ID:-}" ]]; then
     export COMMIT_ID="latest"
@@ -54,8 +60,8 @@ resolve_deployment_instance_host() {
 aws_login() {
     require_variable AWS_ACCOUNT_ID
     aws configure set default.region "${aws_region}"
-    aws ecr get-login-password --region "${aws_region}" | \
-        docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}.dkr.ecr.${aws_region}.amazonaws.com"
+    aws ecr get-login-password --region "${ecr_registry_region}" | \
+        docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}.dkr.ecr.${ecr_registry_region}.amazonaws.com"
 }
 
 prepare_release_for_environment() {
@@ -181,10 +187,13 @@ cd ~/Projects/EvalAI
 export AWS_ACCOUNT_ID="${AWS_ACCOUNT_ID}"
 export COMMIT_ID="${COMMIT_ID}"
 export AWS_DEFAULT_REGION="${aws_region}"
+export ECR_REGISTRY_REGION="${ecr_registry_region}"
 export TARGET_ENVIRONMENT="${target_environment}"
 export DRY_RUN_DEPLOYMENT="${dry_run_deployment}"
 
-aws ecr get-login-password --region "\${AWS_DEFAULT_REGION}" | docker login --username AWS --password-stdin "\${AWS_ACCOUNT_ID}.dkr.ecr.\${AWS_DEFAULT_REGION}.amazonaws.com"
+# Authenticate against the registry region the compose files actually pin, not
+# AWS_DEFAULT_REGION -- see ecr_registry_region in scripts/deployment/deploy.sh.
+aws ecr get-login-password --region "\${ECR_REGISTRY_REGION}" | docker login --username AWS --password-stdin "\${AWS_ACCOUNT_ID}.dkr.ecr.\${ECR_REGISTRY_REGION}.amazonaws.com"
 aws s3 cp "s3://cloudcv-secrets/evalai/\${TARGET_ENVIRONMENT}/docker_\${TARGET_ENVIRONMENT}.env" "./docker/prod/docker_\${TARGET_ENVIRONMENT}.env"
 
 if [[ "\${DRY_RUN_DEPLOYMENT}" == "true" ]]; then

--- a/tests/unit/base/test_health_view.py
+++ b/tests/unit/base/test_health_view.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+from django.urls import reverse
+
+
+class TestHealthCheckView(TestCase):
+    """
+    The load balancer target group health check calls this endpoint, so it
+    must answer unauthenticated requests and must not depend on the database.
+    """
+
+    def test_health_check_returns_ok_for_anonymous_requests(self):
+        response = self.client.get(reverse("health_check"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok"})
+
+    def test_health_check_does_not_query_the_database(self):
+        # A database blip must not fail the health check, otherwise the load
+        # balancer would drain every healthy target at the same time.
+        with self.assertNumQueries(0):
+            self.client.get(reverse("health_check"))

--- a/tests/unit/base/test_health_view.py
+++ b/tests/unit/base/test_health_view.py
@@ -9,6 +9,10 @@ class TestHealthCheckView(TestCase):
     """
 
     def test_health_check_returns_ok_for_anonymous_requests(self):
+        # The literal path is part of the contract: it is configured on the
+        # target group, so renaming the route silently breaks health checks.
+        self.assertEqual(reverse("health_check"), "/api/health/")
+
         response = self.client.get(reverse("health_check"))
 
         self.assertEqual(response.status_code, 200)
@@ -16,6 +20,9 @@ class TestHealthCheckView(TestCase):
 
     def test_health_check_does_not_query_the_database(self):
         # A database blip must not fail the health check, otherwise the load
-        # balancer would drain every healthy target at the same time.
+        # balancer would drain every healthy target at the same time. Assert
+        # the status inside the block too, so an error response that happens
+        # to make no query cannot pass this test.
         with self.assertNumQueries(0):
-            self.client.get(reverse("health_check"))
+            response = self.client.get(reverse("health_check"))
+            self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Why

Groundwork for running the core application tier (django/celery) as more than one container behind a load balancer. Today all of it runs as a single `docker compose` stack on one `t3a.medium`, so there is no way to scale out or survive losing the box.

Two things block a second django container today. This PR removes both. No architecture is changed here — the deployment topology is untouched and this is safe to ship on the current single-instance setup.

## What

**1. `GET /api/health/` — dependency-free liveness probe**

A load balancer target group needs an endpoint to poll. It deliberately does **not** touch the database or cache: a health check answers "is this process still serving?", and folding dependency checks into it means an RDS or ElastiCache blip drains every application target at once instead of raising the alarm that actually owns that dependency.

Kept under `/api/` so the same URL answers both a direct target check and a request routed through a CDN `/api/*` behaviour later.

**2. `migrate` / `collectstatic` moved out of container start**

`docker/prod/django/container-start.sh` ran both on every container boot. Both are once-per-*release* steps, not once-per-*container*:

- Concurrent boots race on `CREATE TABLE` (`pg_type_typname_nsp_index`). This race is already documented in `deploy.sh`, which added a pre-start `migrate` to work around it — so migrate was running twice per deploy.
- `settings/prod.py` sets `STATICFILES_STORAGE` to S3, so `collectstatic` **uploads**. Every extra container repeats the same upload. This is also why it can't simply move to image build time — it needs AWS credentials at run time.

Both now run as one-off tasks in `auto_deploy` before the service starts, and are exposed as a reusable `prepare-release` operation so manual deploy paths (`deploy-django`) keep the same gate.

## Test plan

- New `tests/unit/base/test_health_view.py`, written test-first (both cases confirmed failing on `NoReverseMatch` before the view existed):
  - returns `200 {"status": "ok"}` unauthenticated
  - `assertNumQueries(0)` — pins the no-database property so a future "improvement" that adds a DB probe fails the build
- Full suite green: **2102 passed** (`pytest tests/`)
- `black` / `isort` / `flake8` clean, `pylint` 10.00/10
- `bash -n` / `sh -n` on both shell scripts

## Follow-up needed before wiring up a load balancer

`settings/prod.py` pins `ALLOWED_HOSTS = ["eval.ai"]`. ALB health checks reach targets by private IP with a matching `Host` header, and ALB does not support custom health-check headers — so Django will return 400 and every target will be marked unhealthy. That needs its own change (append the task IP from `ECS_CONTAINER_METADATA_URI_V4`, or an env-driven `ALLOWED_HOSTS` extension) and is out of scope here.

Separately, `settings/common.py` defines a `beat_schedule`, but no `celery beat` process runs in any prod compose file — those scheduled tasks appear to never fire today. Whenever beat is introduced it must stay a singleton and never be autoscaled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deploy behavior changes when migrations and collectstatic run; any path that starts Django without `prepare-release`/`auto_deploy` could boot against an unapplied schema or stale static assets.
> 
> **Overview**
> Prepares for running multiple Django containers behind a load balancer without changing the current single-instance topology.
> 
> **Liveness probe:** Adds unauthenticated `GET /api/health/` returning `{"status": "ok"}`, intentionally with no database or cache checks so dependency outages do not drain all targets. Route lives under `/api/` for future CDN routing.
> 
> **Release steps:** Removes `migrate` and `collectstatic` from `container-start.sh` so they run once per deploy (avoiding migration races and duplicate S3 static uploads). `deploy.sh` now runs both via one-off compose tasks in `auto_deploy`, exposes a `prepare-release` operation, and runs the same gate before standalone `deploy-django`. ECR login is fixed to authenticate against `us-east-1` to match compose image hosts when `AWS_REGION` differs.
> 
> **Tests:** Unit tests lock the health URL, 200 response, and zero DB queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97484c6b9463c371351d24d52f8e24c300425015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a health-check endpoint that returns an “ok” status without requiring authentication or database access.

* **Deployment Improvements**
  * Database migrations and static asset collection now run once during release preparation, improving deployment consistency.
  * Added a dedicated release-preparation step to deployment workflows.

* **Tests**
  * Added coverage for the health-check response, routing, status code, and database-free operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->