### PR TITLE
fix(docker): retry apt fetches instead of failing the build

### DIFF
--- a/docker/dev/celery/Dockerfile
+++ b/docker/dev/celery/Dockerfile
@@ -36,7 +36,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -78,7 +78,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/dev/celery/Dockerfile
+++ b/docker/dev/celery/Dockerfile
@@ -17,20 +17,27 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install build dependencies only (if any native extensions)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    build-essential \
-    libpq-dev \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    libjpeg-dev \
-    zlib1g-dev \
-    libpng-dev \
-    libtiff-dev \
-    libfreetype6-dev \
-    liblcms2-dev \
-    libwebp-dev \
-    && rm -rf /var/lib/apt/lists/*
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        build-essential \
+        libpq-dev \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libjpeg-dev \
+        zlib1g-dev \
+        libpng-dev \
+        libtiff-dev \
+        libfreetype6-dev \
+        liblcms2-dev \
+        libwebp-dev \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
 
@@ -54,17 +61,24 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    libpq5 \
-    libcurl4 \
-    libjpeg62-turbo \
-    zlib1g \
-    libpng16-16 \
-    libtiff5 \
-    libfreetype6 \
-    liblcms2-2 \
-    libwebp6 && \
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        libpq5 \
+        libcurl4 \
+        libjpeg62-turbo \
+        zlib1g \
+        libpng16-16 \
+        libtiff5 \
+        libfreetype6 \
+        liblcms2-2 \
+        libwebp6 \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/dev/celery/Dockerfile
+++ b/docker/dev/celery/Dockerfile
@@ -17,8 +17,8 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install build dependencies only (if any native extensions)
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get -o Acquire::Retries=5 update && \
+    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     build-essential \
     libpq-dev \
     libcurl4-openssl-dev \
@@ -54,8 +54,8 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get -o Acquire::Retries=5 update && \
+    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     libpq5 \
     libcurl4 \
     libjpeg62-turbo \

--- a/docker/dev/code-upload-worker/Dockerfile
+++ b/docker/dev/code-upload-worker/Dockerfile
@@ -17,11 +17,18 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install build dependencies
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    build-essential \
-    unzip \
-    && rm -rf /var/lib/apt/lists/*
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        build-essential \
+        unzip \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
 
@@ -46,12 +53,19 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
 # Note: git is required for kubectl apply -k with github.com kustomize remote bases.
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    curl \
-    unzip \
-    git \
-    ca-certificates && \
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        curl \
+        unzip \
+        git \
+        ca-certificates \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/dev/code-upload-worker/Dockerfile
+++ b/docker/dev/code-upload-worker/Dockerfile
@@ -17,8 +17,8 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install build dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get -o Acquire::Retries=5 update && \
+    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     build-essential \
     unzip \
     && rm -rf /var/lib/apt/lists/*
@@ -46,8 +46,8 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
 # Note: git is required for kubectl apply -k with github.com kustomize remote bases.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get -o Acquire::Retries=5 update && \
+    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     curl \
     unzip \
     git \

--- a/docker/dev/code-upload-worker/Dockerfile
+++ b/docker/dev/code-upload-worker/Dockerfile
@@ -27,7 +27,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -65,7 +65,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -17,20 +17,27 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install build dependencies only
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    build-essential \
-    libpq-dev \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    libjpeg-dev \
-    zlib1g-dev \
-    libpng-dev \
-    libtiff-dev \
-    libfreetype6-dev \
-    liblcms2-dev \
-    libwebp-dev \
-    && rm -rf /var/lib/apt/lists/*
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        build-essential \
+        libpq-dev \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libjpeg-dev \
+        zlib1g-dev \
+        libpng-dev \
+        libtiff-dev \
+        libfreetype6-dev \
+        liblcms2-dev \
+        libwebp-dev \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
 
@@ -56,19 +63,26 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
 # git: for running git commit from container (pre-commit in Linux env, avoids macOS/ARM issues)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    libpq5 \
-    libcurl4 \
-    libjpeg62-turbo \
-    zlib1g \
-    libpng16-16 \
-    libtiff5 \
-    libfreetype6 \
-    liblcms2-2 \
-    libwebp6 \
-    git \
-    ca-certificates && \
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        libpq5 \
+        libcurl4 \
+        libjpeg62-turbo \
+        zlib1g \
+        libpng16-16 \
+        libtiff5 \
+        libfreetype6 \
+        liblcms2-2 \
+        libwebp6 \
+        git \
+        ca-certificates \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -17,8 +17,8 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install build dependencies only
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get -o Acquire::Retries=5 update && \
+    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     build-essential \
     libpq-dev \
     libcurl4-openssl-dev \
@@ -56,8 +56,8 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
 # git: for running git commit from container (pre-commit in Linux env, avoids macOS/ARM issues)
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get -o Acquire::Retries=5 update && \
+    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     libpq5 \
     libcurl4 \
     libjpeg62-turbo \

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -36,7 +36,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -82,7 +82,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -11,20 +11,21 @@ ENV NODE_ENV=development \
 
 # Install build dependencies only (for native module compilation and bower)
 # Note: ca-certificates is needed for git to verify SSL certificates when accessing GitHub
-# Add retry logic and --fix-missing to handle transient network issues
+# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
+# Acquire::Retries makes apt retry the fetch instead of failing the build.
 # Fix any broken dependencies first (from partial installs)
-RUN apt-get update && \
+RUN apt-get -o Acquire::Retries=5 update && \
     apt --fix-broken install -y || true && \
-    (apt-get install -y --no-install-recommends --fix-missing \
+    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     python2 \
     python-is-python2 \
     make \
     g++ \
     git \
     ca-certificates \
-    || (apt-get update && \
+    || (apt-get -o Acquire::Retries=5 update && \
         apt --fix-broken install -y || true && \
-        apt-get install -y --no-install-recommends --fix-missing \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         python2 \
         python-is-python2 \
         make \
@@ -75,8 +76,8 @@ ENV NODE_ENV=development \
 
 # Install only essential runtime dependencies (no build tools, no git).
 # xvfb is installed with Chrome/Chromium in arch-specific stages so Mesa GL deps resolve together.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates && \
+RUN apt-get -o Acquire::Retries=5 update && \
+    apt-get -o Acquire::Retries=5 install -y --no-install-recommends ca-certificates && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 WORKDIR /code
@@ -89,20 +90,20 @@ COPY --from=builder /code/bower_components /code/bower_components
 
 # AMD64-specific stage for Chrome
 FROM base AS amd64
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget gnupg procps && \
+RUN apt-get -o Acquire::Retries=5 update && \
+    apt-get -o Acquire::Retries=5 install -y --no-install-recommends wget gnupg procps && \
     wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt-get -o Acquire::Retries=5 update && \
+    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     google-chrome-stable libxss1 xvfb && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/* && \
     find /opt/google/chrome/locales -name "*.pak" ! -name "en-US.pak" -delete 2>/dev/null || true
 
 # ARM64-specific stage for Chromium
 FROM base AS arm64
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends chromium libxss1 procps xvfb && \
+RUN apt-get -o Acquire::Retries=5 update && \
+    apt-get -o Acquire::Retries=5 install -y --no-install-recommends chromium libxss1 procps xvfb && \
     ln -sf /usr/bin/chromium /usr/bin/google-chrome && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 

--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -15,10 +15,12 @@ ENV NODE_ENV=development \
 # returns 404 for pool files that do exist -- the same URL serves fine minutes
 # later. Acquire::Retries handles the transport errors, but apt treats 404 as
 # fatal and will not retry it, so retry the whole update+install with a pause.
-# Bounded, so a genuinely missing package still fails the build.
+# Bounded and guarded with 'exit 1', so a genuinely missing package still fails
+# the build rather than silently continuing without it.
 # Do not "fix" this by pointing at another mirror: security.debian.org and
-# cloudfront.debian.net were both measured to 404 bullseye-security pool files
-# that deb.debian.org serves correctly.
+# cloudfront.debian.net were each measured, at different times, to 404 on
+# bullseye-security pool files that deb.debian.org served correctly, and vice
+# versa -- there is no single mirror that is reliably the clean one.
 RUN n=0; until [ "$n" -ge 4 ]; do \
         apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -33,7 +35,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -87,7 +89,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 WORKDIR /code
@@ -111,7 +113,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list && \
     rm -rf /var/lib/apt/lists/*
@@ -127,7 +129,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/* && \
     find /opt/google/chrome/locales -name "*.pak" ! -name "en-US.pak" -delete 2>/dev/null || true
 
@@ -145,7 +147,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     ln -sf /usr/bin/chromium /usr/bin/google-chrome && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 

--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -11,27 +11,29 @@ ENV NODE_ENV=development \
 
 # Install build dependencies only (for native module compilation and bower)
 # Note: ca-certificates is needed for git to verify SSL certificates when accessing GitHub
-# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
-# Acquire::Retries makes apt retry the fetch instead of failing the build.
-# Fix any broken dependencies first (from partial installs)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt --fix-broken install -y || true && \
-    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    python2 \
-    python-is-python2 \
-    make \
-    g++ \
-    git \
-    ca-certificates \
-    || (apt-get -o Acquire::Retries=5 update && \
-        apt --fix-broken install -y || true && \
+# deb.debian.org (Fastly) intermittently resets connections, and sporadically
+# returns 404 for pool files that do exist -- the same URL serves fine minutes
+# later. Acquire::Retries handles the transport errors, but apt treats 404 as
+# fatal and will not retry it, so retry the whole update+install with a pause.
+# Bounded, so a genuinely missing package still fails the build.
+# Do not "fix" this by pointing at another mirror: security.debian.org and
+# cloudfront.debian.net were both measured to 404 bullseye-security pool files
+# that deb.debian.org serves correctly.
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         python2 \
         python-is-python2 \
         make \
         g++ \
         git \
-        ca-certificates)) && \
+        ca-certificates \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -76,8 +78,16 @@ ENV NODE_ENV=development \
 
 # Install only essential runtime dependencies (no build tools, no git).
 # xvfb is installed with Chrome/Chromium in arch-specific stages so Mesa GL deps resolve together.
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt-get -o Acquire::Retries=5 install -y --no-install-recommends ca-certificates && \
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        ca-certificates \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 WORKDIR /code
@@ -90,20 +100,52 @@ COPY --from=builder /code/bower_components /code/bower_components
 
 # AMD64-specific stage for Chrome
 FROM base AS amd64
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt-get -o Acquire::Retries=5 install -y --no-install-recommends wget gnupg procps && \
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        wget \
+        gnupg \
+        procps \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list && \
-    apt-get -o Acquire::Retries=5 update && \
-    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    google-chrome-stable libxss1 xvfb && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        google-chrome-stable \
+        libxss1 \
+        xvfb \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/* && \
     find /opt/google/chrome/locales -name "*.pak" ! -name "en-US.pak" -delete 2>/dev/null || true
 
 # ARM64-specific stage for Chromium
 FROM base AS arm64
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt-get -o Acquire::Retries=5 install -y --no-install-recommends chromium libxss1 procps xvfb && \
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        chromium \
+        libxss1 \
+        procps \
+        xvfb \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     ln -sf /usr/bin/chromium /usr/bin/google-chrome && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 

--- a/docker/dev/worker_py3_7/Dockerfile
+++ b/docker/dev/worker_py3_7/Dockerfile
@@ -7,11 +7,12 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install all build dependencies
-# Add retry logic and --fix-missing to handle transient network issues
+# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
+# Acquire::Retries makes apt retry the fetch instead of failing the build.
 # Fix any broken dependencies first (from partial installs)
-RUN apt-get update && \
+RUN apt-get -o Acquire::Retries=5 update && \
     apt --fix-broken install -y || true && \
-    (apt-get install -y --no-install-recommends --fix-missing \
+    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
      build-essential \
      python3-dev \
      libpq-dev \
@@ -25,9 +26,9 @@ RUN apt-get update && \
      liblcms2-dev \
      libwebp-dev \
      default-jre-headless \
-     || (apt-get update && \
+     || (apt-get -o Acquire::Retries=5 update && \
          apt --fix-broken install -y || true && \
-         apt-get install -y --no-install-recommends --fix-missing \
+         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
          build-essential \
          python3-dev \
          libpq-dev \
@@ -72,8 +73,8 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get -o Acquire::Retries=5 update && \
+    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     default-jre-headless \
     libpq5 \
     libcurl4 \

--- a/docker/dev/worker_py3_7/Dockerfile
+++ b/docker/dev/worker_py3_7/Dockerfile
@@ -11,10 +11,12 @@ ENV PYTHONUNBUFFERED=1 \
 # returns 404 for pool files that do exist -- the same URL serves fine minutes
 # later. Acquire::Retries handles the transport errors, but apt treats 404 as
 # fatal and will not retry it, so retry the whole update+install with a pause.
-# Bounded, so a genuinely missing package still fails the build.
+# Bounded and guarded with 'exit 1', so a genuinely missing package still fails
+# the build rather than silently continuing without it.
 # Do not "fix" this by pointing at another mirror: security.debian.org and
-# cloudfront.debian.net were both measured to 404 bullseye-security pool files
-# that deb.debian.org serves correctly.
+# cloudfront.debian.net were each measured, at different times, to 404 on
+# bullseye-security pool files that deb.debian.org served correctly, and vice
+# versa -- there is no single mirror that is reliably the clean one.
 RUN n=0; until [ "$n" -ge 4 ]; do \
         apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -36,7 +38,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -88,7 +90,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/dev/worker_py3_7/Dockerfile
+++ b/docker/dev/worker_py3_7/Dockerfile
@@ -7,41 +7,36 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install all build dependencies
-# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
-# Acquire::Retries makes apt retry the fetch instead of failing the build.
-# Fix any broken dependencies first (from partial installs)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt --fix-broken install -y || true && \
-    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-     build-essential \
-     python3-dev \
-     libpq-dev \
-     libcurl4-openssl-dev \
-     libssl-dev \
-     libjpeg-dev \
-     zlib1g-dev \
-     libpng-dev \
-     libtiff-dev \
-     libfreetype6-dev \
-     liblcms2-dev \
-     libwebp-dev \
-     default-jre-headless \
-     || (apt-get -o Acquire::Retries=5 update && \
-         apt --fix-broken install -y || true && \
-         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-         build-essential \
-         python3-dev \
-         libpq-dev \
-         libcurl4-openssl-dev \
-         libssl-dev \
-         libjpeg-dev \
-         zlib1g-dev \
-         libpng-dev \
-         libtiff-dev \
-         libfreetype6-dev \
-         liblcms2-dev \
-         libwebp-dev \
-         default-jre-headless)) && \
+# deb.debian.org (Fastly) intermittently resets connections, and sporadically
+# returns 404 for pool files that do exist -- the same URL serves fine minutes
+# later. Acquire::Retries handles the transport errors, but apt treats 404 as
+# fatal and will not retry it, so retry the whole update+install with a pause.
+# Bounded, so a genuinely missing package still fails the build.
+# Do not "fix" this by pointing at another mirror: security.debian.org and
+# cloudfront.debian.net were both measured to 404 bullseye-security pool files
+# that deb.debian.org serves correctly.
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        build-essential \
+        python3-dev \
+        libpq-dev \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libjpeg-dev \
+        zlib1g-dev \
+        libpng-dev \
+        libtiff-dev \
+        libfreetype6-dev \
+        liblcms2-dev \
+        libwebp-dev \
+        default-jre-headless \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -73,20 +68,27 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    default-jre-headless \
-    libpq5 \
-    libcurl4 \
-    libjpeg62-turbo \
-    zlib1g \
-    libpng16-16 \
-    libtiff5 \
-    libfreetype6 \
-    liblcms2-2 \
-    libwebp6 \
-    libgl1 \
-    libglib2.0-0 && \
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        default-jre-headless \
+        libpq5 \
+        libcurl4 \
+        libjpeg62-turbo \
+        zlib1g \
+        libpng16-16 \
+        libtiff5 \
+        libfreetype6 \
+        liblcms2-2 \
+        libwebp6 \
+        libgl1 \
+        libglib2.0-0 \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/dev/worker_py3_8/Dockerfile
+++ b/docker/dev/worker_py3_8/Dockerfile
@@ -16,60 +16,46 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_DEFAULT_TIMEOUT=100
 
-# Install all build dependencies with retry logic
-# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
-# Acquire::Retries makes apt retry the fetch instead of failing the build.
-# Fix any broken dependencies first (from partial installs)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt --fix-broken install -y || true && \
-    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-     build-essential \
-     python3-dev \
-     libpq-dev \
-     libcurl4-openssl-dev \
-     libssl-dev \
-     libjpeg-dev \
-     zlib1g-dev \
-     libpng-dev \
-     libtiff-dev \
-     libfreetype6-dev \
-     liblcms2-dev \
-     libwebp-dev \
-     default-jre-headless \
-     git \
-     cmake \
-     libeigen3-dev \
-     libboost-python-dev \
-     libopencv-dev \
-     python3-opencv \
-     libgmp-dev \
-     libcgal-qt5-dev \
-     swig \
-     || (apt-get -o Acquire::Retries=5 update && \
-         apt --fix-broken install -y || true && \
-         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-         build-essential \
-         python3-dev \
-         libpq-dev \
-         libcurl4-openssl-dev \
-         libssl-dev \
-         libjpeg-dev \
-         zlib1g-dev \
-         libpng-dev \
-         libtiff-dev \
-         libfreetype6-dev \
-         liblcms2-dev \
-         libwebp-dev \
-         default-jre-headless \
-         git \
-         cmake \
-         libeigen3-dev \
-         libboost-python-dev \
-         libopencv-dev \
-         python3-opencv \
-         libgmp-dev \
-         libcgal-qt5-dev \
-         swig)) && \
+# Install all build dependencies
+# deb.debian.org (Fastly) intermittently resets connections, and sporadically
+# returns 404 for pool files that do exist -- the same URL serves fine minutes
+# later. Acquire::Retries handles the transport errors, but apt treats 404 as
+# fatal and will not retry it, so retry the whole update+install with a pause.
+# Bounded, so a genuinely missing package still fails the build.
+# Do not "fix" this by pointing at another mirror: security.debian.org and
+# cloudfront.debian.net were both measured to 404 bullseye-security pool files
+# that deb.debian.org serves correctly.
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        build-essential \
+        python3-dev \
+        libpq-dev \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libjpeg-dev \
+        zlib1g-dev \
+        libpng-dev \
+        libtiff-dev \
+        libfreetype6-dev \
+        liblcms2-dev \
+        libwebp-dev \
+        default-jre-headless \
+        git \
+        cmake \
+        libeigen3-dev \
+        libboost-python-dev \
+        libopencv-dev \
+        python3-opencv \
+        libgmp-dev \
+        libcgal-qt5-dev \
+        swig \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -111,21 +97,28 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
 # Note: We copy OpenCV libs from builder to avoid python3-opencv dependency issues
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    default-jre-headless \
-    libpq5 \
-    libcurl4 \
-    libjpeg62-turbo \
-    zlib1g \
-    libpng16-16 \
-    libtiff5 \
-    libfreetype6 \
-    liblcms2-2 \
-    libwebp6 \
-    libgmp10 \
-    libgl1 \
-    libglib2.0-0 && \
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        default-jre-headless \
+        libpq5 \
+        libcurl4 \
+        libjpeg62-turbo \
+        zlib1g \
+        libpng16-16 \
+        libtiff5 \
+        libfreetype6 \
+        liblcms2-2 \
+        libwebp6 \
+        libgmp10 \
+        libgl1 \
+        libglib2.0-0 \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/dev/worker_py3_8/Dockerfile
+++ b/docker/dev/worker_py3_8/Dockerfile
@@ -21,10 +21,12 @@ ENV PYTHONUNBUFFERED=1 \
 # returns 404 for pool files that do exist -- the same URL serves fine minutes
 # later. Acquire::Retries handles the transport errors, but apt treats 404 as
 # fatal and will not retry it, so retry the whole update+install with a pause.
-# Bounded, so a genuinely missing package still fails the build.
+# Bounded and guarded with 'exit 1', so a genuinely missing package still fails
+# the build rather than silently continuing without it.
 # Do not "fix" this by pointing at another mirror: security.debian.org and
-# cloudfront.debian.net were both measured to 404 bullseye-security pool files
-# that deb.debian.org serves correctly.
+# cloudfront.debian.net were each measured, at different times, to 404 on
+# bullseye-security pool files that deb.debian.org served correctly, and vice
+# versa -- there is no single mirror that is reliably the clean one.
 RUN n=0; until [ "$n" -ge 4 ]; do \
         apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -55,7 +57,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -118,7 +120,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/dev/worker_py3_8/Dockerfile
+++ b/docker/dev/worker_py3_8/Dockerfile
@@ -17,11 +17,12 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install all build dependencies with retry logic
-# Add retry logic and --fix-missing to handle transient network issues
+# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
+# Acquire::Retries makes apt retry the fetch instead of failing the build.
 # Fix any broken dependencies first (from partial installs)
-RUN apt-get update && \
+RUN apt-get -o Acquire::Retries=5 update && \
     apt --fix-broken install -y || true && \
-    (apt-get install -y --no-install-recommends --fix-missing \
+    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
      build-essential \
      python3-dev \
      libpq-dev \
@@ -44,9 +45,9 @@ RUN apt-get update && \
      libgmp-dev \
      libcgal-qt5-dev \
      swig \
-     || (apt-get update && \
+     || (apt-get -o Acquire::Retries=5 update && \
          apt --fix-broken install -y || true && \
-         apt-get install -y --no-install-recommends --fix-missing \
+         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
          build-essential \
          python3-dev \
          libpq-dev \
@@ -110,8 +111,8 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
 # Note: We copy OpenCV libs from builder to avoid python3-opencv dependency issues
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get -o Acquire::Retries=5 update && \
+    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     default-jre-headless \
     libpq5 \
     libcurl4 \

--- a/docker/dev/worker_py3_9/Dockerfile
+++ b/docker/dev/worker_py3_9/Dockerfile
@@ -17,43 +17,37 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install all build dependencies
-# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
-# Acquire::Retries makes apt retry the fetch instead of failing the build.
-# Fix any broken dependencies first (from partial installs)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt --fix-broken install -y || true && \
-    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-     build-essential \
-     python3-dev \
-     libpq-dev \
-     libcurl4-openssl-dev \
-     libssl-dev \
-     libjpeg-dev \
-     zlib1g-dev \
-     libpng-dev \
-     libtiff-dev \
-     libfreetype6-dev \
-     liblcms2-dev \
-     libwebp-dev \
-     default-jre-headless \
-     curl \
-     || (apt-get -o Acquire::Retries=5 update && \
-         apt --fix-broken install -y || true && \
-         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-         build-essential \
-         python3-dev \
-         libpq-dev \
-         libcurl4-openssl-dev \
-         libssl-dev \
-         libjpeg-dev \
-         zlib1g-dev \
-         libpng-dev \
-         libtiff-dev \
-         libfreetype6-dev \
-         liblcms2-dev \
-         libwebp-dev \
-         default-jre-headless \
-         curl)) && \
+# deb.debian.org (Fastly) intermittently resets connections, and sporadically
+# returns 404 for pool files that do exist -- the same URL serves fine minutes
+# later. Acquire::Retries handles the transport errors, but apt treats 404 as
+# fatal and will not retry it, so retry the whole update+install with a pause.
+# Bounded, so a genuinely missing package still fails the build.
+# Do not "fix" this by pointing at another mirror: security.debian.org and
+# cloudfront.debian.net were both measured to 404 bullseye-security pool files
+# that deb.debian.org serves correctly.
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        build-essential \
+        python3-dev \
+        libpq-dev \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libjpeg-dev \
+        zlib1g-dev \
+        libpng-dev \
+        libtiff-dev \
+        libfreetype6-dev \
+        liblcms2-dev \
+        libwebp-dev \
+        default-jre-headless \
+        curl \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -85,20 +79,27 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    default-jre-headless \
-    libpq5 \
-    libcurl4 \
-    libjpeg62-turbo \
-    zlib1g \
-    libpng16-16 \
-    libtiff5 \
-    libfreetype6 \
-    liblcms2-2 \
-    libwebp6 \
-    libgl1 \
-    libglib2.0-0 && \
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        default-jre-headless \
+        libpq5 \
+        libcurl4 \
+        libjpeg62-turbo \
+        zlib1g \
+        libpng16-16 \
+        libtiff5 \
+        libfreetype6 \
+        liblcms2-2 \
+        libwebp6 \
+        libgl1 \
+        libglib2.0-0 \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/dev/worker_py3_9/Dockerfile
+++ b/docker/dev/worker_py3_9/Dockerfile
@@ -17,11 +17,12 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install all build dependencies
-# Add retry logic and --fix-missing to handle transient network issues
+# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
+# Acquire::Retries makes apt retry the fetch instead of failing the build.
 # Fix any broken dependencies first (from partial installs)
-RUN apt-get update && \
+RUN apt-get -o Acquire::Retries=5 update && \
     apt --fix-broken install -y || true && \
-    (apt-get install -y --no-install-recommends --fix-missing \
+    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
      build-essential \
      python3-dev \
      libpq-dev \
@@ -36,9 +37,9 @@ RUN apt-get update && \
      libwebp-dev \
      default-jre-headless \
      curl \
-     || (apt-get update && \
+     || (apt-get -o Acquire::Retries=5 update && \
          apt --fix-broken install -y || true && \
-         apt-get install -y --no-install-recommends --fix-missing \
+         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
          build-essential \
          python3-dev \
          libpq-dev \
@@ -84,8 +85,8 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get -o Acquire::Retries=5 update && \
+    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     default-jre-headless \
     libpq5 \
     libcurl4 \

--- a/docker/dev/worker_py3_9/Dockerfile
+++ b/docker/dev/worker_py3_9/Dockerfile
@@ -21,10 +21,12 @@ ENV PYTHONUNBUFFERED=1 \
 # returns 404 for pool files that do exist -- the same URL serves fine minutes
 # later. Acquire::Retries handles the transport errors, but apt treats 404 as
 # fatal and will not retry it, so retry the whole update+install with a pause.
-# Bounded, so a genuinely missing package still fails the build.
+# Bounded and guarded with 'exit 1', so a genuinely missing package still fails
+# the build rather than silently continuing without it.
 # Do not "fix" this by pointing at another mirror: security.debian.org and
-# cloudfront.debian.net were both measured to 404 bullseye-security pool files
-# that deb.debian.org serves correctly.
+# cloudfront.debian.net were each measured, at different times, to 404 on
+# bullseye-security pool files that deb.debian.org served correctly, and vice
+# versa -- there is no single mirror that is reliably the clean one.
 RUN n=0; until [ "$n" -ge 4 ]; do \
         apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -47,7 +49,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -99,7 +101,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/celery/Dockerfile
+++ b/docker/prod/celery/Dockerfile
@@ -17,25 +17,16 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install build dependencies only (if any native extensions)
-# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
-# Acquire::Retries makes apt retry the fetch instead of failing the build.
-# Fix any broken dependencies first (from partial installs)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt --fix-broken install -y || true && \
-    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    build-essential \
-    libpq-dev \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    libjpeg-dev \
-    zlib1g-dev \
-    libpng-dev \
-    libtiff-dev \
-    libfreetype6-dev \
-    liblcms2-dev \
-    libwebp-dev \
-    || (apt-get -o Acquire::Retries=5 update && \
-        apt --fix-broken install -y || true && \
+# deb.debian.org (Fastly) intermittently resets connections, and sporadically
+# returns 404 for pool files that do exist -- the same URL serves fine minutes
+# later. Acquire::Retries handles the transport errors, but apt treats 404 as
+# fatal and will not retry it, so retry the whole update+install with a pause.
+# Bounded, so a genuinely missing package still fails the build.
+# Do not "fix" this by pointing at another mirror: security.debian.org and
+# cloudfront.debian.net were both measured to 404 bullseye-security pool files
+# that deb.debian.org serves correctly.
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         build-essential \
         libpq-dev \
@@ -47,7 +38,13 @@ RUN apt-get -o Acquire::Retries=5 update && \
         libtiff-dev \
         libfreetype6-dev \
         liblcms2-dev \
-        libwebp-dev)) && \
+        libwebp-dev \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -73,23 +70,16 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
-# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
-# Acquire::Retries makes apt retry the fetch instead of failing the build.
-# Fix any broken dependencies first (from partial installs)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt --fix-broken install -y || true && \
-    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    libpq5 \
-    libcurl4 \
-    libjpeg62-turbo \
-    zlib1g \
-    libpng16-16 \
-    libtiff5 \
-    libfreetype6 \
-    liblcms2-2 \
-    libwebp6 \
-    || (apt-get -o Acquire::Retries=5 update && \
-        apt --fix-broken install -y || true && \
+# deb.debian.org (Fastly) intermittently resets connections, and sporadically
+# returns 404 for pool files that do exist -- the same URL serves fine minutes
+# later. Acquire::Retries handles the transport errors, but apt treats 404 as
+# fatal and will not retry it, so retry the whole update+install with a pause.
+# Bounded, so a genuinely missing package still fails the build.
+# Do not "fix" this by pointing at another mirror: security.debian.org and
+# cloudfront.debian.net were both measured to 404 bullseye-security pool files
+# that deb.debian.org serves correctly.
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         libpq5 \
         libcurl4 \
@@ -99,7 +89,13 @@ RUN apt-get -o Acquire::Retries=5 update && \
         libtiff5 \
         libfreetype6 \
         liblcms2-2 \
-        libwebp6)) && \
+        libwebp6 \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/celery/Dockerfile
+++ b/docker/prod/celery/Dockerfile
@@ -21,10 +21,12 @@ ENV PYTHONUNBUFFERED=1 \
 # returns 404 for pool files that do exist -- the same URL serves fine minutes
 # later. Acquire::Retries handles the transport errors, but apt treats 404 as
 # fatal and will not retry it, so retry the whole update+install with a pause.
-# Bounded, so a genuinely missing package still fails the build.
+# Bounded and guarded with 'exit 1', so a genuinely missing package still fails
+# the build rather than silently continuing without it.
 # Do not "fix" this by pointing at another mirror: security.debian.org and
-# cloudfront.debian.net were both measured to 404 bullseye-security pool files
-# that deb.debian.org serves correctly.
+# cloudfront.debian.net were each measured, at different times, to 404 on
+# bullseye-security pool files that deb.debian.org served correctly, and vice
+# versa -- there is no single mirror that is reliably the clean one.
 RUN n=0; until [ "$n" -ge 4 ]; do \
         apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -44,7 +46,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -74,10 +76,12 @@ ENV PYTHONUNBUFFERED=1 \
 # returns 404 for pool files that do exist -- the same URL serves fine minutes
 # later. Acquire::Retries handles the transport errors, but apt treats 404 as
 # fatal and will not retry it, so retry the whole update+install with a pause.
-# Bounded, so a genuinely missing package still fails the build.
+# Bounded and guarded with 'exit 1', so a genuinely missing package still fails
+# the build rather than silently continuing without it.
 # Do not "fix" this by pointing at another mirror: security.debian.org and
-# cloudfront.debian.net were both measured to 404 bullseye-security pool files
-# that deb.debian.org serves correctly.
+# cloudfront.debian.net were each measured, at different times, to 404 on
+# bullseye-security pool files that deb.debian.org served correctly, and vice
+# versa -- there is no single mirror that is reliably the clean one.
 RUN n=0; until [ "$n" -ge 4 ]; do \
         apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -95,7 +99,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/celery/Dockerfile
+++ b/docker/prod/celery/Dockerfile
@@ -17,11 +17,12 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install build dependencies only (if any native extensions)
-# Add retry logic and --fix-missing to handle transient network issues
+# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
+# Acquire::Retries makes apt retry the fetch instead of failing the build.
 # Fix any broken dependencies first (from partial installs)
-RUN apt-get update && \
+RUN apt-get -o Acquire::Retries=5 update && \
     apt --fix-broken install -y || true && \
-    (apt-get install -y --no-install-recommends --fix-missing \
+    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     build-essential \
     libpq-dev \
     libcurl4-openssl-dev \
@@ -33,9 +34,9 @@ RUN apt-get update && \
     libfreetype6-dev \
     liblcms2-dev \
     libwebp-dev \
-    || (apt-get update && \
+    || (apt-get -o Acquire::Retries=5 update && \
         apt --fix-broken install -y || true && \
-        apt-get install -y --no-install-recommends --fix-missing \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         build-essential \
         libpq-dev \
         libcurl4-openssl-dev \
@@ -72,11 +73,12 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
-# Add retry logic and --fix-missing to handle transient network issues
+# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
+# Acquire::Retries makes apt retry the fetch instead of failing the build.
 # Fix any broken dependencies first (from partial installs)
-RUN apt-get update && \
+RUN apt-get -o Acquire::Retries=5 update && \
     apt --fix-broken install -y || true && \
-    (apt-get install -y --no-install-recommends --fix-missing \
+    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     libpq5 \
     libcurl4 \
     libjpeg62-turbo \
@@ -86,9 +88,9 @@ RUN apt-get update && \
     libfreetype6 \
     liblcms2-2 \
     libwebp6 \
-    || (apt-get update && \
+    || (apt-get -o Acquire::Retries=5 update && \
         apt --fix-broken install -y || true && \
-        apt-get install -y --no-install-recommends --fix-missing \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         libpq5 \
         libcurl4 \
         libjpeg62-turbo \

--- a/docker/prod/code-upload-worker/Dockerfile
+++ b/docker/prod/code-upload-worker/Dockerfile
@@ -17,16 +17,17 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install build dependencies
-# Add retry logic and --fix-missing to handle transient network issues
+# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
+# Acquire::Retries makes apt retry the fetch instead of failing the build.
 # Fix any broken dependencies first (from partial installs)
-RUN apt-get update && \
+RUN apt-get -o Acquire::Retries=5 update && \
     apt --fix-broken install -y || true && \
-    (apt-get install -y --no-install-recommends --fix-missing \
+    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     build-essential \
     unzip \
-    || (apt-get update && \
+    || (apt-get -o Acquire::Retries=5 update && \
         apt --fix-broken install -y || true && \
-        apt-get install -y --no-install-recommends --fix-missing \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         build-essential \
         unzip)) && \
     rm -rf /var/lib/apt/lists/*
@@ -55,18 +56,19 @@ ENV PYTHONUNBUFFERED=1 \
 # Install runtime dependencies (apt-get handles multi-arch automatically)
 # Note: curl and unzip are needed by install_dependencies.sh; git is required
 # for kubectl apply -k with github.com kustomize remote bases.
-# Add retry logic and --fix-missing to handle transient network issues
+# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
+# Acquire::Retries makes apt retry the fetch instead of failing the build.
 # Fix any broken dependencies first (from partial installs)
-RUN apt-get update && \
+RUN apt-get -o Acquire::Retries=5 update && \
     apt --fix-broken install -y || true && \
-    (apt-get install -y --no-install-recommends --fix-missing \
+    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     curl \
     unzip \
     git \
     ca-certificates \
-    || (apt-get update && \
+    || (apt-get -o Acquire::Retries=5 update && \
         apt --fix-broken install -y || true && \
-        apt-get install -y --no-install-recommends --fix-missing \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         curl \
         unzip \
         git \

--- a/docker/prod/code-upload-worker/Dockerfile
+++ b/docker/prod/code-upload-worker/Dockerfile
@@ -17,19 +17,25 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install build dependencies
-# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
-# Acquire::Retries makes apt retry the fetch instead of failing the build.
-# Fix any broken dependencies first (from partial installs)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt --fix-broken install -y || true && \
-    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    build-essential \
-    unzip \
-    || (apt-get -o Acquire::Retries=5 update && \
-        apt --fix-broken install -y || true && \
+# deb.debian.org (Fastly) intermittently resets connections, and sporadically
+# returns 404 for pool files that do exist -- the same URL serves fine minutes
+# later. Acquire::Retries handles the transport errors, but apt treats 404 as
+# fatal and will not retry it, so retry the whole update+install with a pause.
+# Bounded, so a genuinely missing package still fails the build.
+# Do not "fix" this by pointing at another mirror: security.debian.org and
+# cloudfront.debian.net were both measured to 404 bullseye-security pool files
+# that deb.debian.org serves correctly.
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         build-essential \
-        unzip)) && \
+        unzip \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -56,23 +62,27 @@ ENV PYTHONUNBUFFERED=1 \
 # Install runtime dependencies (apt-get handles multi-arch automatically)
 # Note: curl and unzip are needed by install_dependencies.sh; git is required
 # for kubectl apply -k with github.com kustomize remote bases.
-# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
-# Acquire::Retries makes apt retry the fetch instead of failing the build.
-# Fix any broken dependencies first (from partial installs)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt --fix-broken install -y || true && \
-    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    curl \
-    unzip \
-    git \
-    ca-certificates \
-    || (apt-get -o Acquire::Retries=5 update && \
-        apt --fix-broken install -y || true && \
+# deb.debian.org (Fastly) intermittently resets connections, and sporadically
+# returns 404 for pool files that do exist -- the same URL serves fine minutes
+# later. Acquire::Retries handles the transport errors, but apt treats 404 as
+# fatal and will not retry it, so retry the whole update+install with a pause.
+# Bounded, so a genuinely missing package still fails the build.
+# Do not "fix" this by pointing at another mirror: security.debian.org and
+# cloudfront.debian.net were both measured to 404 bullseye-security pool files
+# that deb.debian.org serves correctly.
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         curl \
         unzip \
         git \
-        ca-certificates)) && \
+        ca-certificates \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/code-upload-worker/Dockerfile
+++ b/docker/prod/code-upload-worker/Dockerfile
@@ -21,10 +21,12 @@ ENV PYTHONUNBUFFERED=1 \
 # returns 404 for pool files that do exist -- the same URL serves fine minutes
 # later. Acquire::Retries handles the transport errors, but apt treats 404 as
 # fatal and will not retry it, so retry the whole update+install with a pause.
-# Bounded, so a genuinely missing package still fails the build.
+# Bounded and guarded with 'exit 1', so a genuinely missing package still fails
+# the build rather than silently continuing without it.
 # Do not "fix" this by pointing at another mirror: security.debian.org and
-# cloudfront.debian.net were both measured to 404 bullseye-security pool files
-# that deb.debian.org serves correctly.
+# cloudfront.debian.net were each measured, at different times, to 404 on
+# bullseye-security pool files that deb.debian.org served correctly, and vice
+# versa -- there is no single mirror that is reliably the clean one.
 RUN n=0; until [ "$n" -ge 4 ]; do \
         apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -35,7 +37,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -66,10 +68,12 @@ ENV PYTHONUNBUFFERED=1 \
 # returns 404 for pool files that do exist -- the same URL serves fine minutes
 # later. Acquire::Retries handles the transport errors, but apt treats 404 as
 # fatal and will not retry it, so retry the whole update+install with a pause.
-# Bounded, so a genuinely missing package still fails the build.
+# Bounded and guarded with 'exit 1', so a genuinely missing package still fails
+# the build rather than silently continuing without it.
 # Do not "fix" this by pointing at another mirror: security.debian.org and
-# cloudfront.debian.net were both measured to 404 bullseye-security pool files
-# that deb.debian.org serves correctly.
+# cloudfront.debian.net were each measured, at different times, to 404 on
+# bullseye-security pool files that deb.debian.org served correctly, and vice
+# versa -- there is no single mirror that is reliably the clean one.
 RUN n=0; until [ "$n" -ge 4 ]; do \
         apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -82,7 +86,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/django/Dockerfile
+++ b/docker/prod/django/Dockerfile
@@ -17,25 +17,16 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install build dependencies only
-# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
-# Acquire::Retries makes apt retry the fetch instead of failing the build.
-# Fix any broken dependencies first (from partial installs)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt --fix-broken install -y || true && \
-    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    build-essential \
-    libpq-dev \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    libjpeg-dev \
-    zlib1g-dev \
-    libpng-dev \
-    libtiff-dev \
-    libfreetype6-dev \
-    liblcms2-dev \
-    libwebp-dev \
-    || (apt-get -o Acquire::Retries=5 update && \
-        apt --fix-broken install -y || true && \
+# deb.debian.org (Fastly) intermittently resets connections, and sporadically
+# returns 404 for pool files that do exist -- the same URL serves fine minutes
+# later. Acquire::Retries handles the transport errors, but apt treats 404 as
+# fatal and will not retry it, so retry the whole update+install with a pause.
+# Bounded, so a genuinely missing package still fails the build.
+# Do not "fix" this by pointing at another mirror: security.debian.org and
+# cloudfront.debian.net were both measured to 404 bullseye-security pool files
+# that deb.debian.org serves correctly.
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         build-essential \
         libpq-dev \
@@ -47,7 +38,13 @@ RUN apt-get -o Acquire::Retries=5 update && \
         libtiff-dev \
         libfreetype6-dev \
         liblcms2-dev \
-        libwebp-dev)) && \
+        libwebp-dev \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -73,23 +70,16 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
-# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
-# Acquire::Retries makes apt retry the fetch instead of failing the build.
-# Fix any broken dependencies first (from partial installs)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt --fix-broken install -y || true && \
-    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    libpq5 \
-    libcurl4 \
-    libjpeg62-turbo \
-    zlib1g \
-    libpng16-16 \
-    libtiff5 \
-    libfreetype6 \
-    liblcms2-2 \
-    libwebp6 \
-    || (apt-get -o Acquire::Retries=5 update && \
-        apt --fix-broken install -y || true && \
+# deb.debian.org (Fastly) intermittently resets connections, and sporadically
+# returns 404 for pool files that do exist -- the same URL serves fine minutes
+# later. Acquire::Retries handles the transport errors, but apt treats 404 as
+# fatal and will not retry it, so retry the whole update+install with a pause.
+# Bounded, so a genuinely missing package still fails the build.
+# Do not "fix" this by pointing at another mirror: security.debian.org and
+# cloudfront.debian.net were both measured to 404 bullseye-security pool files
+# that deb.debian.org serves correctly.
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         libpq5 \
         libcurl4 \
@@ -99,7 +89,13 @@ RUN apt-get -o Acquire::Retries=5 update && \
         libtiff5 \
         libfreetype6 \
         liblcms2-2 \
-        libwebp6)) && \
+        libwebp6 \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/django/Dockerfile
+++ b/docker/prod/django/Dockerfile
@@ -17,11 +17,12 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install build dependencies only
-# Add retry logic and --fix-missing to handle transient network issues
+# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
+# Acquire::Retries makes apt retry the fetch instead of failing the build.
 # Fix any broken dependencies first (from partial installs)
-RUN apt-get update && \
+RUN apt-get -o Acquire::Retries=5 update && \
     apt --fix-broken install -y || true && \
-    (apt-get install -y --no-install-recommends --fix-missing \
+    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     build-essential \
     libpq-dev \
     libcurl4-openssl-dev \
@@ -33,9 +34,9 @@ RUN apt-get update && \
     libfreetype6-dev \
     liblcms2-dev \
     libwebp-dev \
-    || (apt-get update && \
+    || (apt-get -o Acquire::Retries=5 update && \
         apt --fix-broken install -y || true && \
-        apt-get install -y --no-install-recommends --fix-missing \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         build-essential \
         libpq-dev \
         libcurl4-openssl-dev \
@@ -72,11 +73,12 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
-# Add retry logic and --fix-missing to handle transient network issues
+# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
+# Acquire::Retries makes apt retry the fetch instead of failing the build.
 # Fix any broken dependencies first (from partial installs)
-RUN apt-get update && \
+RUN apt-get -o Acquire::Retries=5 update && \
     apt --fix-broken install -y || true && \
-    (apt-get install -y --no-install-recommends --fix-missing \
+    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     libpq5 \
     libcurl4 \
     libjpeg62-turbo \
@@ -86,9 +88,9 @@ RUN apt-get update && \
     libfreetype6 \
     liblcms2-2 \
     libwebp6 \
-    || (apt-get update && \
+    || (apt-get -o Acquire::Retries=5 update && \
         apt --fix-broken install -y || true && \
-        apt-get install -y --no-install-recommends --fix-missing \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         libpq5 \
         libcurl4 \
         libjpeg62-turbo \

--- a/docker/prod/django/Dockerfile
+++ b/docker/prod/django/Dockerfile
@@ -21,10 +21,12 @@ ENV PYTHONUNBUFFERED=1 \
 # returns 404 for pool files that do exist -- the same URL serves fine minutes
 # later. Acquire::Retries handles the transport errors, but apt treats 404 as
 # fatal and will not retry it, so retry the whole update+install with a pause.
-# Bounded, so a genuinely missing package still fails the build.
+# Bounded and guarded with 'exit 1', so a genuinely missing package still fails
+# the build rather than silently continuing without it.
 # Do not "fix" this by pointing at another mirror: security.debian.org and
-# cloudfront.debian.net were both measured to 404 bullseye-security pool files
-# that deb.debian.org serves correctly.
+# cloudfront.debian.net were each measured, at different times, to 404 on
+# bullseye-security pool files that deb.debian.org served correctly, and vice
+# versa -- there is no single mirror that is reliably the clean one.
 RUN n=0; until [ "$n" -ge 4 ]; do \
         apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -44,7 +46,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -74,10 +76,12 @@ ENV PYTHONUNBUFFERED=1 \
 # returns 404 for pool files that do exist -- the same URL serves fine minutes
 # later. Acquire::Retries handles the transport errors, but apt treats 404 as
 # fatal and will not retry it, so retry the whole update+install with a pause.
-# Bounded, so a genuinely missing package still fails the build.
+# Bounded and guarded with 'exit 1', so a genuinely missing package still fails
+# the build rather than silently continuing without it.
 # Do not "fix" this by pointing at another mirror: security.debian.org and
-# cloudfront.debian.net were both measured to 404 bullseye-security pool files
-# that deb.debian.org serves correctly.
+# cloudfront.debian.net were each measured, at different times, to 404 on
+# bullseye-security pool files that deb.debian.org served correctly, and vice
+# versa -- there is no single mirror that is reliably the clean one.
 RUN n=0; until [ "$n" -ge 4 ]; do \
         apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -95,7 +99,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/nodejs/Dockerfile
+++ b/docker/prod/nodejs/Dockerfile
@@ -16,10 +16,12 @@ ENV NODE_ENV=${NODE_ENV} \
 # returns 404 for pool files that do exist -- the same URL serves fine minutes
 # later. Acquire::Retries handles the transport errors, but apt treats 404 as
 # fatal and will not retry it, so retry the whole update+install with a pause.
-# Bounded, so a genuinely missing package still fails the build.
+# Bounded and guarded with 'exit 1', so a genuinely missing package still fails
+# the build rather than silently continuing without it.
 # Do not "fix" this by pointing at another mirror: security.debian.org and
-# cloudfront.debian.net were both measured to 404 bullseye-security pool files
-# that deb.debian.org serves correctly.
+# cloudfront.debian.net were each measured, at different times, to 404 on
+# bullseye-security pool files that deb.debian.org served correctly, and vice
+# versa -- there is no single mirror that is reliably the clean one.
 RUN n=0; until [ "$n" -ge 4 ]; do \
         apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -37,7 +39,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -90,10 +92,12 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 # returns 404 for pool files that do exist -- the same URL serves fine minutes
 # later. Acquire::Retries handles the transport errors, but apt treats 404 as
 # fatal and will not retry it, so retry the whole update+install with a pause.
-# Bounded, so a genuinely missing package still fails the build.
+# Bounded and guarded with 'exit 1', so a genuinely missing package still fails
+# the build rather than silently continuing without it.
 # Do not "fix" this by pointing at another mirror: security.debian.org and
-# cloudfront.debian.net were both measured to 404 bullseye-security pool files
-# that deb.debian.org serves correctly.
+# cloudfront.debian.net were each measured, at different times, to 404 on
+# bullseye-security pool files that deb.debian.org served correctly, and vice
+# versa -- there is no single mirror that is reliably the clean one.
 RUN n=0; until [ "$n" -ge 4 ]; do \
         apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -105,7 +109,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/* && \
     # Clean Chrome unnecessary files

--- a/docker/prod/nodejs/Dockerfile
+++ b/docker/prod/nodejs/Dockerfile
@@ -12,23 +12,16 @@ ENV NODE_ENV=${NODE_ENV} \
     NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000
 
 # Install build dependencies only (for native module compilation and bower)
-# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
-# Acquire::Retries makes apt retry the fetch instead of failing the build.
-# Fix any broken dependencies first (from partial installs)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt --fix-broken install -y || true && \
-    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    python2 \
-    python-is-python2 \
-    make \
-    g++ \
-    git \
-    ca-certificates \
-    curl \
-    wget \
-    gnupg \
-    || (apt-get -o Acquire::Retries=5 update && \
-        apt --fix-broken install -y || true && \
+# deb.debian.org (Fastly) intermittently resets connections, and sporadically
+# returns 404 for pool files that do exist -- the same URL serves fine minutes
+# later. Acquire::Retries handles the transport errors, but apt treats 404 as
+# fatal and will not retry it, so retry the whole update+install with a pause.
+# Bounded, so a genuinely missing package still fails the build.
+# Do not "fix" this by pointing at another mirror: security.debian.org and
+# cloudfront.debian.net were both measured to 404 bullseye-security pool files
+# that deb.debian.org serves correctly.
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         python2 \
         python-is-python2 \
@@ -38,7 +31,13 @@ RUN apt-get -o Acquire::Retries=5 update && \
         ca-certificates \
         curl \
         wget \
-        gnupg)) && \
+        gnupg \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -84,12 +83,29 @@ RUN mkdir -p /code/ssl && \
 RUN bower install --allow-root
 
 # Install Chrome for testing (if needed)
-# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
-# Acquire::Retries makes apt retry the fetch instead of failing the build.
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list && \
-    apt-get -o Acquire::Retries=5 update && \
-    apt-get -o Acquire::Retries=5 install -y --no-install-recommends google-chrome-stable libxss1 xvfb && \
+    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
+
+# deb.debian.org (Fastly) intermittently resets connections, and sporadically
+# returns 404 for pool files that do exist -- the same URL serves fine minutes
+# later. Acquire::Retries handles the transport errors, but apt treats 404 as
+# fatal and will not retry it, so retry the whole update+install with a pause.
+# Bounded, so a genuinely missing package still fails the build.
+# Do not "fix" this by pointing at another mirror: security.debian.org and
+# cloudfront.debian.net were both measured to 404 bullseye-security pool files
+# that deb.debian.org serves correctly.
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        google-chrome-stable \
+        libxss1 \
+        xvfb \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/* && \
     # Clean Chrome unnecessary files

--- a/docker/prod/nodejs/Dockerfile
+++ b/docker/prod/nodejs/Dockerfile
@@ -12,11 +12,12 @@ ENV NODE_ENV=${NODE_ENV} \
     NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000
 
 # Install build dependencies only (for native module compilation and bower)
-# Add retry logic and --fix-missing to handle transient network issues
+# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
+# Acquire::Retries makes apt retry the fetch instead of failing the build.
 # Fix any broken dependencies first (from partial installs)
-RUN apt-get update && \
+RUN apt-get -o Acquire::Retries=5 update && \
     apt --fix-broken install -y || true && \
-    (apt-get install -y --no-install-recommends --fix-missing \
+    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     python2 \
     python-is-python2 \
     make \
@@ -26,9 +27,9 @@ RUN apt-get update && \
     curl \
     wget \
     gnupg \
-    || (apt-get update && \
+    || (apt-get -o Acquire::Retries=5 update && \
         apt --fix-broken install -y || true && \
-        apt-get install -y --no-install-recommends --fix-missing \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         python2 \
         python-is-python2 \
         make \
@@ -83,11 +84,12 @@ RUN mkdir -p /code/ssl && \
 RUN bower install --allow-root
 
 # Install Chrome for testing (if needed)
-# Add retry logic and --fix-missing to handle transient network issues
+# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
+# Acquire::Retries makes apt retry the fetch instead of failing the build.
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends google-chrome-stable libxss1 xvfb && \
+    apt-get -o Acquire::Retries=5 update && \
+    apt-get -o Acquire::Retries=5 install -y --no-install-recommends google-chrome-stable libxss1 xvfb && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/* && \
     # Clean Chrome unnecessary files

--- a/docker/prod/worker_py3_7/Dockerfile
+++ b/docker/prod/worker_py3_7/Dockerfile
@@ -17,11 +17,12 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install all build dependencies
-# Add retry logic and --fix-missing to handle transient network issues
+# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
+# Acquire::Retries makes apt retry the fetch instead of failing the build.
 # Fix any broken dependencies first (from partial installs)
-RUN apt-get update && \
+RUN apt-get -o Acquire::Retries=5 update && \
     apt --fix-broken install -y || true && \
-    (apt-get install -y --no-install-recommends --fix-missing \
+    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
      build-essential \
      python3-dev \
      libpq-dev \
@@ -44,9 +45,9 @@ RUN apt-get update && \
      libgmp-dev \
      libcgal-qt5-dev \
      swig \
-     || (apt-get update && \
+     || (apt-get -o Acquire::Retries=5 update && \
          apt --fix-broken install -y || true && \
-         apt-get install -y --no-install-recommends --fix-missing \
+         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
          build-essential \
          python3-dev \
          libpq-dev \
@@ -112,11 +113,12 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
 # Note: We copy OpenCV libs from builder to avoid python3-opencv dependency issues
-# Add retry logic and --fix-missing to handle transient network issues
+# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
+# Acquire::Retries makes apt retry the fetch instead of failing the build.
 # Fix any broken dependencies first (from partial installs)
-RUN apt-get update && \
+RUN apt-get -o Acquire::Retries=5 update && \
     apt --fix-broken install -y || true && \
-    (apt-get install -y --no-install-recommends --fix-missing \
+    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     default-jre-headless \
     libpq5 \
     libcurl4 \
@@ -130,9 +132,9 @@ RUN apt-get update && \
     libgmp10 \
     libgl1 \
     libglib2.0-0 \
-    || (apt-get update && \
+    || (apt-get -o Acquire::Retries=5 update && \
         apt --fix-broken install -y || true && \
-        apt-get install -y --no-install-recommends --fix-missing \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         default-jre-headless \
         libpq5 \
         libcurl4 \

--- a/docker/prod/worker_py3_7/Dockerfile
+++ b/docker/prod/worker_py3_7/Dockerfile
@@ -21,10 +21,12 @@ ENV PYTHONUNBUFFERED=1 \
 # returns 404 for pool files that do exist -- the same URL serves fine minutes
 # later. Acquire::Retries handles the transport errors, but apt treats 404 as
 # fatal and will not retry it, so retry the whole update+install with a pause.
-# Bounded, so a genuinely missing package still fails the build.
+# Bounded and guarded with 'exit 1', so a genuinely missing package still fails
+# the build rather than silently continuing without it.
 # Do not "fix" this by pointing at another mirror: security.debian.org and
-# cloudfront.debian.net were both measured to 404 bullseye-security pool files
-# that deb.debian.org serves correctly.
+# cloudfront.debian.net were each measured, at different times, to 404 on
+# bullseye-security pool files that deb.debian.org served correctly, and vice
+# versa -- there is no single mirror that is reliably the clean one.
 RUN n=0; until [ "$n" -ge 4 ]; do \
         apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -55,7 +57,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -103,10 +105,12 @@ ENV PYTHONUNBUFFERED=1 \
 # returns 404 for pool files that do exist -- the same URL serves fine minutes
 # later. Acquire::Retries handles the transport errors, but apt treats 404 as
 # fatal and will not retry it, so retry the whole update+install with a pause.
-# Bounded, so a genuinely missing package still fails the build.
+# Bounded and guarded with 'exit 1', so a genuinely missing package still fails
+# the build rather than silently continuing without it.
 # Do not "fix" this by pointing at another mirror: security.debian.org and
-# cloudfront.debian.net were both measured to 404 bullseye-security pool files
-# that deb.debian.org serves correctly.
+# cloudfront.debian.net were each measured, at different times, to 404 on
+# bullseye-security pool files that deb.debian.org served correctly, and vice
+# versa -- there is no single mirror that is reliably the clean one.
 RUN n=0; until [ "$n" -ge 4 ]; do \
         apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -128,7 +132,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/worker_py3_7/Dockerfile
+++ b/docker/prod/worker_py3_7/Dockerfile
@@ -17,59 +17,45 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install all build dependencies
-# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
-# Acquire::Retries makes apt retry the fetch instead of failing the build.
-# Fix any broken dependencies first (from partial installs)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt --fix-broken install -y || true && \
-    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-     build-essential \
-     python3-dev \
-     libpq-dev \
-     libcurl4-openssl-dev \
-     libssl-dev \
-     libjpeg-dev \
-     zlib1g-dev \
-     libpng-dev \
-     libtiff-dev \
-     libfreetype6-dev \
-     liblcms2-dev \
-     libwebp-dev \
-     default-jre-headless \
-     git \
-     cmake \
-     libeigen3-dev \
-     libboost-python-dev \
-     libopencv-dev \
-     python3-opencv \
-     libgmp-dev \
-     libcgal-qt5-dev \
-     swig \
-     || (apt-get -o Acquire::Retries=5 update && \
-         apt --fix-broken install -y || true && \
-         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-         build-essential \
-         python3-dev \
-         libpq-dev \
-         libcurl4-openssl-dev \
-         libssl-dev \
-         libjpeg-dev \
-         zlib1g-dev \
-         libpng-dev \
-         libtiff-dev \
-         libfreetype6-dev \
-         liblcms2-dev \
-         libwebp-dev \
-         default-jre-headless \
-         git \
-         cmake \
-         libeigen3-dev \
-         libboost-python-dev \
-         libopencv-dev \
-         python3-opencv \
-         libgmp-dev \
-         libcgal-qt5-dev \
-         swig)) && \
+# deb.debian.org (Fastly) intermittently resets connections, and sporadically
+# returns 404 for pool files that do exist -- the same URL serves fine minutes
+# later. Acquire::Retries handles the transport errors, but apt treats 404 as
+# fatal and will not retry it, so retry the whole update+install with a pause.
+# Bounded, so a genuinely missing package still fails the build.
+# Do not "fix" this by pointing at another mirror: security.debian.org and
+# cloudfront.debian.net were both measured to 404 bullseye-security pool files
+# that deb.debian.org serves correctly.
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        build-essential \
+        python3-dev \
+        libpq-dev \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libjpeg-dev \
+        zlib1g-dev \
+        libpng-dev \
+        libtiff-dev \
+        libfreetype6-dev \
+        liblcms2-dev \
+        libwebp-dev \
+        default-jre-headless \
+        git \
+        cmake \
+        libeigen3-dev \
+        libboost-python-dev \
+        libopencv-dev \
+        python3-opencv \
+        libgmp-dev \
+        libcgal-qt5-dev \
+        swig \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -113,27 +99,16 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
 # Note: We copy OpenCV libs from builder to avoid python3-opencv dependency issues
-# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
-# Acquire::Retries makes apt retry the fetch instead of failing the build.
-# Fix any broken dependencies first (from partial installs)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt --fix-broken install -y || true && \
-    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    default-jre-headless \
-    libpq5 \
-    libcurl4 \
-    libjpeg62-turbo \
-    zlib1g \
-    libpng16-16 \
-    libtiff5 \
-    libfreetype6 \
-    liblcms2-2 \
-    libwebp6 \
-    libgmp10 \
-    libgl1 \
-    libglib2.0-0 \
-    || (apt-get -o Acquire::Retries=5 update && \
-        apt --fix-broken install -y || true && \
+# deb.debian.org (Fastly) intermittently resets connections, and sporadically
+# returns 404 for pool files that do exist -- the same URL serves fine minutes
+# later. Acquire::Retries handles the transport errors, but apt treats 404 as
+# fatal and will not retry it, so retry the whole update+install with a pause.
+# Bounded, so a genuinely missing package still fails the build.
+# Do not "fix" this by pointing at another mirror: security.debian.org and
+# cloudfront.debian.net were both measured to 404 bullseye-security pool files
+# that deb.debian.org serves correctly.
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         default-jre-headless \
         libpq5 \
@@ -147,7 +122,13 @@ RUN apt-get -o Acquire::Retries=5 update && \
         libwebp6 \
         libgmp10 \
         libgl1 \
-        libglib2.0-0)) && \
+        libglib2.0-0 \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/worker_py3_8/Dockerfile
+++ b/docker/prod/worker_py3_8/Dockerfile
@@ -21,10 +21,12 @@ ENV PYTHONUNBUFFERED=1 \
 # returns 404 for pool files that do exist -- the same URL serves fine minutes
 # later. Acquire::Retries handles the transport errors, but apt treats 404 as
 # fatal and will not retry it, so retry the whole update+install with a pause.
-# Bounded, so a genuinely missing package still fails the build.
+# Bounded and guarded with 'exit 1', so a genuinely missing package still fails
+# the build rather than silently continuing without it.
 # Do not "fix" this by pointing at another mirror: security.debian.org and
-# cloudfront.debian.net were both measured to 404 bullseye-security pool files
-# that deb.debian.org serves correctly.
+# cloudfront.debian.net were each measured, at different times, to 404 on
+# bullseye-security pool files that deb.debian.org served correctly, and vice
+# versa -- there is no single mirror that is reliably the clean one.
 RUN n=0; until [ "$n" -ge 4 ]; do \
         apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -55,7 +57,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -101,10 +103,12 @@ ENV PYTHONUNBUFFERED=1 \
 # returns 404 for pool files that do exist -- the same URL serves fine minutes
 # later. Acquire::Retries handles the transport errors, but apt treats 404 as
 # fatal and will not retry it, so retry the whole update+install with a pause.
-# Bounded, so a genuinely missing package still fails the build.
+# Bounded and guarded with 'exit 1', so a genuinely missing package still fails
+# the build rather than silently continuing without it.
 # Do not "fix" this by pointing at another mirror: security.debian.org and
-# cloudfront.debian.net were both measured to 404 bullseye-security pool files
-# that deb.debian.org serves correctly.
+# cloudfront.debian.net were each measured, at different times, to 404 on
+# bullseye-security pool files that deb.debian.org served correctly, and vice
+# versa -- there is no single mirror that is reliably the clean one.
 RUN n=0; until [ "$n" -ge 4 ]; do \
         apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -126,7 +130,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/worker_py3_8/Dockerfile
+++ b/docker/prod/worker_py3_8/Dockerfile
@@ -16,60 +16,46 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_DEFAULT_TIMEOUT=100
 
-# Install all build dependencies with retry logic
-# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
-# Acquire::Retries makes apt retry the fetch instead of failing the build.
-# Fix any broken dependencies first (from partial installs)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt --fix-broken install -y || true && \
-    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-     build-essential \
-     python3-dev \
-     libpq-dev \
-     libcurl4-openssl-dev \
-     libssl-dev \
-     libjpeg-dev \
-     zlib1g-dev \
-     libpng-dev \
-     libtiff-dev \
-     libfreetype6-dev \
-     liblcms2-dev \
-     libwebp-dev \
-     default-jre-headless \
-     git \
-     cmake \
-     libeigen3-dev \
-     libboost-python-dev \
-     libopencv-dev \
-     python3-opencv \
-     libgmp-dev \
-     libcgal-qt5-dev \
-     swig \
-     || (apt-get -o Acquire::Retries=5 update && \
-         apt --fix-broken install -y || true && \
-         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-         build-essential \
-         python3-dev \
-         libpq-dev \
-         libcurl4-openssl-dev \
-         libssl-dev \
-         libjpeg-dev \
-         zlib1g-dev \
-         libpng-dev \
-         libtiff-dev \
-         libfreetype6-dev \
-         liblcms2-dev \
-         libwebp-dev \
-         default-jre-headless \
-         git \
-         cmake \
-         libeigen3-dev \
-         libboost-python-dev \
-         libopencv-dev \
-         python3-opencv \
-         libgmp-dev \
-         libcgal-qt5-dev \
-         swig)) && \
+# Install all build dependencies
+# deb.debian.org (Fastly) intermittently resets connections, and sporadically
+# returns 404 for pool files that do exist -- the same URL serves fine minutes
+# later. Acquire::Retries handles the transport errors, but apt treats 404 as
+# fatal and will not retry it, so retry the whole update+install with a pause.
+# Bounded, so a genuinely missing package still fails the build.
+# Do not "fix" this by pointing at another mirror: security.debian.org and
+# cloudfront.debian.net were both measured to 404 bullseye-security pool files
+# that deb.debian.org serves correctly.
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        build-essential \
+        python3-dev \
+        libpq-dev \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libjpeg-dev \
+        zlib1g-dev \
+        libpng-dev \
+        libtiff-dev \
+        libfreetype6-dev \
+        liblcms2-dev \
+        libwebp-dev \
+        default-jre-headless \
+        git \
+        cmake \
+        libeigen3-dev \
+        libboost-python-dev \
+        libopencv-dev \
+        python3-opencv \
+        libgmp-dev \
+        libcgal-qt5-dev \
+        swig \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -111,27 +97,16 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
 # Note: We copy OpenCV libs from builder to avoid python3-opencv dependency issues
-# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
-# Acquire::Retries makes apt retry the fetch instead of failing the build.
-# Fix any broken dependencies first (from partial installs)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt --fix-broken install -y || true && \
-    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    default-jre-headless \
-    libpq5 \
-    libcurl4 \
-    libjpeg62-turbo \
-    zlib1g \
-    libpng16-16 \
-    libtiff5 \
-    libfreetype6 \
-    liblcms2-2 \
-    libwebp6 \
-    libgmp10 \
-    libgl1 \
-    libglib2.0-0 \
-    || (apt-get -o Acquire::Retries=5 update && \
-        apt --fix-broken install -y || true && \
+# deb.debian.org (Fastly) intermittently resets connections, and sporadically
+# returns 404 for pool files that do exist -- the same URL serves fine minutes
+# later. Acquire::Retries handles the transport errors, but apt treats 404 as
+# fatal and will not retry it, so retry the whole update+install with a pause.
+# Bounded, so a genuinely missing package still fails the build.
+# Do not "fix" this by pointing at another mirror: security.debian.org and
+# cloudfront.debian.net were both measured to 404 bullseye-security pool files
+# that deb.debian.org serves correctly.
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         default-jre-headless \
         libpq5 \
@@ -145,7 +120,13 @@ RUN apt-get -o Acquire::Retries=5 update && \
         libwebp6 \
         libgmp10 \
         libgl1 \
-        libglib2.0-0)) && \
+        libglib2.0-0 \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/worker_py3_8/Dockerfile
+++ b/docker/prod/worker_py3_8/Dockerfile
@@ -17,11 +17,12 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install all build dependencies with retry logic
-# Add retry logic and --fix-missing to handle transient network issues
+# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
+# Acquire::Retries makes apt retry the fetch instead of failing the build.
 # Fix any broken dependencies first (from partial installs)
-RUN apt-get update && \
+RUN apt-get -o Acquire::Retries=5 update && \
     apt --fix-broken install -y || true && \
-    (apt-get install -y --no-install-recommends --fix-missing \
+    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
      build-essential \
      python3-dev \
      libpq-dev \
@@ -44,9 +45,9 @@ RUN apt-get update && \
      libgmp-dev \
      libcgal-qt5-dev \
      swig \
-     || (apt-get update && \
+     || (apt-get -o Acquire::Retries=5 update && \
          apt --fix-broken install -y || true && \
-         apt-get install -y --no-install-recommends --fix-missing \
+         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
          build-essential \
          python3-dev \
          libpq-dev \
@@ -110,11 +111,12 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
 # Note: We copy OpenCV libs from builder to avoid python3-opencv dependency issues
-# Add retry logic and --fix-missing to handle transient network issues
+# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
+# Acquire::Retries makes apt retry the fetch instead of failing the build.
 # Fix any broken dependencies first (from partial installs)
-RUN apt-get update && \
+RUN apt-get -o Acquire::Retries=5 update && \
     apt --fix-broken install -y || true && \
-    (apt-get install -y --no-install-recommends --fix-missing \
+    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     default-jre-headless \
     libpq5 \
     libcurl4 \
@@ -128,9 +130,9 @@ RUN apt-get update && \
     libgmp10 \
     libgl1 \
     libglib2.0-0 \
-    || (apt-get update && \
+    || (apt-get -o Acquire::Retries=5 update && \
         apt --fix-broken install -y || true && \
-        apt-get install -y --no-install-recommends --fix-missing \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         default-jre-headless \
         libpq5 \
         libcurl4 \

--- a/docker/prod/worker_py3_9/Dockerfile
+++ b/docker/prod/worker_py3_9/Dockerfile
@@ -17,11 +17,12 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install all build dependencies
-# Add retry logic and --fix-missing to handle transient network issues
+# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
+# Acquire::Retries makes apt retry the fetch instead of failing the build.
 # Fix any broken dependencies first (from partial installs)
-RUN apt-get update && \
+RUN apt-get -o Acquire::Retries=5 update && \
     apt --fix-broken install -y || true && \
-    (apt-get install -y --no-install-recommends --fix-missing \
+    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
      build-essential \
      python3-dev \
      libpq-dev \
@@ -45,9 +46,9 @@ RUN apt-get update && \
      libcgal-qt5-dev \
      swig \
      curl \
-     || (apt-get update && \
+     || (apt-get -o Acquire::Retries=5 update && \
          apt --fix-broken install -y || true && \
-         apt-get install -y --no-install-recommends --fix-missing \
+         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
          build-essential \
          python3-dev \
          libpq-dev \
@@ -115,11 +116,12 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
 # Note: We copy OpenCV libs from builder to avoid python3-opencv dependency issues
-# Add retry logic and --fix-missing to handle transient network issues
+# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
+# Acquire::Retries makes apt retry the fetch instead of failing the build.
 # Fix any broken dependencies first (from partial installs)
-RUN apt-get update && \
+RUN apt-get -o Acquire::Retries=5 update && \
     apt --fix-broken install -y || true && \
-    (apt-get install -y --no-install-recommends --fix-missing \
+    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     default-jre-headless \
     libpq5 \
     libcurl4 \
@@ -133,9 +135,9 @@ RUN apt-get update && \
     libgmp10 \
     libgl1 \
     libglib2.0-0 \
-    || (apt-get update && \
+    || (apt-get -o Acquire::Retries=5 update && \
         apt --fix-broken install -y || true && \
-        apt-get install -y --no-install-recommends --fix-missing \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         default-jre-headless \
         libpq5 \
         libcurl4 \

--- a/docker/prod/worker_py3_9/Dockerfile
+++ b/docker/prod/worker_py3_9/Dockerfile
@@ -21,10 +21,12 @@ ENV PYTHONUNBUFFERED=1 \
 # returns 404 for pool files that do exist -- the same URL serves fine minutes
 # later. Acquire::Retries handles the transport errors, but apt treats 404 as
 # fatal and will not retry it, so retry the whole update+install with a pause.
-# Bounded, so a genuinely missing package still fails the build.
+# Bounded and guarded with 'exit 1', so a genuinely missing package still fails
+# the build rather than silently continuing without it.
 # Do not "fix" this by pointing at another mirror: security.debian.org and
-# cloudfront.debian.net were both measured to 404 bullseye-security pool files
-# that deb.debian.org serves correctly.
+# cloudfront.debian.net were each measured, at different times, to 404 on
+# bullseye-security pool files that deb.debian.org served correctly, and vice
+# versa -- there is no single mirror that is reliably the clean one.
 RUN n=0; until [ "$n" -ge 4 ]; do \
         apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -56,7 +58,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -105,10 +107,12 @@ ENV PYTHONUNBUFFERED=1 \
 # returns 404 for pool files that do exist -- the same URL serves fine minutes
 # later. Acquire::Retries handles the transport errors, but apt treats 404 as
 # fatal and will not retry it, so retry the whole update+install with a pause.
-# Bounded, so a genuinely missing package still fails the build.
+# Bounded and guarded with 'exit 1', so a genuinely missing package still fails
+# the build rather than silently continuing without it.
 # Do not "fix" this by pointing at another mirror: security.debian.org and
-# cloudfront.debian.net were both measured to 404 bullseye-security pool files
-# that deb.debian.org serves correctly.
+# cloudfront.debian.net were each measured, at different times, to 404 on
+# bullseye-security pool files that deb.debian.org served correctly, and vice
+# versa -- there is no single mirror that is reliably the clean one.
 RUN n=0; until [ "$n" -ge 4 ]; do \
         apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -130,7 +134,7 @@ RUN n=0; until [ "$n" -ge 4 ]; do \
         echo "apt failed (attempt $n), retrying in 20s" >&2; \
         sleep 20; \
     done; \
-    [ "$n" -lt 4 ] && \
+    [ "$n" -lt 4 ] || exit 1; \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/worker_py3_9/Dockerfile
+++ b/docker/prod/worker_py3_9/Dockerfile
@@ -17,61 +17,46 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100
 
 # Install all build dependencies
-# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
-# Acquire::Retries makes apt retry the fetch instead of failing the build.
-# Fix any broken dependencies first (from partial installs)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt --fix-broken install -y || true && \
-    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-     build-essential \
-     python3-dev \
-     libpq-dev \
-     libcurl4-openssl-dev \
-     libssl-dev \
-     libjpeg-dev \
-     zlib1g-dev \
-     libpng-dev \
-     libtiff-dev \
-     libfreetype6-dev \
-     liblcms2-dev \
-     libwebp-dev \
-     default-jre-headless \
-     git \
-     cmake \
-     libeigen3-dev \
-     libboost-python-dev \
-     libopencv-dev \
-     python3-opencv \
-     libgmp-dev \
-     libcgal-qt5-dev \
-     swig \
-     curl \
-     || (apt-get -o Acquire::Retries=5 update && \
-         apt --fix-broken install -y || true && \
-         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-         build-essential \
-         python3-dev \
-         libpq-dev \
-         libcurl4-openssl-dev \
-         libssl-dev \
-         libjpeg-dev \
-         zlib1g-dev \
-         libpng-dev \
-         libtiff-dev \
-         libfreetype6-dev \
-         liblcms2-dev \
-         libwebp-dev \
-         default-jre-headless \
-         git \
-         cmake \
-         libeigen3-dev \
-         libboost-python-dev \
-         libopencv-dev \
-         python3-opencv \
-         libgmp-dev \
-         libcgal-qt5-dev \
-         swig \
-         curl)) && \
+# deb.debian.org (Fastly) intermittently resets connections, and sporadically
+# returns 404 for pool files that do exist -- the same URL serves fine minutes
+# later. Acquire::Retries handles the transport errors, but apt treats 404 as
+# fatal and will not retry it, so retry the whole update+install with a pause.
+# Bounded, so a genuinely missing package still fails the build.
+# Do not "fix" this by pointing at another mirror: security.debian.org and
+# cloudfront.debian.net were both measured to 404 bullseye-security pool files
+# that deb.debian.org serves correctly.
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
+        apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        build-essential \
+        python3-dev \
+        libpq-dev \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libjpeg-dev \
+        zlib1g-dev \
+        libpng-dev \
+        libtiff-dev \
+        libfreetype6-dev \
+        liblcms2-dev \
+        libwebp-dev \
+        default-jre-headless \
+        git \
+        cmake \
+        libeigen3-dev \
+        libboost-python-dev \
+        libopencv-dev \
+        python3-opencv \
+        libgmp-dev \
+        libcgal-qt5-dev \
+        swig \
+        curl \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
@@ -116,27 +101,16 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Install runtime dependencies (apt-get handles multi-arch automatically)
 # Note: We copy OpenCV libs from builder to avoid python3-opencv dependency issues
-# deb.debian.org (Fastly) intermittently resets connections and 404s pool files;
-# Acquire::Retries makes apt retry the fetch instead of failing the build.
-# Fix any broken dependencies first (from partial installs)
-RUN apt-get -o Acquire::Retries=5 update && \
-    apt --fix-broken install -y || true && \
-    (apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
-    default-jre-headless \
-    libpq5 \
-    libcurl4 \
-    libjpeg62-turbo \
-    zlib1g \
-    libpng16-16 \
-    libtiff5 \
-    libfreetype6 \
-    liblcms2-2 \
-    libwebp6 \
-    libgmp10 \
-    libgl1 \
-    libglib2.0-0 \
-    || (apt-get -o Acquire::Retries=5 update && \
-        apt --fix-broken install -y || true && \
+# deb.debian.org (Fastly) intermittently resets connections, and sporadically
+# returns 404 for pool files that do exist -- the same URL serves fine minutes
+# later. Acquire::Retries handles the transport errors, but apt treats 404 as
+# fatal and will not retry it, so retry the whole update+install with a pause.
+# Bounded, so a genuinely missing package still fails the build.
+# Do not "fix" this by pointing at another mirror: security.debian.org and
+# cloudfront.debian.net were both measured to 404 bullseye-security pool files
+# that deb.debian.org serves correctly.
+RUN n=0; until [ "$n" -ge 4 ]; do \
+        apt-get -o Acquire::Retries=5 update && \
         apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
         default-jre-headless \
         libpq5 \
@@ -150,7 +124,13 @@ RUN apt-get -o Acquire::Retries=5 update && \
         libwebp6 \
         libgmp10 \
         libgl1 \
-        libglib2.0-0)) && \
+        libglib2.0-0 \
+        && break; \
+        n=$((n+1)); \
+        echo "apt failed (attempt $n), retrying in 20s" >&2; \
+        sleep 20; \
+    done; \
+    [ "$n" -lt 4 ] && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 


### PR DESCRIPTION
## Change Description

Docker image builds fail intermittently on `deb.debian.org` fetch errors. Two distinct failure modes were observed in CI, and this PR addresses both.

**1. Transport errors — connection resets.** From [run 33665809471](https://github.com/Cloud-CV/EvalAI/actions/runs/33665809471), in the `worker_py3_7` **runtime** stage:

```
E: Failed to fetch http://deb.debian.org/debian/pool/main/z/z3/libz3-4_4.8.10-1_amd64.deb
   Error reading from server - read (104: Connection reset by peer) [IP: 151.101.202.132 80]
target worker_py3_7: failed to solve: ... exit code: 100
```

apt 2.2 on bullseye defaults `Acquire::Retries` to `0`, so one blip fails the build. The builder stages had an ad-hoc fallback; the runtime stages had nothing. Now every `apt-get update`/`install` passes `-o Acquire::Retries=5`.

**2. Spurious 404s on URLs that are valid.** From [run 33901178189](https://github.com/Cloud-CV/EvalAI/actions/runs/33901178189), in the `worker_py3_8` builder stage:

```
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/q/qtbase-opensource-src/libqt5opengl5-dev_5.15.2%2bdfsg-9%2bdeb11u2_amd64.deb  404  Not Found [IP: 146.75.38.132 80]
```

That version is exactly what the current `bullseye-security` index advertises, and the URL serves `200` again minutes later. apt treats 404 as a definitive answer and will **not** retry it, so `Acquire::Retries` cannot help here. The existing fallback re-ran the install immediately — same second, same CDN edge — and duplicated the entire package list to do it.

Both shapes are now one bounded retry loop that re-runs `update`+`install` with a pause between attempts, capped at 4, with its exit status checked so a genuinely missing package still fails the build.

**Also removed:** `--fix-missing`. It tells apt to silently skip packages it could not download and continue, which turns a network failure into an unrelated-looking dependency error — the base image keeps its older `libssl1.1` (`1.1.1w-0+deb11u2`), `libssl-dev` pins `libssl1.1 (= 1.1.1w-0+deb11u8)`, and apt reports unmet dependencies instead of the download that actually failed. It can also yield images quietly missing build dependencies. Gone from all 14 Dockerfiles (52 occurrences), along with the cargo-culted `apt --fix-broken install -y || true`, which ran against a clean base image and swallowed its own exit code.

## Change Type

- [x] Bug fix (fix)

## Testing Method

- Retry loop semantics tested under **dash** (the shell these images actually use): succeeds on first attempt; retries then succeeds on a later attempt; exhausts its attempts and **fails the build non-zero** rather than continuing to the cleanup step.
- `docker build --check` passes on all 14 Dockerfiles.
- `libssl` resolution verified on `linux/amd64` in the real base image: `libssl1.1` upgrades `1.1.1w-0+deb11u2` → `1.1.1w-0+deb11u8` in lockstep with `libssl-dev`, confirming the reported "unmet dependencies" were a symptom of the masked download failure, not a real conflict.

**Not verified:** recovery from a live 404 episode. Reproducing one locally stopped being meaningful — repeated full package-set downloads got the test host rate limited, at which point failure counts no longer reflected CI conditions.

## Notes for reviewers

- **Do not "fix" this by switching mirrors.** Two candidates were tried and rejected on measurement, and the reasons are recorded in the Dockerfile comments: `security.debian.org` and `cloudfront.debian.net` both return 404 for `bullseye-security` pool files that `deb.debian.org` serves correctly. `security.debian.org` is also Fastly-fronted, so it is not an independent path.
- An earlier revision of this description claimed the spurious 404s were arm64-only. **That was wrong** — CI hit one on amd64. The encoding of `+` as `%2b` is not the cause either; both `%2b` and `%2B` were observed serving 200 and 404 for different objects at different times.
- The loop is deliberately bounded rather than `until ... done` unbounded, so a real packaging problem fails fast instead of hanging until the job timeout.

## Related Issue

No linked issue — reported via failing CI runs.

## Checklist

- [x] Code has been self-tested
- [x] Comments updated to match the new behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container build reliability by retrying Debian package updates and installations up to four times when repository operations fail.
  * Added a 20-second delay between retry attempts to better handle transient network errors and package repository inconsistencies.
  * Applied consistent package installation behavior across development and production container images.
  * Builds now stop with a clear failure after all retry attempts are exhausted, rather than continuing after unsuccessful installation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Dockerfile apt install mechanics; runtime images and package lists are unchanged, with stricter failure behavior than the removed `--fix-missing` path.
> 
> **Overview**
> Hardens **CI Docker builds** against flaky `deb.debian.org` fetches by standardizing how every image installs Debian packages.
> 
> **apt reliability:** All `apt-get update` / `install` steps in **14 dev and prod Dockerfiles** (Python workers, Django, Celery, code-upload-worker, Node) now use `-o Acquire::Retries=5` and a **bounded loop** (up to 4 attempts, 20s between tries) that re-runs **update + install** together. That covers connection resets and transient **404s** on valid pool URLs, which apt does not retry on its own. Failed installs still **exit non-zero** after exhausting attempts.
> 
> **Removed unsafe fallbacks:** **`--fix-missing`**, **`apt --fix-broken install … || true`**, and the old nested immediate re-install patterns are gone everywhere they existed, so network failures cannot produce images missing packages or misleading dependency errors.
> 
> **Node-specific:** Dev **amd64** Chrome setup splits Google repo setup from a separate retried Chrome install `RUN`; prod Node applies the same retry pattern to the Chrome install step after adding the Google apt source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0219f649dd8ba40933823e460337d5fe37b4a0ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->