### PR TITLE
Docs: Add Stripe customer portal link to pricing page

### DIFF
--- a/docs/source/01-getting-started/pricing.md
+++ b/docs/source/01-getting-started/pricing.md
@@ -3,6 +3,8 @@
 Thank you for your interest in hosting your challenge on EvalAI. We’re excited to support your work.
 We offer 4 plans based on the compute needs of the challenge hosts. Each plan is a monthly subscription (managed via Stripe) with no long-term commitment—you can cancel anytime once your challenge concludes. Stripe accepts all major payment methods and provides monthly receipts.
 
+To manage or cancel your subscription, visit the [Stripe customer portal](https://billing.stripe.com/p/login/3cI8wO5Nh8a27cwgYXcEw00).
+
 Each plan is a monthly subscription that includes one always-on worker to handle submissions (except for the Remote Evaluation Plan, which relies on your own infrastructure). If you expect higher submission volume—especially near deadlines—we can scale easily by adding additional workers. These extra workers will be billed separately according to your selected plan.
 
 Below is a detailed comparison of the available plans:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a sentence to the pricing page directing challenge hosts to the Stripe customer portal to manage or cancel their subscription, so they do not need to email the team.

## Changes

- Updated `docs/source/01-getting-started/pricing.md` with a link to the Stripe customer portal.

## Testing

- Built docs locally with `make html` in `docs/` — build succeeded.
- Verified the generated pricing page includes the portal link.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://cvmlp.slack.com/archives/C0B4U4Y62E6/p1788371201080719?thread_ts=1788371201.080719&cid=C0B4U4Y62E6)

<div><a href="https://cursor.com/agents/bc-5d3cc791-dfae-5779-9147-edf1279edbd7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d3cc791-dfae-5779-9147-edf1279edbd7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a link to the Stripe customer portal in the pricing documentation, allowing users to manage or cancel their subscription.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->