### PR TITLE
Migrate Docker base images from Debian bullseye to bookworm to unblock CI

### DIFF
--- a/docker/dev/celery/Dockerfile
+++ b/docker/dev/celery/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build stage with build dependencies
-FROM python:3.9.21-slim-bullseye AS builder
+FROM python:3.9.21-slim-bookworm AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
@@ -46,7 +46,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     find /usr/local/lib/python3.9/site-packages \( -name "*.pyc" -o -name "*.pyo" \) -delete 2>/dev/null || true
 
 # Stage 2: Runtime stage - minimal dependencies
-FROM python:3.9.21-slim-bullseye
+FROM python:3.9.21-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
@@ -61,10 +61,10 @@ RUN apt-get update && \
     libjpeg62-turbo \
     zlib1g \
     libpng16-16 \
-    libtiff5 \
+    libtiff6 \
     libfreetype6 \
     liblcms2-2 \
-    libwebp6 && \
+    libwebp7 && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/dev/code-upload-worker/Dockerfile
+++ b/docker/dev/code-upload-worker/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build stage with build dependencies
-FROM python:3.9.21-slim-bullseye AS builder
+FROM python:3.9.21-slim-bookworm AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
@@ -37,7 +37,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     find /usr/local/lib/python3.9/site-packages \( -name "*.pyc" -o -name "*.pyo" \) -delete 2>/dev/null || true
 
 # Stage 2: Runtime stage - minimal dependencies
-FROM python:3.9.21-slim-bullseye
+FROM python:3.9.21-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build stage with all build dependencies
-FROM python:3.9.21-slim-bullseye AS builder
+FROM python:3.9.21-slim-bookworm AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
@@ -47,7 +47,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     find /usr/local/lib/python3.9/site-packages \( -name "*.pyc" -o -name "*.pyo" \) -delete 2>/dev/null || true
 
 # Stage 2: Runtime stage - minimal dependencies only
-FROM python:3.9.21-slim-bullseye
+FROM python:3.9.21-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
@@ -63,10 +63,10 @@ RUN apt-get update && \
     libjpeg62-turbo \
     zlib1g \
     libpng16-16 \
-    libtiff5 \
+    libtiff6 \
     libfreetype6 \
     liblcms2-2 \
-    libwebp6 \
+    libwebp7 \
     git \
     ca-certificates && \
     rm -rf /var/lib/apt/lists/* && \

--- a/docker/dev/nodejs/Dockerfile
+++ b/docker/dev/nodejs/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build stage with build tools
-FROM node:20.18.0-bullseye-slim AS builder
+FROM node:20.18.0-bookworm-slim AS builder
 
 # Set environment variables for npm
 ENV NODE_ENV=development \
@@ -16,8 +16,8 @@ ENV NODE_ENV=development \
 RUN apt-get update && \
     apt --fix-broken install -y || true && \
     (apt-get install -y --no-install-recommends --fix-missing \
-    python2 \
-    python-is-python2 \
+    python3 \
+    python-is-python3 \
     make \
     g++ \
     git \
@@ -25,8 +25,8 @@ RUN apt-get update && \
     || (apt-get update && \
         apt --fix-broken install -y || true && \
         apt-get install -y --no-install-recommends --fix-missing \
-        python2 \
-        python-is-python2 \
+        python3 \
+        python-is-python3 \
         make \
         g++ \
         git \
@@ -66,7 +66,7 @@ RUN rm -rf /root/.npm && \
     rm -rf /tmp/*
 
 # Stage 2: Base runtime stage (no build tools, no git)
-FROM node:20.18.0-bullseye-slim AS base
+FROM node:20.18.0-bookworm-slim AS base
 
 ENV NODE_ENV=development \
     CHROME_BIN=/usr/bin/google-chrome \

--- a/docker/dev/worker_py3_7/Dockerfile
+++ b/docker/dev/worker_py3_7/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build stage with all build dependencies
-FROM python:3.7-slim-bullseye AS builder
+FROM python:3.7-slim-bookworm AS builder
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
@@ -64,7 +64,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     find /usr/local/lib/python3.7/site-packages \( -name "*.pyc" -o -name "*.pyo" \) -delete 2>/dev/null || true
 
 # Stage 2: Runtime stage - minimal dependencies only
-FROM python:3.7-slim-bullseye
+FROM python:3.7-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
@@ -80,10 +80,10 @@ RUN apt-get update && \
     libjpeg62-turbo \
     zlib1g \
     libpng16-16 \
-    libtiff5 \
+    libtiff6 \
     libfreetype6 \
     liblcms2-2 \
-    libwebp6 \
+    libwebp7 \
     libgl1 \
     libglib2.0-0 && \
     rm -rf /var/lib/apt/lists/* && \

--- a/docker/dev/worker_py3_8/Dockerfile
+++ b/docker/dev/worker_py3_8/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build stage with all build dependencies
-FROM python:3.8-slim-bullseye AS builder
+FROM python:3.8-slim-bookworm AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
@@ -101,7 +101,7 @@ RUN mkdir -p /runtime-libs && \
     cp -P /usr/lib/*/libHalf* /runtime-libs/ 2>/dev/null || true
 
 # Stage 2: Runtime stage - minimal dependencies only
-FROM python:3.8-slim-bullseye
+FROM python:3.8-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
@@ -118,10 +118,10 @@ RUN apt-get update && \
     libjpeg62-turbo \
     zlib1g \
     libpng16-16 \
-    libtiff5 \
+    libtiff6 \
     libfreetype6 \
     liblcms2-2 \
-    libwebp6 \
+    libwebp7 \
     libgmp10 \
     libgl1 \
     libglib2.0-0 && \

--- a/docker/dev/worker_py3_9/Dockerfile
+++ b/docker/dev/worker_py3_9/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build stage with all build dependencies
-FROM python:3.9.21-slim-bullseye AS builder
+FROM python:3.9.21-slim-bookworm AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
@@ -76,7 +76,7 @@ RUN rm -rf /root/.cache/pip && \
 RUN python -c "import boto3, botocore, django, requests, yaml"
 
 # Stage 2: Runtime stage - minimal dependencies only
-FROM python:3.9.21-slim-bullseye
+FROM python:3.9.21-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
@@ -92,10 +92,10 @@ RUN apt-get update && \
     libjpeg62-turbo \
     zlib1g \
     libpng16-16 \
-    libtiff5 \
+    libtiff6 \
     libfreetype6 \
     liblcms2-2 \
-    libwebp6 \
+    libwebp7 \
     libgl1 \
     libglib2.0-0 && \
     rm -rf /var/lib/apt/lists/* && \

--- a/docker/prod/celery/Dockerfile
+++ b/docker/prod/celery/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build stage with build dependencies
-FROM python:3.9.21-slim-bullseye AS builder
+FROM python:3.9.21-slim-bookworm AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
@@ -64,7 +64,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     find /usr/local/lib/python3.9/site-packages \( -name "*.pyc" -o -name "*.pyo" \) -delete 2>/dev/null || true
 
 # Stage 2: Runtime stage - minimal dependencies only
-FROM python:3.9.21-slim-bullseye
+FROM python:3.9.21-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
@@ -82,10 +82,10 @@ RUN apt-get update && \
     libjpeg62-turbo \
     zlib1g \
     libpng16-16 \
-    libtiff5 \
+    libtiff6 \
     libfreetype6 \
     liblcms2-2 \
-    libwebp6 \
+    libwebp7 \
     || (apt-get update && \
         apt --fix-broken install -y || true && \
         apt-get install -y --no-install-recommends --fix-missing \
@@ -94,10 +94,10 @@ RUN apt-get update && \
         libjpeg62-turbo \
         zlib1g \
         libpng16-16 \
-        libtiff5 \
+        libtiff6 \
         libfreetype6 \
         liblcms2-2 \
-        libwebp6)) && \
+        libwebp7)) && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/code-upload-worker/Dockerfile
+++ b/docker/prod/code-upload-worker/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build stage with build dependencies
-FROM python:3.9.21-slim-bullseye AS builder
+FROM python:3.9.21-slim-bookworm AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
@@ -45,7 +45,7 @@ RUN find /usr/local/lib/python3.9/site-packages -type d -name "__pycache__" -exe
     find /usr/local/lib/python3.9/site-packages \( -name "*.pyc" -o -name "*.pyo" \) -delete 2>/dev/null || true
 
 # Stage 2: Minimal runtime stage (needs shell for install script, so can't use distroless)
-FROM python:3.9.21-slim-bullseye
+FROM python:3.9.21-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \

--- a/docker/prod/django/Dockerfile
+++ b/docker/prod/django/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build stage with all build dependencies
-FROM python:3.9.21-slim-bullseye AS builder
+FROM python:3.9.21-slim-bookworm AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
@@ -64,7 +64,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     find /usr/local/lib/python3.9/site-packages \( -name "*.pyc" -o -name "*.pyo" \) -delete 2>/dev/null || true
 
 # Stage 2: Runtime stage - minimal dependencies only
-FROM python:3.9.21-slim-bullseye
+FROM python:3.9.21-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
@@ -82,10 +82,10 @@ RUN apt-get update && \
     libjpeg62-turbo \
     zlib1g \
     libpng16-16 \
-    libtiff5 \
+    libtiff6 \
     libfreetype6 \
     liblcms2-2 \
-    libwebp6 \
+    libwebp7 \
     || (apt-get update && \
         apt --fix-broken install -y || true && \
         apt-get install -y --no-install-recommends --fix-missing \
@@ -94,10 +94,10 @@ RUN apt-get update && \
         libjpeg62-turbo \
         zlib1g \
         libpng16-16 \
-        libtiff5 \
+        libtiff6 \
         libfreetype6 \
         liblcms2-2 \
-        libwebp6)) && \
+        libwebp7)) && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*
 

--- a/docker/prod/nodejs/Dockerfile
+++ b/docker/prod/nodejs/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build stage with build tools
-FROM node:20.18.0-bullseye-slim AS builder
+FROM node:20.18.0-bookworm-slim AS builder
 
 ARG NODE_ENV=production
 
@@ -17,8 +17,8 @@ ENV NODE_ENV=${NODE_ENV} \
 RUN apt-get update && \
     apt --fix-broken install -y || true && \
     (apt-get install -y --no-install-recommends --fix-missing \
-    python2 \
-    python-is-python2 \
+    python3 \
+    python-is-python3 \
     make \
     g++ \
     git \
@@ -29,8 +29,8 @@ RUN apt-get update && \
     || (apt-get update && \
         apt --fix-broken install -y || true && \
         apt-get install -y --no-install-recommends --fix-missing \
-        python2 \
-        python-is-python2 \
+        python3 \
+        python-is-python3 \
         make \
         g++ \
         git \

--- a/docker/prod/worker_py3_7/Dockerfile
+++ b/docker/prod/worker_py3_7/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build stage with all build dependencies
-FROM python:3.7-slim-bullseye AS builder
+FROM python:3.7-slim-bookworm AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
@@ -103,7 +103,7 @@ RUN mkdir -p /runtime-libs && \
     cp -P /usr/lib/*/libHalf* /runtime-libs/ 2>/dev/null || true
 
 # Stage 2: Minimal runtime stage (Python 3.7 not available in distroless, use optimized slim)
-FROM python:3.7-slim-bullseye
+FROM python:3.7-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
@@ -123,10 +123,10 @@ RUN apt-get update && \
     libjpeg62-turbo \
     zlib1g \
     libpng16-16 \
-    libtiff5 \
+    libtiff6 \
     libfreetype6 \
     liblcms2-2 \
-    libwebp6 \
+    libwebp7 \
     libgmp10 \
     libgl1 \
     libglib2.0-0 \
@@ -139,10 +139,10 @@ RUN apt-get update && \
         libjpeg62-turbo \
         zlib1g \
         libpng16-16 \
-        libtiff5 \
+        libtiff6 \
         libfreetype6 \
         liblcms2-2 \
-        libwebp6 \
+        libwebp7 \
         libgmp10 \
         libgl1 \
         libglib2.0-0)) && \

--- a/docker/prod/worker_py3_8/Dockerfile
+++ b/docker/prod/worker_py3_8/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build stage with all build dependencies
-FROM python:3.8-slim-bullseye AS builder
+FROM python:3.8-slim-bookworm AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
@@ -101,7 +101,7 @@ RUN mkdir -p /runtime-libs && \
     cp -P /usr/lib/*/libHalf* /runtime-libs/ 2>/dev/null || true
 
 # Stage 2: Minimal runtime stage (Python 3.8 not available in distroless, use optimized slim)
-FROM python:3.8-slim-bullseye
+FROM python:3.8-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
@@ -121,10 +121,10 @@ RUN apt-get update && \
     libjpeg62-turbo \
     zlib1g \
     libpng16-16 \
-    libtiff5 \
+    libtiff6 \
     libfreetype6 \
     liblcms2-2 \
-    libwebp6 \
+    libwebp7 \
     libgmp10 \
     libgl1 \
     libglib2.0-0 \
@@ -137,10 +137,10 @@ RUN apt-get update && \
         libjpeg62-turbo \
         zlib1g \
         libpng16-16 \
-        libtiff5 \
+        libtiff6 \
         libfreetype6 \
         liblcms2-2 \
-        libwebp6 \
+        libwebp7 \
         libgmp10 \
         libgl1 \
         libglib2.0-0)) && \

--- a/docker/prod/worker_py3_9/Dockerfile
+++ b/docker/prod/worker_py3_9/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build stage with all build dependencies
-FROM python:3.9.21-slim-bullseye AS builder
+FROM python:3.9.21-slim-bookworm AS builder
 
 # Fast dependency installs via uv (drop-in for pip); the binary lives at /uv in
 # the builder stage only and is never copied into the runtime image.
@@ -106,7 +106,7 @@ RUN mkdir -p /runtime-libs && \
     cp -P /usr/lib/*/libHalf* /runtime-libs/ 2>/dev/null || true
 
 # Stage 2: Runtime stage - minimal dependencies only
-FROM python:3.9.21-slim-bullseye
+FROM python:3.9.21-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
@@ -126,10 +126,10 @@ RUN apt-get update && \
     libjpeg62-turbo \
     zlib1g \
     libpng16-16 \
-    libtiff5 \
+    libtiff6 \
     libfreetype6 \
     liblcms2-2 \
-    libwebp6 \
+    libwebp7 \
     libgmp10 \
     libgl1 \
     libglib2.0-0 \
@@ -142,10 +142,10 @@ RUN apt-get update && \
         libjpeg62-turbo \
         zlib1g \
         libpng16-16 \
-        libtiff5 \
+        libtiff6 \
         libfreetype6 \
         liblcms2-2 \
-        libwebp6 \
+        libwebp7 \
         libgmp10 \
         libgl1 \
         libglib2.0-0)) && \


### PR DESCRIPTION
## Why

Debian 11 bullseye reached [LTS end-of-life on 2026-08-31](https://www.debian.org/News/2026/20260831). The `bullseye-security` archive is now being decommissioned, and its package index still advertises versions whose pool binaries have already been pruned. `apt-get install` therefore fails mid-build with 404s.

This broke CI on `production` with no code change — [run 34092507321](https://github.com/Cloud-CV/EvalAI/actions/runs/34092507321) is commit `12a71340`, identical to `master` HEAD. All three jobs died in `Set up CI environment` (`docker compose build`), so `Package and Deploy Services` never started.

```
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/p/perl/libperl5.32_5.32.1-4%2bdeb11u5_amd64.deb  404  Not Found
```

Two things make this urgent rather than transient:

1. **The pruning is progressive.** Within hours of the first failure, `libtiff-dev`, `liblcms2-dev` and `linux-libc-dev` were also returning 404 — reproduced locally on a clean bullseye image.
2. **The index itself expires.** `bullseye-security`'s `Release` carries `Valid-Until: Mon, 07 Sep 2026 21:13:04 UTC`. Past that, apt fails on expiry for *every* bullseye image regardless of which packages it installs.

`archive.debian.org` does not yet carry `bullseye-security` (404), so there is no fallback mirror to repoint at. Moving off bullseye is the only durable fix.

## What changed

All 14 Dockerfiles move to Debian 12 bookworm:

```
python:{3.7,3.8,3.9.21}-slim-bullseye  ->  python:{3.7,3.8,3.9.21}-slim-bookworm
node:20.18.0-bullseye-slim             ->  node:20.18.0-bookworm-slim
```

A plain base-image bump is **not** sufficient — bookworm renamed two runtime libraries and dropped Python 2 entirely:

```
libtiff5           ->  libtiff6
libwebp6           ->  libwebp7
python2            ->  python3
python-is-python2  ->  python-is-python3
```

Every apt package named across all 14 Dockerfiles was checked against the bookworm package index for **both amd64 and arm64** before making the change; those four were the only ones missing.

The Python 2 removal is safe for the frontend build: it was legacy `node-gyp` cruft. The tree uses dart-sass (`sass`), not `node-sass`, and `package.json` has no native modules requiring compilation.

## Verification

All 14 images built clean for `linux/amd64` (matching the CI runners):

| Image | dev | prod |
|---|---|---|
| django | ✅ | ✅ |
| celery | ✅ | ✅ |
| code-upload-worker | ✅ | ✅ |
| nodejs | ✅ | ✅ |
| worker_py3_7 | ✅ | ✅ |
| worker_py3_8 | ✅ | ✅ |
| worker_py3_9 | ✅ | ✅ |

The five light images were additionally built natively for `linux/arm64`.

Because build success alone does not prove runtime linkage, I also diffed the resulting `django` image against a **bullseye baseline built from `master`** (pinned to `snapshot.debian.org` at `20260801T000000Z`, before the pruning, so it could be built at all). Pillow feature flags are byte-for-byte identical:

```
BASELINE (bullseye, master)   Pillow 7.1.0 | tiff: False webp: False jpg: True freetype: True lcms: True
PATCHED  (bookworm, this PR)  Pillow 7.1.0 | tiff: False webp: False jpg: True freetype: True lcms: True
```

Interpreters and native extensions load correctly on bookworm: `psycopg2 2.8.4`, `pycurl`, Python `3.9.21 [GCC 12.2.0]`, `Debian GNU/Linux 12 (bookworm)`.

## Reviewer notes

- **The backend test suite has not finished running locally** — it was still executing when this PR was opened. CI on this PR is the authoritative check for it. Please don't merge on the build evidence alone.
- **`tiff: False` / `webp: False` in Pillow is a pre-existing bug on `master`, not introduced here** — confirmed by the baseline comparison above. The runtime stages install `libwebp7` but not `libwebpmux3`/`libwebpdemux2`, which Pillow's `_webp` extension links against, and bookworm ships `tiff.h` in a multiarch path. Worth a separate issue; deliberately out of scope so this stays a minimal unblock.
- **`worker_py3_7` and `worker_py3_8` remain on EOL Pythons.** Their bookworm base images are stale (last built 2023-09 and 2024-09) and receive no updates. This fixes the apt breakage but does not make those workers supported. They also now build under gcc 12 instead of gcc 10, and pick up Java 17 rather than Java 11 via `default-jre-headless` — worth a sanity check against real challenge evaluation scripts before this reaches production.
- `apt-key` is deprecated in bookworm (used in the nodejs Chrome install). It still works here but is removed in trixie, so it will need replacing with a keyring file at the next bump.
- Not linked to an existing issue — this is an unplanned upstream breakage. Happy to file one if the project prefers a tracking bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every CI and production container base plus native image libraries; worker images may pick up newer gcc and default JRE on bookworm, so runtime behavior should be validated in CI and for evaluation workloads.
> 
> **Overview**
> Moves all **14** dev and prod Docker images off Debian 11 (`bullseye`) to Debian 12 (`bookworm`) so `apt-get` during image builds stops failing as `bullseye-security` packages are pruned and the archive expires.
> 
> Python services switch `python:*-slim-bullseye` to `python:*-slim-bookworm` (3.7, 3.8, 3.9.21); **nodejs** uses `node:20.18.0-bookworm-slim` instead of bullseye-slim. Runtime `apt` lists are updated for bookworm package renames: **`libtiff5` → `libtiff6`** and **`libwebp6` → `libwebp7`** on django, celery, and worker images that install image libs.
> 
> **nodejs** builder stages replace **`python2` / `python-is-python2`** with **`python3` / `python-is-python3`** because bookworm drops Python 2. Application code and install logic are unchanged; only base tags and matching system packages differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9347f6249e8f78f9139cacc9125f68b17533ca42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated application and worker container environments from Debian Bullseye to Bookworm.
  - Updated image libraries for compatibility with the newer base distribution.
  - Replaced Python 2 build tooling with Python 3 in Node.js container builds.
  - Applied these updates consistently across development and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->