### PR TITLE
fix(worker): bump pycocotools to 2.0.7 so uv can install the py3.7/3.8 stack

### DIFF
--- a/requirements/worker_py3_7.txt
+++ b/requirements/worker_py3_7.txt
@@ -7,7 +7,7 @@ matplotlib==3.3.3
 networkx==2.5
 numpy==1.21.0
 pandas==1.1.4
-pycocotools==2.0.2
+pycocotools==2.0.7
 scikit-learn==0.24.0
 scipy==1.5.4
 tqdm==4.54.0

--- a/requirements/worker_py3_8.txt
+++ b/requirements/worker_py3_8.txt
@@ -7,7 +7,7 @@ matplotlib==3.3.3
 networkx==2.5
 numpy==1.21.0
 pandas==1.1.4
-pycocotools==2.0.2
+pycocotools==2.0.7
 scikit-learn==0.24.0
 scipy==1.5.4
 tqdm==4.54.0


### PR DESCRIPTION
## Problem

Submission workers throw `ModuleNotFoundError: No module named 'sklearn'` at challenge-import time after the recent deployments (observed on the **py3.7** worker, `challenge_id 2319`, whose `main.py` does `from sklearn.metrics import r2_score, mean_squared_error` at module load).

scikit-learn is a **worker-baked** dependency (`requirements/worker_py3_7.txt`), not challenge-supplied — so this means the pinned scientific stack is missing from the built image.

## Root cause

The uv migration (#5214) silently stopped installing the **entire** pinned scientific stack in the **py3.7 and py3.8** worker images (`scipy, pandas, scikit-learn, matplotlib, networkx, pycocotools, tqdm`), leaving `numpy` at the pre-installed `1.18.1` and `networkx` at `2.4` (from `common.txt`).

Both files pinned `pycocotools==2.0.2`, which ships **no wheels**, so uv builds it from the sdist. pycocotools 2.0.2's legacy `setup.py` resolves its numpy build dep via setuptools' `fetch_build_eggs`, which shells `python -m pip wheel numpy` **inside uv's isolated PEP 517 build env**. uv provisions only the build backend there — **no `pip`** — so the call dies with `No module named pip` and the build fails. Because **uv installs atomically**, that single failure aborts the whole requirements file. pip's build isolation seeds pip, which is why this worked before #5214.

## Verification (uv 0.12.9, `python:3.{7,8,9}-slim-bookworm`, amd64)

| worker | pycocotools | `uv pip install -r worker_*.txt` | scientific stack |
|--------|-------------|----------------------------------|------------------|
| py3.7  | `2.0.2`     | **exit 1** (pycocotools build fail) | **all missing** |
| py3.8  | `2.0.2`     | **exit 1** | **all missing** |
| py3.9  | `2.0.7`     | exit 0 | all present |

Confirmed against the actual built `docker/prod/worker_py3_7/Dockerfile` image: `import sklearn` → `ModuleNotFoundError`, plus scipy/pandas/matplotlib/pycocotools/tqdm all absent, numpy stuck at 1.18.1.

## Fix

Bump `pycocotools` `2.0.2 → 2.0.7` in `worker_py3_7.txt` and `worker_py3_8.txt`. 2.0.7 ships **cp37/cp38 manylinux2014 wheels** (x86_64 + aarch64) → no source build → no uv build-isolation problem. This is the **same version py3.9 already uses** (unaffected by this bug).

After the bump, both files install green under uv and `numpy/scipy/pandas/scikit-learn/matplotlib/networkx/pycocotools/tqdm` all import.

## Notes

- py3.9 worker needs no change.
- Alternatives considered: `--no-build-isolation` (broader, needs build deps in the system env) or reverting py3.7/3.8 to pip (as `docker/dev/worker_py3_7` already is). The wheel-backed version bump is the smallest, most robust fix and keeps all workers on uv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pinned deps for production submission worker images; impact is limited to aligning with py3.9 and restoring the intended baked stack after rebuild.
> 
> **Overview**
> Bumps **`pycocotools`** from **`2.0.2` → `2.0.7`** in `requirements/worker_py3_7.txt` and `requirements/worker_py3_8.txt`, matching the py3.9 worker pin.
> 
> The older pin has no wheels on 3.7/3.8, so **uv** fails while building it from source (PEP 517 isolation without `pip`), and **atomic install** drops the rest of the baked stack (`scikit-learn`, `scipy`, `pandas`, etc.). **2.0.7** installs from manylinux wheels so the full pinned scientific dependencies land in the rebuilt worker images again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11ae3cb08c2b72f4d8ec235798b1ad3a65586495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the bundled computer vision tooling to a newer version for Python 3.7 and 3.8 worker environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->