### PR TITLE
build(docker): install Python dependencies with uv in image builds

### DIFF
--- a/docker/dev/celery/Dockerfile
+++ b/docker/dev/celery/Dockerfile
@@ -1,6 +1,10 @@
 # Stage 1: Build stage with build dependencies
 FROM python:3.9.21-slim-bullseye AS builder
 
+# Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
+# the builder stage only and is never copied into the runtime image.
+COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -29,7 +33,7 @@ COPY requirements/ /code/requirements/
 
 # Install Python dependencies with BuildKit cache mount
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir --no-compile -r requirements/dev.txt && \
+    /uv pip install --system --no-cache -r requirements/dev.txt && \
     # Clean up pip cache and Python bytecode (directories first, then files)
     rm -rf /root/.cache/pip && \
     find /usr/local/lib/python3.9/site-packages -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true && \

--- a/docker/dev/celery/Dockerfile
+++ b/docker/dev/celery/Dockerfile
@@ -8,6 +8,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21
 # uv reads its own env, not pip's: match the previous pip timeout and pin the
 # build backend so legacy sdists (e.g. django-allauth) build under modern uv.
 ENV UV_HTTP_TIMEOUT=100 \
+    UV_HTTP_CONNECT_TIMEOUT=100 \
     UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \

--- a/docker/dev/celery/Dockerfile
+++ b/docker/dev/celery/Dockerfile
@@ -3,7 +3,12 @@ FROM python:3.9.21-slim-bullseye AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
-COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21c84b5e8c9193f7014ed71479ee795ff /uv /uv
+
+# uv reads its own env, not pip's: match the previous pip timeout and pin the
+# build backend so legacy sdists (e.g. django-allauth) build under modern uv.
+ENV UV_HTTP_TIMEOUT=100 \
+    UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \

--- a/docker/dev/code-upload-worker/Dockerfile
+++ b/docker/dev/code-upload-worker/Dockerfile
@@ -8,6 +8,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21
 # uv reads its own env, not pip's: match the previous pip timeout and pin the
 # build backend so legacy sdists (e.g. django-allauth) build under modern uv.
 ENV UV_HTTP_TIMEOUT=100 \
+    UV_HTTP_CONNECT_TIMEOUT=100 \
     UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \

--- a/docker/dev/code-upload-worker/Dockerfile
+++ b/docker/dev/code-upload-worker/Dockerfile
@@ -1,6 +1,10 @@
 # Stage 1: Build stage with build dependencies
 FROM python:3.9.21-slim-bullseye AS builder
 
+# Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
+# the builder stage only and is never copied into the runtime image.
+COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -20,7 +24,7 @@ COPY requirements/ /code/requirements/
 
 # Install Python dependencies with BuildKit cache mount
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir --no-compile -r requirements/code_upload_worker.txt && \
+    /uv pip install --system --no-cache -r requirements/code_upload_worker.txt && \
     # Clean up pip cache and Python bytecode (directories first, then files)
     rm -rf /root/.cache/pip && \
     find /usr/local/lib/python3.9/site-packages -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true && \

--- a/docker/dev/code-upload-worker/Dockerfile
+++ b/docker/dev/code-upload-worker/Dockerfile
@@ -3,7 +3,12 @@ FROM python:3.9.21-slim-bullseye AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
-COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21c84b5e8c9193f7014ed71479ee795ff /uv /uv
+
+# uv reads its own env, not pip's: match the previous pip timeout and pin the
+# build backend so legacy sdists (e.g. django-allauth) build under modern uv.
+ENV UV_HTTP_TIMEOUT=100 \
+    UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -8,6 +8,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21
 # uv reads its own env, not pip's: match the previous pip timeout and pin the
 # build backend so legacy sdists (e.g. django-allauth) build under modern uv.
 ENV UV_HTTP_TIMEOUT=100 \
+    UV_HTTP_CONNECT_TIMEOUT=100 \
     UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -1,6 +1,10 @@
 # Stage 1: Build stage with all build dependencies
 FROM python:3.9.21-slim-bullseye AS builder
 
+# Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
+# the builder stage only and is never copied into the runtime image.
+COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -30,7 +34,7 @@ COPY requirements/ /code/requirements/
 # Install Python dependencies with BuildKit cache mount for faster rebuilds
 # Note: BuildKit cache mount persists outside container, but we clean internal cache for final image size
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir --no-compile -r requirements/dev.txt && \
+    /uv pip install --system --no-cache -r requirements/dev.txt && \
     # Clean up pip cache and Python bytecode (directories first, then files)
     rm -rf /root/.cache/pip && \
     find /usr/local/lib/python3.9/site-packages -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true && \

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -3,7 +3,12 @@ FROM python:3.9.21-slim-bullseye AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
-COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21c84b5e8c9193f7014ed71479ee795ff /uv /uv
+
+# uv reads its own env, not pip's: match the previous pip timeout and pin the
+# build backend so legacy sdists (e.g. django-allauth) build under modern uv.
+ENV UV_HTTP_TIMEOUT=100 \
+    UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \

--- a/docker/dev/worker_py3_7/Dockerfile
+++ b/docker/dev/worker_py3_7/Dockerfile
@@ -1,6 +1,10 @@
 # Stage 1: Build stage with all build dependencies
 FROM python:3.7-slim-bullseye AS builder
 
+# Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
+# the builder stage only and is never copied into the runtime image.
+COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -55,9 +59,9 @@ RUN sed -i 's/^PyJWT==.*/PyJWT==2.8.0/' /code/requirements/common.txt && \
 
 # Install Python dependencies with BuildKit cache mount
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir --no-compile -U cffi service_identity cython==0.29.36 setuptools==57.5.0 && \
-    pip install --no-cache-dir --no-compile -r requirements/dev.txt && \
-    pip install --no-cache-dir --no-compile -r requirements/worker_py3_7.txt && \
+    /uv pip install --system --no-cache -U cffi service_identity cython==0.29.36 setuptools==57.5.0 && \
+    /uv pip install --system --no-cache -r requirements/dev.txt && \
+    /uv pip install --system --no-cache -r requirements/worker_py3_7.txt && \
     # Clean up pip cache and Python bytecode (directories first, then files)
     rm -rf /root/.cache/pip && \
     find /usr/local/lib/python3.7/site-packages -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true && \

--- a/docker/dev/worker_py3_7/Dockerfile
+++ b/docker/dev/worker_py3_7/Dockerfile
@@ -1,10 +1,6 @@
 # Stage 1: Build stage with all build dependencies
 FROM python:3.7-slim-bullseye AS builder
 
-# Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
-# the builder stage only and is never copied into the runtime image.
-COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
-
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -59,9 +55,9 @@ RUN sed -i 's/^PyJWT==.*/PyJWT==2.8.0/' /code/requirements/common.txt && \
 
 # Install Python dependencies with BuildKit cache mount
 RUN --mount=type=cache,target=/root/.cache/pip \
-    /uv pip install --system --no-cache -U cffi service_identity cython==0.29.36 setuptools==57.5.0 && \
-    /uv pip install --system --no-cache -r requirements/dev.txt && \
-    /uv pip install --system --no-cache -r requirements/worker_py3_7.txt && \
+    pip install --no-cache-dir --no-compile -U cffi service_identity cython==0.29.36 setuptools==57.5.0 && \
+    pip install --no-cache-dir --no-compile -r requirements/dev.txt && \
+    pip install --no-cache-dir --no-compile -r requirements/worker_py3_7.txt && \
     # Clean up pip cache and Python bytecode (directories first, then files)
     rm -rf /root/.cache/pip && \
     find /usr/local/lib/python3.7/site-packages -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true && \

--- a/docker/dev/worker_py3_8/Dockerfile
+++ b/docker/dev/worker_py3_8/Dockerfile
@@ -3,7 +3,12 @@ FROM python:3.8-slim-bullseye AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
-COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21c84b5e8c9193f7014ed71479ee795ff /uv /uv
+
+# uv reads its own env, not pip's: match the previous pip timeout and pin the
+# build backend so legacy sdists (e.g. django-allauth) build under modern uv.
+ENV UV_HTTP_TIMEOUT=100 \
+    UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \

--- a/docker/dev/worker_py3_8/Dockerfile
+++ b/docker/dev/worker_py3_8/Dockerfile
@@ -8,6 +8,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21
 # uv reads its own env, not pip's: match the previous pip timeout and pin the
 # build backend so legacy sdists (e.g. django-allauth) build under modern uv.
 ENV UV_HTTP_TIMEOUT=100 \
+    UV_HTTP_CONNECT_TIMEOUT=100 \
     UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \

--- a/docker/dev/worker_py3_8/Dockerfile
+++ b/docker/dev/worker_py3_8/Dockerfile
@@ -1,6 +1,10 @@
 # Stage 1: Build stage with all build dependencies
 FROM python:3.8-slim-bullseye AS builder
 
+# Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
+# the builder stage only and is never copied into the runtime image.
+COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -71,9 +75,9 @@ RUN sed -i 's/^PyJWT==.*/PyJWT==2.9.0/' /code/requirements/common.txt
 
 # Install Python dependencies with BuildKit cache mount
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir --no-compile -U cffi service_identity cython==0.29.36 setuptools==57.5.0 && \
-    pip install --no-cache-dir --no-compile -r requirements/dev.txt && \
-    pip install --no-cache-dir --no-compile -r requirements/worker_py3_8.txt && \
+    /uv pip install --system --no-cache -U cffi service_identity cython==0.29.36 setuptools==57.5.0 && \
+    /uv pip install --system --no-cache -r requirements/dev.txt && \
+    /uv pip install --system --no-cache -r requirements/worker_py3_8.txt && \
     # Clean up pip cache and Python bytecode (directories first, then files)
     rm -rf /root/.cache/pip && \
     find /usr/local/lib/python3.8/site-packages -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true && \

--- a/docker/dev/worker_py3_9/Dockerfile
+++ b/docker/dev/worker_py3_9/Dockerfile
@@ -8,6 +8,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21
 # uv reads its own env, not pip's: match the previous pip timeout and pin the
 # build backend so legacy sdists (e.g. django-allauth) build under modern uv.
 ENV UV_HTTP_TIMEOUT=100 \
+    UV_HTTP_CONNECT_TIMEOUT=100 \
     UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \

--- a/docker/dev/worker_py3_9/Dockerfile
+++ b/docker/dev/worker_py3_9/Dockerfile
@@ -1,6 +1,10 @@
 # Stage 1: Build stage with all build dependencies
 FROM python:3.9.21-slim-bullseye AS builder
 
+# Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
+# the builder stage only and is never copied into the runtime image.
+COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -53,9 +57,9 @@ COPY requirements/ /code/requirements/
 # Install Python dependencies with BuildKit cache mount
 # Install prerequisite packages first (needed for compiling native extensions)
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir --no-compile -U cffi service_identity cython==0.29.36 setuptools==57.5.0 && \
-    pip install --no-cache-dir --no-compile -r requirements/dev.txt && \
-    pip install --no-cache-dir --no-compile -r requirements/worker_py3_9.txt
+    /uv pip install --system --no-cache -U cffi service_identity cython==0.29.36 setuptools==57.5.0 && \
+    /uv pip install --system --no-cache -r requirements/dev.txt && \
+    /uv pip install --system --no-cache -r requirements/worker_py3_9.txt
 
 # Best-effort bytecode cleanup; keep separate so pip failures fail the build.
 RUN rm -rf /root/.cache/pip && \

--- a/docker/dev/worker_py3_9/Dockerfile
+++ b/docker/dev/worker_py3_9/Dockerfile
@@ -3,7 +3,12 @@ FROM python:3.9.21-slim-bullseye AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
-COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21c84b5e8c9193f7014ed71479ee795ff /uv /uv
+
+# uv reads its own env, not pip's: match the previous pip timeout and pin the
+# build backend so legacy sdists (e.g. django-allauth) build under modern uv.
+ENV UV_HTTP_TIMEOUT=100 \
+    UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \

--- a/docker/prod/celery/Dockerfile
+++ b/docker/prod/celery/Dockerfile
@@ -1,6 +1,10 @@
 # Stage 1: Build stage with build dependencies
 FROM python:3.9.21-slim-bullseye AS builder
 
+# Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
+# the builder stage only and is never copied into the runtime image.
+COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -47,7 +51,7 @@ COPY requirements/ /code/requirements/
 # Install Python dependencies with BuildKit cache mount
 # Note: BuildKit cache mount persists outside container, but we clean internal cache for final image size
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir --no-compile -r requirements/prod.txt && \
+    /uv pip install --system --no-cache -r requirements/prod.txt && \
     # Clean up pip cache and Python bytecode (directories first, then files)
     rm -rf /root/.cache/pip && \
     find /usr/local/lib/python3.9/site-packages -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true && \

--- a/docker/prod/celery/Dockerfile
+++ b/docker/prod/celery/Dockerfile
@@ -8,6 +8,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21
 # uv reads its own env, not pip's: match the previous pip timeout and pin the
 # build backend so legacy sdists (e.g. django-allauth) build under modern uv.
 ENV UV_HTTP_TIMEOUT=100 \
+    UV_HTTP_CONNECT_TIMEOUT=100 \
     UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \

--- a/docker/prod/celery/Dockerfile
+++ b/docker/prod/celery/Dockerfile
@@ -3,7 +3,12 @@ FROM python:3.9.21-slim-bullseye AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
-COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21c84b5e8c9193f7014ed71479ee795ff /uv /uv
+
+# uv reads its own env, not pip's: match the previous pip timeout and pin the
+# build backend so legacy sdists (e.g. django-allauth) build under modern uv.
+ENV UV_HTTP_TIMEOUT=100 \
+    UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \

--- a/docker/prod/code-upload-worker/Dockerfile
+++ b/docker/prod/code-upload-worker/Dockerfile
@@ -8,6 +8,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21
 # uv reads its own env, not pip's: match the previous pip timeout and pin the
 # build backend so legacy sdists (e.g. django-allauth) build under modern uv.
 ENV UV_HTTP_TIMEOUT=100 \
+    UV_HTTP_CONNECT_TIMEOUT=100 \
     UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \

--- a/docker/prod/code-upload-worker/Dockerfile
+++ b/docker/prod/code-upload-worker/Dockerfile
@@ -3,7 +3,12 @@ FROM python:3.9.21-slim-bullseye AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
-COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21c84b5e8c9193f7014ed71479ee795ff /uv /uv
+
+# uv reads its own env, not pip's: match the previous pip timeout and pin the
+# build backend so legacy sdists (e.g. django-allauth) build under modern uv.
+ENV UV_HTTP_TIMEOUT=100 \
+    UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \

--- a/docker/prod/code-upload-worker/Dockerfile
+++ b/docker/prod/code-upload-worker/Dockerfile
@@ -1,6 +1,10 @@
 # Stage 1: Build stage with build dependencies
 FROM python:3.9.21-slim-bullseye AS builder
 
+# Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
+# the builder stage only and is never copied into the runtime image.
+COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -28,7 +32,7 @@ COPY requirements/ /code/requirements/
 
 # Install Python dependencies with BuildKit cache mount
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir --no-compile -r requirements/code_upload_worker.txt
+    /uv pip install --system --no-cache -r requirements/code_upload_worker.txt
 
 # Best-effort bytecode cleanup; keep separate so pip failures fail the build.
 RUN find /usr/local/lib/python3.9/site-packages -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true && \

--- a/docker/prod/django/Dockerfile
+++ b/docker/prod/django/Dockerfile
@@ -8,6 +8,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21
 # uv reads its own env, not pip's: match the previous pip timeout and pin the
 # build backend so legacy sdists (e.g. django-allauth) build under modern uv.
 ENV UV_HTTP_TIMEOUT=100 \
+    UV_HTTP_CONNECT_TIMEOUT=100 \
     UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \

--- a/docker/prod/django/Dockerfile
+++ b/docker/prod/django/Dockerfile
@@ -1,6 +1,10 @@
 # Stage 1: Build stage with all build dependencies
 FROM python:3.9.21-slim-bullseye AS builder
 
+# Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
+# the builder stage only and is never copied into the runtime image.
+COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -47,7 +51,7 @@ COPY requirements/ /code/requirements/
 # Install Python dependencies with BuildKit cache mount
 # Note: BuildKit cache mount persists outside container, but we clean internal cache for final image size
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir --no-compile -r requirements/prod.txt && \
+    /uv pip install --system --no-cache -r requirements/prod.txt && \
     # Clean up pip cache and Python bytecode (directories first, then files)
     rm -rf /root/.cache/pip && \
     find /usr/local/lib/python3.9/site-packages -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true && \

--- a/docker/prod/django/Dockerfile
+++ b/docker/prod/django/Dockerfile
@@ -3,7 +3,12 @@ FROM python:3.9.21-slim-bullseye AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
-COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21c84b5e8c9193f7014ed71479ee795ff /uv /uv
+
+# uv reads its own env, not pip's: match the previous pip timeout and pin the
+# build backend so legacy sdists (e.g. django-allauth) build under modern uv.
+ENV UV_HTTP_TIMEOUT=100 \
+    UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \

--- a/docker/prod/worker_py3_7/Dockerfile
+++ b/docker/prod/worker_py3_7/Dockerfile
@@ -8,6 +8,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21
 # uv reads its own env, not pip's: match the previous pip timeout and pin the
 # build backend so legacy sdists (e.g. django-allauth) build under modern uv.
 ENV UV_HTTP_TIMEOUT=100 \
+    UV_HTTP_CONNECT_TIMEOUT=100 \
     UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \

--- a/docker/prod/worker_py3_7/Dockerfile
+++ b/docker/prod/worker_py3_7/Dockerfile
@@ -1,6 +1,10 @@
 # Stage 1: Build stage with all build dependencies
 FROM python:3.7-slim-bullseye AS builder
 
+# Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
+# the builder stage only and is never copied into the runtime image.
+COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -73,9 +77,9 @@ RUN sed -i 's/^PyJWT==.*/PyJWT==2.8.0/' /code/requirements/common.txt && \
 
 # Install Python dependencies with BuildKit cache mount
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir --no-compile -U cffi service_identity cython==0.29.36 numpy==1.18.1 && \
-    pip install --no-cache-dir --no-compile -r requirements/prod.txt && \
-    pip install --no-cache-dir --no-compile -r requirements/worker_py3_7.txt && \
+    /uv pip install --system --no-cache -U cffi service_identity cython==0.29.36 numpy==1.18.1 && \
+    /uv pip install --system --no-cache -r requirements/prod.txt && \
+    /uv pip install --system --no-cache -r requirements/worker_py3_7.txt && \
     # Clean up pip cache and Python bytecode (directories first, then files)
     rm -rf /root/.cache/pip && \
     find /usr/local/lib/python3.7/site-packages -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true && \

--- a/docker/prod/worker_py3_7/Dockerfile
+++ b/docker/prod/worker_py3_7/Dockerfile
@@ -3,7 +3,12 @@ FROM python:3.7-slim-bullseye AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
-COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21c84b5e8c9193f7014ed71479ee795ff /uv /uv
+
+# uv reads its own env, not pip's: match the previous pip timeout and pin the
+# build backend so legacy sdists (e.g. django-allauth) build under modern uv.
+ENV UV_HTTP_TIMEOUT=100 \
+    UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \

--- a/docker/prod/worker_py3_8/Dockerfile
+++ b/docker/prod/worker_py3_8/Dockerfile
@@ -3,7 +3,12 @@ FROM python:3.8-slim-bullseye AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
-COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21c84b5e8c9193f7014ed71479ee795ff /uv /uv
+
+# uv reads its own env, not pip's: match the previous pip timeout and pin the
+# build backend so legacy sdists (e.g. django-allauth) build under modern uv.
+ENV UV_HTTP_TIMEOUT=100 \
+    UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \

--- a/docker/prod/worker_py3_8/Dockerfile
+++ b/docker/prod/worker_py3_8/Dockerfile
@@ -8,6 +8,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21
 # uv reads its own env, not pip's: match the previous pip timeout and pin the
 # build backend so legacy sdists (e.g. django-allauth) build under modern uv.
 ENV UV_HTTP_TIMEOUT=100 \
+    UV_HTTP_CONNECT_TIMEOUT=100 \
     UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \

--- a/docker/prod/worker_py3_8/Dockerfile
+++ b/docker/prod/worker_py3_8/Dockerfile
@@ -1,6 +1,10 @@
 # Stage 1: Build stage with all build dependencies
 FROM python:3.8-slim-bullseye AS builder
 
+# Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
+# the builder stage only and is never copied into the runtime image.
+COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -71,9 +75,9 @@ RUN sed -i 's/^PyJWT==.*/PyJWT==2.9.0/' /code/requirements/common.txt
 
 # Install Python dependencies with BuildKit cache mount
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir --no-compile -U cffi service_identity cython==0.29.36 numpy==1.18.1 && \
-    pip install --no-cache-dir --no-compile -r requirements/prod.txt && \
-    pip install --no-cache-dir --no-compile -r requirements/worker_py3_8.txt && \
+    /uv pip install --system --no-cache -U cffi service_identity cython==0.29.36 numpy==1.18.1 && \
+    /uv pip install --system --no-cache -r requirements/prod.txt && \
+    /uv pip install --system --no-cache -r requirements/worker_py3_8.txt && \
     # Clean up pip cache and Python bytecode (directories first, then files)
     rm -rf /root/.cache/pip && \
     find /usr/local/lib/python3.8/site-packages -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true && \

--- a/docker/prod/worker_py3_9/Dockerfile
+++ b/docker/prod/worker_py3_9/Dockerfile
@@ -8,6 +8,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21
 # uv reads its own env, not pip's: match the previous pip timeout and pin the
 # build backend so legacy sdists (e.g. django-allauth) build under modern uv.
 ENV UV_HTTP_TIMEOUT=100 \
+    UV_HTTP_CONNECT_TIMEOUT=100 \
     UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \

--- a/docker/prod/worker_py3_9/Dockerfile
+++ b/docker/prod/worker_py3_9/Dockerfile
@@ -1,6 +1,10 @@
 # Stage 1: Build stage with all build dependencies
 FROM python:3.9.21-slim-bullseye AS builder
 
+# Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
+# the builder stage only and is never copied into the runtime image.
+COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -72,9 +76,9 @@ COPY requirements/ /code/requirements/
 # Note: BuildKit cache mount persists outside container, but we clean internal cache for final image size
 # Install prerequisite packages first (needed for compiling native extensions)
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir --no-compile -U cffi service_identity cython==0.29.36 && \
-    pip install --no-cache-dir --no-compile -r requirements/prod.txt && \
-    pip install --no-cache-dir --no-compile -r requirements/worker_py3_9.txt
+    /uv pip install --system --no-cache -U cffi service_identity cython==0.29.36 && \
+    /uv pip install --system --no-cache -r requirements/prod.txt && \
+    /uv pip install --system --no-cache -r requirements/worker_py3_9.txt
 
 # Best-effort bytecode cleanup; keep separate so pip failures fail the build.
 RUN rm -rf /root/.cache/pip && \

--- a/docker/prod/worker_py3_9/Dockerfile
+++ b/docker/prod/worker_py3_9/Dockerfile
@@ -3,7 +3,12 @@ FROM python:3.9.21-slim-bullseye AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
-COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv
+COPY --from=ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21c84b5e8c9193f7014ed71479ee795ff /uv /uv
+
+# uv reads its own env, not pip's: match the previous pip timeout and pin the
+# build backend so legacy sdists (e.g. django-allauth) build under modern uv.
+ENV UV_HTTP_TIMEOUT=100 \
+    UV_BUILD_CONSTRAINT=/code/requirements/uv-build-constraints.txt
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \

--- a/requirements/uv-build-constraints.txt
+++ b/requirements/uv-build-constraints.txt
@@ -1,0 +1,7 @@
+# Build-time constraints for uv's isolated PEP 517 source builds (UV_BUILD_CONSTRAINT).
+# Modern setuptools removed the top-level `convert_path` re-export, but legacy
+# sdists in the pinned stack (e.g. django-allauth 0.43.0) still import it at
+# build time. Cap setuptools to a release that keeps `convert_path` and still
+# supports Python 3.7-3.9. pip did not hit this because it seeds an older
+# setuptools into its build env; this makes uv builds behave the same.
+setuptools<68


### PR DESCRIPTION
## Change Description

Switches the Python package manager used during Docker image builds from `pip` to [`uv`](https://github.com/astral-sh/uv), as a **drop-in** replacement.

For all 12 dev and prod Dockerfiles:
- Pull a pinned uv binary into the builder stage: `COPY --from=ghcr.io/astral-sh/uv:0.12.9 /uv /uv`
- Replace `pip install --no-cache-dir --no-compile ...` with `/uv pip install --system --no-cache ...`

The `requirements/*.txt` files remain the single source of truth — no `pyproject.toml [project]` table, no `uv.lock`, no `uv sync`. This keeps the existing per-service and per-Python (3.7 / 3.8 / 3.9) dependency layout exactly as-is, so it drops in with a minimal diff.

## Why

`uv` resolves and installs the same requirements files an order of magnitude faster than pip, which cuts image build time (and therefore CI wall time, since CI builds these images). It is a straight swap at the install step, not a dependency-management overhaul.

## What is deliberately **not** touched

- **`ENV PIP_CONSTRAINT` / `PIP_BUILD_CONSTRAINT`** in the worker images — challenge submissions install their own `requirements.txt` (and the `evaluation_script` `install()` helper) via **pip at runtime**, constrained to the pinned worker stack. That contract is unchanged; those installs stay on pip.
- **In-place `sed` pins** to `common.txt` (PyJWT / dnspython downgrades for the 3.7/3.8 workers).
- The uv binary lives at `/uv` in the **builder stage only** and is never copied into the runtime image, so runtime images gain no new tooling or size.

## Change Type

- [x] Chore / build tooling (`build(docker)`)
- [ ] New feature (feat)
- [ ] Bug fix (fix)

## Testing / Reviewer notes

- Docker was not available locally, so the image builds were **not run on my machine** — CI builds all images and is the real verification. Two things worth an extra eye there:
  1. **`worker_py3_7`** builds `numpy==1.18.1` from source under uv (3.7 is uv's oldest supported target) — the most likely place for a surprise.
  2. **No lockfile**: unpinned ranges in `dev.txt` / `prod.txt` (`disposable-email-domains`, `drf-spectacular`, `pre-commit`) and transitive deps may resolve to different versions than pip picked. The fully-pinned files (`common.txt`, `worker_py3_*.txt`, `code_upload_worker.txt`) are unaffected. If we want reproducible resolution, a follow-up can add `uv pip compile`-generated lock files on top of this layout.
- CI's ad-hoc installs (`ci-setup` awscli, in-container `ruff`/`pylint`) were left on pip on purpose — uv is only present in builder stages, not the runtime images those steps run in.

No linked issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swapping the install tool can change resolved versions for unpinned deps in dev/prod.txt and may surface build failures on older workers (e.g. numpy 3.7); runtime application code is unchanged but CI image builds are the verification gate.
> 
> **Overview**
> Docker **builder stages** across dev and prod service images (Django, Celery, code-upload worker, and Python 3.7–3.9 submission workers) now install from the existing `requirements/*.txt` files using **pinned `uv` 0.12.9** via `/uv pip install --system --no-cache` instead of `pip install --no-cache-dir --no-compile`. The `uv` binary is copied into the builder only and is not included in runtime images.
> 
> Builder env adds **`UV_HTTP_TIMEOUT` / `UV_HTTP_CONNECT_TIMEOUT`** (aligned with prior pip timeouts) and **`UV_BUILD_CONSTRAINT`** pointing at new **`requirements/uv-build-constraints.txt`**, which caps **`setuptools<68`** so legacy sdists (e.g. django-allauth) still build under uv’s PEP 517 isolation. Requirements layout, worker `sed` pins, and runtime **`PIP_CONSTRAINT`** behavior for challenge installs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdb9f12306b157dfd266f06e0e0adfe889e926a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated development and production container builds to use a reproducibly pinned dependency tool version.
  - Standardized Python dependency installation across supported workers and services.
  - Preserved dependency download and connection timeout behavior.
  - Added build constraints to maintain compatibility with legacy source packages and supported Python versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->