### PR TITLE
feat(base): answer load balancer health checks before host validation

### DIFF
--- a/apps/base/middleware.py
+++ b/apps/base/middleware.py
@@ -1,0 +1,34 @@
+from .views import health_check
+
+HEALTH_CHECK_PATH = "/api/health/"
+
+
+class HealthCheckMiddleware:
+    """
+    Answer the load balancer health check before host validation runs.
+
+    An ALB health-checks its targets by private IP and cannot be configured to
+    send a custom Host header, so the request never matches ALLOWED_HOSTS.
+    Django would reject it with 400 and the load balancer would mark every
+    target unhealthy, taking the whole service out of rotation.
+
+    Matching on ``request.path`` is what makes this work: the path comes from
+    PATH_INFO and needs no host, so nothing here calls ``request.get_host()``
+    and validation never runs. This middleware must stay FIRST in MIDDLEWARE.
+    Returning without calling ``get_response`` skips every middleware below it,
+    including the ones that would perform the host check.
+
+    The bypass is deliberately limited to one path serving a static payload
+    with no database access and no user data. The attacks ALLOWED_HOSTS exists
+    to prevent -- poisoned password-reset links, cache poisoning, redirects to
+    attacker-controlled hosts -- all need a response that reflects the host
+    back, which this one never does. Every other path keeps full validation.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.path == HEALTH_CHECK_PATH:
+            return health_check(request)
+        return self.get_response(request)

--- a/settings/common.py
+++ b/settings/common.py
@@ -85,6 +85,10 @@ THIRD_PARTY_APPS = [
 INSTALLED_APPS = DEFAULT_APPS + OUR_APPS + THIRD_PARTY_APPS
 
 MIDDLEWARE = [
+    # Must stay first. It answers the load balancer health check on path
+    # alone, before anything below can reject the request for having a Host
+    # header that is not in ALLOWED_HOSTS. See base.middleware for why.
+    "base.middleware.HealthCheckMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/tests/unit/base/test_health_middleware.py
+++ b/tests/unit/base/test_health_middleware.py
@@ -1,0 +1,31 @@
+from django.test import TestCase, override_settings
+
+
+@override_settings(ALLOWED_HOSTS=["eval.ai"])
+class TestHealthCheckMiddleware(TestCase):
+    """
+    A load balancer health-checks targets by private IP and cannot send a
+    custom Host header, so the request never matches ALLOWED_HOSTS. Without a
+    bypass every target is marked unhealthy and the service is taken out of
+    rotation.
+    """
+
+    def test_health_check_answers_a_host_outside_allowed_hosts(self):
+        response = self.client.get("/api/health/", HTTP_HOST="10.0.1.42")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok"})
+
+    def test_other_paths_still_reject_a_host_outside_allowed_hosts(self):
+        # The bypass must be scoped to the health path. If host validation
+        # stopped applying everywhere, this would return something other
+        # than 400 and the protection would be gone site-wide.
+        response = self.client.get("/api/challenges/", HTTP_HOST="10.0.1.42")
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_health_check_still_answers_a_permitted_host(self):
+        response = self.client.get("/api/health/", HTTP_HOST="eval.ai")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok"})


### PR DESCRIPTION
## Why

`settings/prod.py` pins `ALLOWED_HOSTS = ["eval.ai"]`. An ALB health-checks its targets by private IP and **cannot** be configured to send a custom `Host` header, so the request never matches `ALLOWED_HOSTS`. Django rejects it with 400, the load balancer marks every target unhealthy, and the service drops out of rotation.

This is not hypothetical — the added test reproduces it. Before this change, `GET /api/health/` with a private-IP `Host` returns **400**.

It doesn't bite today only because the prod target group points at nginx rather than Django, so nginx absorbs the health checks. It bites the moment Django sits directly behind the ALB, which is the next step in moving the core tier off a single instance. This is groundwork for that, and is safe to ship on the current single-instance setup — it only *adds* a bypass for one path.

## What

`HealthCheckMiddleware`, registered first in `MIDDLEWARE`.

It matches on `request.path`, which comes from `PATH_INFO` and needs no host, so nothing in it calls `request.get_host()` and validation never runs. Returning without calling `get_response` skips every middleware below it, including the ones that would perform the host check — which is why the ordering matters and is commented at the registration site.

It delegates to the existing `health_check` view so there is one implementation of the response.

## Why this approach

Two alternatives were considered and rejected:

- **Read the task IP from `ECS_CONTAINER_METADATA_URI_V4` at startup** and append it to `ALLOWED_HOSTS`
- **Drive `ALLOWED_HOSTS` from an environment variable**

Both whitelist the host for *every* path. This scopes the bypass to a single endpoint. It also needs no startup network call, has no dependency on the ECS metadata endpoint being reachable, and behaves identically on ECS, EC2 and locally.

## Security

The exposure is nil. The bypassed path serves a static `{"status": "ok"}` with no database access and no user data.

The attacks `ALLOWED_HOSTS` exists to prevent — poisoned password-reset links, cache poisoning, redirects to attacker-controlled hosts — all require a response that reflects the host back. This one never does.

`test_other_paths_still_reject_a_host_outside_allowed_hosts` asserts an unlisted `Host` on a normal path still returns 400, so the scoping cannot silently regress into a site-wide bypass.

## Test plan

Written test-first; the first case was confirmed failing with `AssertionError: 400 != 200` before the middleware existed.

- `test_health_check_answers_a_host_outside_allowed_hosts` — the actual ALB scenario
- `test_other_paths_still_reject_a_host_outside_allowed_hosts` — pins the scoping
- `test_health_check_still_answers_a_permitted_host` — no regression for normal traffic

Full suite: **2105 passed** (up from 2102). `black` / `isort` / `flake8` clean; `pylint` 9.54/10 — the reported line-length warnings are pre-existing in `settings/common.py` and untouched here.

## Notes for the reviewer

Not linked to a filed issue — this is groundwork for the core-tier autoscaling migration that #5205 started.

The middleware **must** stay first in `MIDDLEWARE`. If it moves below `SecurityMiddleware` or `CommonMiddleware`, those call `get_host()` and the 400 returns. There's a comment at the registration site, but it's worth knowing when reordering middleware in future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a narrow bypass of `ALLOWED_HOSTS` on one static endpoint; regressions would mainly come from middleware reordering or widening the path match beyond `/api/health/`.
> 
> **Overview**
> Adds **`HealthCheckMiddleware`** as the **first** entry in `MIDDLEWARE` so `GET /api/health/` can return 200 when the `Host` header is a target private IP (ALB health checks), instead of Django’s usual **400** from `ALLOWED_HOSTS`.
> 
> For that path only, the middleware matches on `request.path` and returns the existing `health_check` response **without** running the rest of the stack, so nothing calls `get_host()` for that request. All other routes still enforce host validation.
> 
> Unit tests cover the private-IP health case, a non-health path still returning 400 with a bad host, and health checks with a permitted host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce6cb71b2b59975d9cc7bdfcc91cf7b02303c722. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a health-check endpoint at `/api/health/` that returns a successful status for infrastructure monitoring.
  * Health checks work even when accessed through hosts not included in the application’s allowed host settings.
* **Bug Fixes**
  * Restricted host validation bypass to the health-check endpoint; other routes continue to enforce host validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->