### PR TITLE
Retry apt-get install in prod worker and service images to survive transient Debian mirror failures

### DIFF
--- a/docker/prod/celery/Dockerfile
+++ b/docker/prod/celery/Dockerfile
@@ -7,8 +7,11 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install build dependencies only (if any native extensions)
+# Add retry logic and --fix-missing to handle transient network issues
+# Fix any broken dependencies first (from partial installs)
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt --fix-broken install -y || true && \
+    (apt-get install -y --no-install-recommends --fix-missing \
     build-essential \
     libpq-dev \
     libcurl4-openssl-dev \
@@ -20,7 +23,21 @@ RUN apt-get update && \
     libfreetype6-dev \
     liblcms2-dev \
     libwebp-dev \
-    && rm -rf /var/lib/apt/lists/*
+    || (apt-get update && \
+        apt --fix-broken install -y || true && \
+        apt-get install -y --no-install-recommends --fix-missing \
+        build-essential \
+        libpq-dev \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libjpeg-dev \
+        zlib1g-dev \
+        libpng-dev \
+        libtiff-dev \
+        libfreetype6-dev \
+        liblcms2-dev \
+        libwebp-dev)) && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
 
@@ -45,8 +62,11 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
+# Add retry logic and --fix-missing to handle transient network issues
+# Fix any broken dependencies first (from partial installs)
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt --fix-broken install -y || true && \
+    (apt-get install -y --no-install-recommends --fix-missing \
     libpq5 \
     libcurl4 \
     libjpeg62-turbo \
@@ -55,7 +75,19 @@ RUN apt-get update && \
     libtiff5 \
     libfreetype6 \
     liblcms2-2 \
-    libwebp6 && \
+    libwebp6 \
+    || (apt-get update && \
+        apt --fix-broken install -y || true && \
+        apt-get install -y --no-install-recommends --fix-missing \
+        libpq5 \
+        libcurl4 \
+        libjpeg62-turbo \
+        zlib1g \
+        libpng16-16 \
+        libtiff5 \
+        libfreetype6 \
+        liblcms2-2 \
+        libwebp6)) && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/code-upload-worker/Dockerfile
+++ b/docker/prod/code-upload-worker/Dockerfile
@@ -7,11 +7,19 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install build dependencies
+# Add retry logic and --fix-missing to handle transient network issues
+# Fix any broken dependencies first (from partial installs)
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt --fix-broken install -y || true && \
+    (apt-get install -y --no-install-recommends --fix-missing \
     build-essential \
     unzip \
-    && rm -rf /var/lib/apt/lists/*
+    || (apt-get update && \
+        apt --fix-broken install -y || true && \
+        apt-get install -y --no-install-recommends --fix-missing \
+        build-essential \
+        unzip)) && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
 
@@ -37,12 +45,22 @@ ENV PYTHONUNBUFFERED=1 \
 # Install runtime dependencies (apt-get handles multi-arch automatically)
 # Note: curl and unzip are needed by install_dependencies.sh; git is required
 # for kubectl apply -k with github.com kustomize remote bases.
+# Add retry logic and --fix-missing to handle transient network issues
+# Fix any broken dependencies first (from partial installs)
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt --fix-broken install -y || true && \
+    (apt-get install -y --no-install-recommends --fix-missing \
     curl \
     unzip \
     git \
-    ca-certificates && \
+    ca-certificates \
+    || (apt-get update && \
+        apt --fix-broken install -y || true && \
+        apt-get install -y --no-install-recommends --fix-missing \
+        curl \
+        unzip \
+        git \
+        ca-certificates)) && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/django/Dockerfile
+++ b/docker/prod/django/Dockerfile
@@ -7,8 +7,11 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install build dependencies only
+# Add retry logic and --fix-missing to handle transient network issues
+# Fix any broken dependencies first (from partial installs)
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt --fix-broken install -y || true && \
+    (apt-get install -y --no-install-recommends --fix-missing \
     build-essential \
     libpq-dev \
     libcurl4-openssl-dev \
@@ -20,7 +23,21 @@ RUN apt-get update && \
     libfreetype6-dev \
     liblcms2-dev \
     libwebp-dev \
-    && rm -rf /var/lib/apt/lists/*
+    || (apt-get update && \
+        apt --fix-broken install -y || true && \
+        apt-get install -y --no-install-recommends --fix-missing \
+        build-essential \
+        libpq-dev \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libjpeg-dev \
+        zlib1g-dev \
+        libpng-dev \
+        libtiff-dev \
+        libfreetype6-dev \
+        liblcms2-dev \
+        libwebp-dev)) && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
 
@@ -45,8 +62,11 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
+# Add retry logic and --fix-missing to handle transient network issues
+# Fix any broken dependencies first (from partial installs)
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt --fix-broken install -y || true && \
+    (apt-get install -y --no-install-recommends --fix-missing \
     libpq5 \
     libcurl4 \
     libjpeg62-turbo \
@@ -55,7 +75,19 @@ RUN apt-get update && \
     libtiff5 \
     libfreetype6 \
     liblcms2-2 \
-    libwebp6 && \
+    libwebp6 \
+    || (apt-get update && \
+        apt --fix-broken install -y || true && \
+        apt-get install -y --no-install-recommends --fix-missing \
+        libpq5 \
+        libcurl4 \
+        libjpeg62-turbo \
+        zlib1g \
+        libpng16-16 \
+        libtiff5 \
+        libfreetype6 \
+        liblcms2-2 \
+        libwebp6)) && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/worker_py3_7/Dockerfile
+++ b/docker/prod/worker_py3_7/Dockerfile
@@ -102,8 +102,11 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
 # Note: We copy OpenCV libs from builder to avoid python3-opencv dependency issues
+# Add retry logic and --fix-missing to handle transient network issues
+# Fix any broken dependencies first (from partial installs)
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt --fix-broken install -y || true && \
+    (apt-get install -y --no-install-recommends --fix-missing \
     default-jre-headless \
     libpq5 \
     libcurl4 \
@@ -116,7 +119,23 @@ RUN apt-get update && \
     libwebp6 \
     libgmp10 \
     libgl1 \
-    libglib2.0-0 && \
+    libglib2.0-0 \
+    || (apt-get update && \
+        apt --fix-broken install -y || true && \
+        apt-get install -y --no-install-recommends --fix-missing \
+        default-jre-headless \
+        libpq5 \
+        libcurl4 \
+        libjpeg62-turbo \
+        zlib1g \
+        libpng16-16 \
+        libtiff5 \
+        libfreetype6 \
+        liblcms2-2 \
+        libwebp6 \
+        libgmp10 \
+        libgl1 \
+        libglib2.0-0)) && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/worker_py3_8/Dockerfile
+++ b/docker/prod/worker_py3_8/Dockerfile
@@ -100,8 +100,11 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
 # Note: We copy OpenCV libs from builder to avoid python3-opencv dependency issues
+# Add retry logic and --fix-missing to handle transient network issues
+# Fix any broken dependencies first (from partial installs)
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt --fix-broken install -y || true && \
+    (apt-get install -y --no-install-recommends --fix-missing \
     default-jre-headless \
     libpq5 \
     libcurl4 \
@@ -114,7 +117,23 @@ RUN apt-get update && \
     libwebp6 \
     libgmp10 \
     libgl1 \
-    libglib2.0-0 && \
+    libglib2.0-0 \
+    || (apt-get update && \
+        apt --fix-broken install -y || true && \
+        apt-get install -y --no-install-recommends --fix-missing \
+        default-jre-headless \
+        libpq5 \
+        libcurl4 \
+        libjpeg62-turbo \
+        zlib1g \
+        libpng16-16 \
+        libtiff5 \
+        libfreetype6 \
+        liblcms2-2 \
+        libwebp6 \
+        libgmp10 \
+        libgl1 \
+        libglib2.0-0)) && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/worker_py3_9/Dockerfile
+++ b/docker/prod/worker_py3_9/Dockerfile
@@ -105,8 +105,11 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
 # Note: We copy OpenCV libs from builder to avoid python3-opencv dependency issues
+# Add retry logic and --fix-missing to handle transient network issues
+# Fix any broken dependencies first (from partial installs)
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt --fix-broken install -y || true && \
+    (apt-get install -y --no-install-recommends --fix-missing \
     default-jre-headless \
     libpq5 \
     libcurl4 \
@@ -119,7 +122,23 @@ RUN apt-get update && \
     libwebp6 \
     libgmp10 \
     libgl1 \
-    libglib2.0-0 && \
+    libglib2.0-0 \
+    || (apt-get update && \
+        apt --fix-broken install -y || true && \
+        apt-get install -y --no-install-recommends --fix-missing \
+        default-jre-headless \
+        libpq5 \
+        libcurl4 \
+        libjpeg62-turbo \
+        zlib1g \
+        libpng16-16 \
+        libtiff5 \
+        libfreetype6 \
+        liblcms2-2 \
+        libwebp6 \
+        libgmp10 \
+        libgl1 \
+        libglib2.0-0)) && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 


### PR DESCRIPTION
## What

Applies the retry / `--fix-missing` pattern already used in `docker/prod/nodejs/Dockerfile` to the nine remaining `apt-get install` layers across the production worker and service images.

## Why

Transient Debian mirror failures abort production image builds. A recent CI run (job `99004112589` on https://github.com/Cloud-CV/EvalAI/pull/5205) failed during the `worker_py3_9` build:

```
E: Failed to fetch http://deb.debian.org/debian/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_amd64.deb  Error reading from server - read (104: Connection reset by peer)
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

This killed the whole **Code quality and migrations** job before a single linter ran. A re-run passed, so it is purely transient — but it will recur.

## Where the actual gap was

The worker Dockerfiles were **not** entirely unguarded — their **builder** stages already had the retry pattern. The gap was the **stage 2 runtime** layers.

`libbrotli1` arrives as a `libfreetype6` dependency, and `libfreetype6` is installed in *both* stages. The builder stage was covered; the runtime stage was not. That is the layer that broke.

| File | Builder stage | Runtime stage |
| --- | --- | --- |
| `worker_py3_7` | already guarded | **added** |
| `worker_py3_8` | already guarded | **added** |
| `worker_py3_9` | already guarded | **added** |
| `code-upload-worker` | **added** | **added** |
| `django` | **added** | **added** |
| `celery` | **added** | **added** |

## How

Pattern copied verbatim from `docker/prod/nodejs/Dockerfile` rather than inventing a new one — `apt --fix-broken install -y || true`, `--fix-missing`, and an `|| ( ... )` block repeating `apt-get update` plus the full package list. No package lists, versions, or install flags were otherwise changed.

## Verification

- `docker build --check` — no warnings on all seven prod Dockerfiles (including the untouched `nodejs`).
- `docker build -f <dockerfile> .` — all six modified images build successfully (linux/arm64, bullseye).

`docker compose -f docker-compose-production.yml build` could not be used locally because `docker/prod/docker_production.env` is not in the repo (only `.example`), and compose resolves `env_file` before building. `docker build` is what compose invokes anyway, so coverage is equivalent.

## Notes for the reviewer

Two things worth knowing, neither of which is changed here:

1. **The retry has no backoff.** Both attempts fire within seconds of each other, so it covers a dropped connection (the `Connection reset by peer` above) but not a sustained mirror outage. This is inherited from the existing `nodejs` pattern, kept as-is for consistency. During verification a real ~1-minute `deb.debian.org` outage defeated both attempts on an *unmodified* builder-stage layer; a rebuild after the mirror recovered passed. Adding `sleep 5` before the retry would widen coverage meaningfully — happy to do that here or in a follow-up if preferred.
2. **`docker/prod/nodejs/Dockerfile` line 87** — the Chrome install layer carries the "Add retry logic" comment but has no actual retry. Out of scope for this PR, flagged for awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only Dockerfile changes with no runtime application logic; slightly longer/more complex apt layers but same installed packages.
> 
> **Overview**
> Production **celery**, **django**, **code-upload-worker**, and **worker_py3_7/8/9** Dockerfiles now use the same **apt** resilience pattern as `docker/prod/nodejs/Dockerfile`: run `apt --fix-broken install` before installs, pass **`--fix-missing`**, and on failure repeat **`apt-get update`** plus the full package list inside an `|| (...)` block.
> 
> The change targets **CI flakes** from transient Debian mirror errors (e.g. connection reset while fetching transitive deps like `libbrotli1` on runtime **`libfreetype6`** installs). Worker images already had this on **builder** stages; this PR adds it to **runtime** `apt-get` layers and fills gaps on **django**, **celery**, and **code-upload-worker** builder/runtime steps. **Package lists and versions are unchanged**—only install shell structure and comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4433ee763546ac5fbe9687f0ebd34f84358bccab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container build reliability by adding recovery and retry handling for system package installation.
  * Builds can now better tolerate transient repository, network, missing-package, and broken-dependency errors.
  * Applied consistent installation safeguards across production application, worker, and upload-service images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->