### PR TITLE
fix(worker): derive permissive pip constraints for challenge installs

### DIFF
--- a/docs/source/02-for-challenge-hosts/evaluation/evaluation-scripts.md
+++ b/docs/source/02-for-challenge-hosts/evaluation/evaluation-scripts.md
@@ -105,10 +105,13 @@ applies a derived pip constraint to every challenge install:
 ### Relaxing a pin (`worker_constraint_overrides.txt`)
 
 If you need a version the derived constraint still blocks, add a
-`worker_constraint_overrides.txt` file to your evaluation-script zip listing the
-package names to drop from the worker pins — one per line, `#` comments allowed:
+`worker_constraint_overrides.txt` file to the **root** of your evaluation-script
+zip (next to `__init__.py`, the same place as `requirements.txt`) listing the
+package names to drop from the worker pins — one per line, `#` comments allowed.
+The worker only reads this file from the zip root; a copy in a subdirectory is
+ignored and every pin stays in force:
 
-```
+```text
 # take full control of these versions for this challenge
 scipy
 tqdm

--- a/docs/source/02-for-challenge-hosts/evaluation/evaluation-scripts.md
+++ b/docs/source/02-for-challenge-hosts/evaluation/evaluation-scripts.md
@@ -84,6 +84,41 @@ Let's break down what is happening in the above code snippet.
 2. Each entry in the list should be a dict that has a key with the corresponding dataset split codename (`train_split` and `test_split` for this example).
 3. Each of these dataset split dict contains various keys (`Metric1`, `Metric2`, `Metric3`, `Total` in this example), which are then displayed as columns in the leaderboard.
 
+## Custom Python Dependencies
+
+If your evaluation script needs extra Python packages, ship a `requirements.txt`
+in the root of your evaluation-script zip (next to `__init__.py`). The worker
+installs it before importing your script. Packages your `__init__.py` installs
+at import time (via a helper such as `pip install ...`) are handled the same way.
+
+The worker image bakes a shared scientific stack (numpy, scipy, pandas,
+scikit-learn, matplotlib, tqdm, ...). To keep those installs safe, the worker
+applies a derived pip constraint to every challenge install:
+
+- **numpy is capped** below its next major version. Its C-ABI is the foundation
+  the baked scipy/scikit-learn/pandas/pycocotools are compiled against, so
+  moving numpy across a major version breaks them.
+- **Every other baked package is a floor, not a lock.** You may install a
+  *newer* version (e.g. a dependency that needs `scipy>=1.13.1` or
+  `tqdm>=4.67.3` resolves fine); you just cannot go below the baked version.
+
+### Relaxing a pin (`worker_constraint_overrides.txt`)
+
+If you need a version the derived constraint still blocks, add a
+`worker_constraint_overrides.txt` file to your evaluation-script zip listing the
+package names to drop from the worker pins — one per line, `#` comments allowed:
+
+```
+# take full control of these versions for this challenge
+scipy
+tqdm
+```
+
+Listed packages are left entirely to your `requirements.txt` / installer to
+resolve. **Relaxing `numpy` is risky**: unless your script reinstalls the rest
+of the compiled stack too, a numpy major bump will break the baked C
+extensions. Relax it only if you know your dependencies need it.
+
 ## Editing Evaluation Script
 
 Each prediction upload challenge has an evaluation script, which evaluates the submission of participants and returns the scores which will populate the leaderboard. The logic for evaluating a submission is customizable and varies from challenge to challenge.

--- a/requirements/worker_py3_7.txt
+++ b/requirements/worker_py3_7.txt
@@ -1,8 +1,13 @@
 # Default-provided worker stack (Python 3.7). These packages are baked into every
-# submission worker image and pinned. Challenge requirements.txt and the
-# evaluation_script install() helper are constrained to these versions
-# (PIP_CONSTRAINT), so a challenge cannot move them. To add or bump a shared
-# package, open a PR against this file so the base image is rebuilt and tested.
+# submission worker image and pinned here for reproducible image builds.
+# Challenge requirements.txt and the evaluation_script install() helper do NOT
+# receive these exact pins: the worker derives a permissive constraint from this
+# file (numpy is capped below the next major for C-extension ABI safety; every
+# other package becomes a >= floor a challenge may upgrade past) and exports it
+# as PIP_CONSTRAINT. A challenge may drop a pin entirely by shipping a
+# worker_constraint_overrides.txt in its evaluation-script zip. To add or bump a
+# shared package, open a PR against this file so the base image is rebuilt and
+# tested.
 matplotlib==3.3.3
 networkx==2.5
 numpy==1.21.0

--- a/requirements/worker_py3_8.txt
+++ b/requirements/worker_py3_8.txt
@@ -1,8 +1,13 @@
 # Default-provided worker stack (Python 3.8). These packages are baked into every
-# submission worker image and pinned. Challenge requirements.txt and the
-# evaluation_script install() helper are constrained to these versions
-# (PIP_CONSTRAINT), so a challenge cannot move them. To add or bump a shared
-# package, open a PR against this file so the base image is rebuilt and tested.
+# submission worker image and pinned here for reproducible image builds.
+# Challenge requirements.txt and the evaluation_script install() helper do NOT
+# receive these exact pins: the worker derives a permissive constraint from this
+# file (numpy is capped below the next major for C-extension ABI safety; every
+# other package becomes a >= floor a challenge may upgrade past) and exports it
+# as PIP_CONSTRAINT. A challenge may drop a pin entirely by shipping a
+# worker_constraint_overrides.txt in its evaluation-script zip. To add or bump a
+# shared package, open a PR against this file so the base image is rebuilt and
+# tested.
 matplotlib==3.3.3
 networkx==2.5
 numpy==1.21.0

--- a/requirements/worker_py3_9.txt
+++ b/requirements/worker_py3_9.txt
@@ -1,8 +1,13 @@
 # Default-provided worker stack (Python 3.9). These packages are baked into every
-# submission worker image and pinned. Challenge requirements.txt and the
-# evaluation_script install() helper are constrained to these versions
-# (PIP_CONSTRAINT), so a challenge cannot move them. To add or bump a shared
-# package, open a PR against this file so the base image is rebuilt and tested.
+# submission worker image and pinned here for reproducible image builds.
+# Challenge requirements.txt and the evaluation_script install() helper do NOT
+# receive these exact pins: the worker derives a permissive constraint from this
+# file (numpy is capped below the next major for C-extension ABI safety; every
+# other package becomes a >= floor a challenge may upgrade past) and exports it
+# as PIP_CONSTRAINT. A challenge may drop a pin entirely by shipping a
+# worker_constraint_overrides.txt in its evaluation-script zip. To add or bump a
+# shared package, open a PR against this file so the base image is rebuilt and
+# tested.
 matplotlib==3.8.4
 cfn-lint==0.79.5
 networkx==3.2.1

--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -537,13 +537,26 @@ def configure_challenge_pip_environment(
             )
 
     if relaxed_packages:
-        logger.warning(
-            "{0} Challenge relaxed worker pip constraints for: {1}. The "
-            "challenge owns those versions; relaxing numpy can break the "
-            "worker's compiled C extensions.".format(
-                WORKER_LOGS_PREFIX, ", ".join(sorted(relaxed_packages))
+        relaxed_names = ", ".join(sorted(relaxed_packages))
+        if effective_path != manifest_path:
+            logger.warning(
+                "{0} Challenge relaxed worker pip constraints for: {1}. The "
+                "challenge owns those versions; relaxing numpy can break the "
+                "worker's compiled C extensions.".format(
+                    WORKER_LOGS_PREFIX, relaxed_names
+                )
             )
-        )
+        else:
+            # The derived file could not be written, so the exact manifest is in
+            # force and still pins every package. Do not claim the constraints
+            # were relaxed — that would mislead anyone debugging a resolution
+            # failure.
+            logger.warning(
+                "{0} Challenge requested relaxing pip constraints for {1}, but "
+                "the derived constraints file could not be written; the exact "
+                "worker manifest is in force and those pins are still "
+                "enforced.".format(WORKER_LOGS_PREFIX, relaxed_names)
+            )
 
     os.environ["PIP_CONSTRAINT"] = effective_path
     os.environ["PIP_BUILD_CONSTRAINT"] = effective_path

--- a/scripts/workers/submission_worker.py
+++ b/scripts/workers/submission_worker.py
@@ -19,6 +19,7 @@ import time
 import traceback
 import zipfile
 from os.path import join
+from typing import List, Optional, Set
 
 import django
 import requests
@@ -362,26 +363,191 @@ def get_challenge_pip_constraints_file():
     return None
 
 
-def configure_challenge_pip_environment():
-    """Force every pip invocation in the worker to honor the core dependency
-    pins.
+# Only numpy is ABI-critical for the baked worker stack: moving it across a
+# major version breaks every C-extension compiled against it (scipy,
+# scikit-learn, pandas, pycocotools). numpy therefore keeps a hard ceiling
+# below the next major; every other worker pin is emitted as a ``>=`` floor a
+# challenge may upgrade past. Map of canonical package name -> exclusive major
+# ceiling.
+PIP_CONSTRAINT_ABI_CEILINGS = {"numpy": "2"}
 
-    Both challenge dependency paths run pip: the ``requirements.txt`` install in
+# A challenge may ship this file alongside ``requirements.txt`` in its
+# evaluation-script zip to drop the worker's pin for the listed packages,
+# taking full responsibility for those versions.
+CHALLENGE_CONSTRAINT_OVERRIDES_FILENAME = "worker_constraint_overrides.txt"
+
+# Derived, challenge-facing constraints written into the challenge data dir.
+EFFECTIVE_PIP_CONSTRAINTS_FILENAME = "pip_constraints.effective.txt"
+
+# Characters that begin a version specifier / marker in a requirement line.
+_REQUIREMENT_NAME_SEPARATORS = ("<", ">", "=", "!", "~", ";", "[", " ", "\t")
+
+
+def _canonical_package_name(name):
+    """Normalize a distribution name for case/separator-insensitive matching."""
+    return name.strip().lower().replace("_", "-")
+
+
+def _requirement_project_name(specifier):
+    """Return the bare project name from a requirement specifier.
+
+    ``scipy`` -> ``scipy``; ``scipy>=1.13`` -> ``scipy``; ``PyYaml==5.4.1`` ->
+    ``PyYaml`` (case preserved for display, callers canonicalize as needed).
+    """
+    name = specifier
+    for separator in _REQUIREMENT_NAME_SEPARATORS:
+        name = name.split(separator, 1)[0]
+    return name.strip()
+
+
+def build_challenge_pip_constraint_lines(
+    manifest_path: str, relaxed_packages: Set[str]
+) -> List[str]:
+    """Derive challenge-facing pip constraint lines from the worker manifest.
+
+    The worker image bakes an exact-pinned scientific stack (``manifest_path``)
+    for reproducible builds. Forcing those exact pins onto challenge installs is
+    too strict — it blocks a challenge from *upgrading* a pure-Python or
+    forward-compatible package (e.g. ``darts-devkit`` needs ``tqdm>=4.67.3`` and
+    ``scipy>=1.13.1``; an exact pin makes pip resolution impossible).
+
+    Only numpy is ABI-critical (see ``PIP_CONSTRAINT_ABI_CEILINGS``): moving it
+    across a major version breaks every C-extension compiled against the baked
+    numpy. So capped packages keep a floor plus a hard ceiling, and every other
+    manifest pin becomes a ``>=`` floor that permits upgrades — a challenge dep
+    that in turn needs a newer numpy then fails cleanly at resolve time rather
+    than breaking silently at import. Packages named in ``relaxed_packages`` are
+    dropped entirely, leaving the challenge fully in control of them.
+    """
+    lines: List[str] = []
+    with open(manifest_path, "r") as manifest:
+        for raw_line in manifest:
+            stripped = raw_line.split("#", 1)[0].strip()
+            if not stripped or "==" not in stripped:
+                continue
+            display_name, _, version = stripped.partition("==")
+            display_name = display_name.strip()
+            version = version.strip()
+            canonical = _canonical_package_name(display_name)
+            if canonical in relaxed_packages:
+                continue
+            ceiling = PIP_CONSTRAINT_ABI_CEILINGS.get(canonical)
+            if ceiling:
+                lines.append(
+                    "{0}>={1},<{2}".format(display_name, version, ceiling)
+                )
+            else:
+                lines.append("{0}>={1}".format(display_name, version))
+    return lines
+
+
+def read_challenge_constraint_overrides(
+    challenge_data_directory: Optional[str],
+) -> Set[str]:
+    """Return canonical names a challenge asked to drop from the worker pins.
+
+    Reads ``worker_constraint_overrides.txt`` from the challenge's extracted
+    evaluation-script directory if present. One package per line; ``#`` comments
+    and blank lines are ignored. A line may be a bare name (``scipy``) or a full
+    specifier (``scipy>=1.13``) — only the project name is used for matching.
+    """
+    if not challenge_data_directory:
+        return set()
+    overrides_path = join(
+        challenge_data_directory, CHALLENGE_CONSTRAINT_OVERRIDES_FILENAME
+    )
+    if not os.path.isfile(overrides_path):
+        return set()
+    relaxed: Set[str] = set()
+    try:
+        with open(overrides_path, "r") as handle:
+            for raw_line in handle:
+                token = raw_line.split("#", 1)[0].strip()
+                if not token:
+                    continue
+                name = _requirement_project_name(token)
+                if name:
+                    relaxed.add(_canonical_package_name(name))
+    except OSError as exc:
+        logger.warning(
+            "{0} Could not read challenge pip constraint overrides at {1} "
+            "({2}); enforcing the full worker pin set.".format(
+                WORKER_LOGS_PREFIX, overrides_path, exc
+            )
+        )
+        return set()
+    return relaxed
+
+
+def configure_challenge_pip_environment(
+    challenge_data_directory: Optional[str] = None,
+) -> Optional[str]:
+    """Build the effective challenge pip constraints and export them.
+
+    Derives a permissive constraints file from the worker's pinned manifest
+    (see ``build_challenge_pip_constraint_lines``) so a challenge may upgrade
+    non-ABI-critical packages while numpy stays capped, honoring any
+    per-challenge override file (``worker_constraint_overrides.txt``). Both
+    challenge dependency paths run pip: the ``requirements.txt`` install in
     ``extract_challenge_data`` and the ``install()`` helper shipped inside a
     challenge's ``evaluation_script/__init__.py`` (which runs
     ``sys.executable -m pip install`` at import time). Exporting
-    ``PIP_CONSTRAINT``/``PIP_BUILD_CONSTRAINT`` into the process environment
-    makes *both* subprocesses inherit the constraint, so a challenge cannot move
-    numpy/scipy/etc. off the worker's already-compiled core stack.
+    ``PIP_CONSTRAINT``/``PIP_BUILD_CONSTRAINT`` makes *both* subprocesses
+    inherit the derived constraints.
 
-    Returns the constraints file path applied, or ``None`` if no per-version
-    constraints file was found (environment left untouched).
+    Returns the effective constraints file path applied, or ``None`` when no
+    manifest is found (environment left untouched, preserving prior behavior).
     """
-    constraints_file = get_challenge_pip_constraints_file()
-    if constraints_file:
-        os.environ["PIP_CONSTRAINT"] = constraints_file
-        os.environ["PIP_BUILD_CONSTRAINT"] = constraints_file
-    return constraints_file
+    manifest_path = get_challenge_pip_constraints_file()
+    if not manifest_path:
+        return None
+
+    relaxed_packages = read_challenge_constraint_overrides(
+        challenge_data_directory
+    )
+    constraint_lines = build_challenge_pip_constraint_lines(
+        manifest_path, relaxed_packages
+    )
+
+    # Fall back to the exact manifest so installs stay constrained even when the
+    # derived file cannot be written (e.g. no challenge dir available).
+    effective_path = manifest_path
+    if challenge_data_directory:
+        candidate = join(
+            challenge_data_directory, EFFECTIVE_PIP_CONSTRAINTS_FILENAME
+        )
+        try:
+            with open(candidate, "w") as handle:
+                handle.write(
+                    "# Auto-generated challenge pip constraints derived from "
+                    "{0}.\n# numpy is capped for ABI safety; other worker "
+                    "packages are floors\n# a challenge may upgrade past.\n".format(
+                        os.path.basename(manifest_path)
+                    )
+                )
+                handle.write("\n".join(constraint_lines))
+                handle.write("\n")
+            effective_path = candidate
+        except OSError as exc:
+            logger.warning(
+                "{0} Could not write derived pip constraints to {1} ({2}); "
+                "falling back to the exact worker manifest.".format(
+                    WORKER_LOGS_PREFIX, candidate, exc
+                )
+            )
+
+    if relaxed_packages:
+        logger.warning(
+            "{0} Challenge relaxed worker pip constraints for: {1}. The "
+            "challenge owns those versions; relaxing numpy can break the "
+            "worker's compiled C extensions.".format(
+                WORKER_LOGS_PREFIX, ", ".join(sorted(relaxed_packages))
+            )
+        )
+
+    os.environ["PIP_CONSTRAINT"] = effective_path
+    os.environ["PIP_BUILD_CONSTRAINT"] = effective_path
+    return effective_path
 
 
 def extract_challenge_data(challenge, phases):
@@ -390,11 +556,6 @@ def extract_challenge_data(challenge, phases):
     * Extracts `evaluation_script` for challenge and `annotation_file` for each phase
 
     """
-
-    # Pin the core dependency stack for every pip path (requirements.txt and the
-    # challenge __init__.py install() helper) before any challenge dependency is
-    # installed or the challenge module is imported.
-    configure_challenge_pip_environment()
 
     challenge_data_directory = CHALLENGE_DATA_DIR.format(
         challenge_id=challenge.id
@@ -417,6 +578,16 @@ def extract_challenge_data(challenge, phases):
         evaluation_script_url, challenge_zip_file, challenge_data_directory
     )
 
+    # Derive the challenge-facing pip constraints from the worker's pinned
+    # manifest (numpy capped for ABI safety, other packages floored so a
+    # challenge may upgrade them), honoring any per-challenge override file, and
+    # export them. Runs after the zip is extracted so the override file is
+    # visible, and before both pip paths: the requirements.txt install below and
+    # the challenge __init__.py install() helper that runs at import time.
+    constraints_file = configure_challenge_pip_environment(
+        challenge_data_directory
+    )
+
     requirements_location = join(challenge_data_directory, "requirements.txt")
     if os.path.isfile(requirements_location):
         pip_install_command = [
@@ -427,9 +598,6 @@ def extract_challenge_data(challenge, phases):
             "-r",
             requirements_location,
         ]
-        # Pin the worker's core dependency stack so a challenge cannot
-        # upgrade numpy/scipy/etc. and break already-compiled C extensions.
-        constraints_file = get_challenge_pip_constraints_file()
         if constraints_file:
             pip_install_command += ["-c", constraints_file]
         try:

--- a/tests/unit/worker/test_submission_worker.py
+++ b/tests/unit/worker/test_submission_worker.py
@@ -1588,6 +1588,48 @@ class ConfigureChallengePipEnvironmentTest(APITestCase):
         self.assertNotIn("scipy", body)
         self.assertNotIn("tqdm", body)
 
+    @patch("scripts.workers.submission_worker.logger.warning")
+    @patch(
+        "scripts.workers.submission_worker.get_challenge_pip_constraints_file"
+    )
+    def test_write_failure_falls_back_to_exact_manifest(
+        self, mock_constraints, mock_warning
+    ):
+        # If the derived constraints file cannot be written, installs must fall
+        # back to the exact-pinned manifest (the strictest, safe outcome) and
+        # the log must NOT claim the constraints were relaxed.
+        challenge_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, challenge_dir, ignore_errors=True)
+        manifest_path = join(challenge_dir, "manifest.txt")
+        with open(manifest_path, "w") as manifest:
+            manifest.write("numpy==1.26.4\nscipy==1.11.4\n")
+        mock_constraints.return_value = manifest_path
+        with open(
+            join(challenge_dir, "worker_constraint_overrides.txt"), "w"
+        ) as overrides:
+            overrides.write("scipy\n")
+
+        real_open = open
+
+        def fail_on_effective_write(path, *args, **kwargs):
+            if str(path).endswith("pip_constraints.effective.txt"):
+                raise OSError("read-only file system")
+            return real_open(path, *args, **kwargs)
+
+        with patch("builtins.open", side_effect=fail_on_effective_write):
+            returned = configure_challenge_pip_environment(challenge_dir)
+
+        # Fell back to the exact manifest, and both env vars point at it.
+        self.assertEqual(returned, manifest_path)
+        self.assertEqual(os.environ["PIP_CONSTRAINT"], manifest_path)
+        self.assertEqual(os.environ["PIP_BUILD_CONSTRAINT"], manifest_path)
+        # The relaxation warning must reflect that pins are still enforced.
+        warnings = " ".join(
+            str(call.args[0]) for call in mock_warning.call_args_list
+        )
+        self.assertIn("still", warnings)
+        self.assertNotIn("owns those versions", warnings)
+
 
 class BuildChallengePipConstraintLinesTest(TestCase):
     MANIFEST = (

--- a/tests/unit/worker/test_submission_worker.py
+++ b/tests/unit/worker/test_submission_worker.py
@@ -42,6 +42,7 @@ from scripts.workers.submission_worker import (
     GracefulKiller,
     MultiOut,
     alarm_handler,
+    build_challenge_pip_constraint_lines,
     configure_challenge_pip_environment,
     create_dir,
     create_dir_as_python_package,
@@ -57,6 +58,7 @@ from scripts.workers.submission_worker import (
     main,
     process_add_challenge_message,
     process_submission_message,
+    read_challenge_constraint_overrides,
     return_file_url_per_environment,
     run_submission,
     serialize_submission_artifact,
@@ -1519,19 +1521,21 @@ class ConfigureChallengePipEnvironmentTest(APITestCase):
         "scripts.workers.submission_worker.get_challenge_pip_constraints_file"
     )
     def test_sets_both_pip_constraint_env_vars(self, mock_constraints):
-        mock_constraints.return_value = "/code/requirements/worker_py3_9.txt"
+        # With no challenge directory to write a derived file into, the exact
+        # manifest is used as the fallback constraint and exported to both vars.
+        manifest = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".txt", delete=False
+        )
+        manifest.write("numpy==1.26.4\ntqdm==4.67.1\n")
+        manifest.close()
+        self.addCleanup(os.remove, manifest.name)
+        mock_constraints.return_value = manifest.name
 
         returned = configure_challenge_pip_environment()
 
-        self.assertEqual(returned, "/code/requirements/worker_py3_9.txt")
-        self.assertEqual(
-            os.environ["PIP_CONSTRAINT"],
-            "/code/requirements/worker_py3_9.txt",
-        )
-        self.assertEqual(
-            os.environ["PIP_BUILD_CONSTRAINT"],
-            "/code/requirements/worker_py3_9.txt",
-        )
+        self.assertEqual(returned, manifest.name)
+        self.assertEqual(os.environ["PIP_CONSTRAINT"], manifest.name)
+        self.assertEqual(os.environ["PIP_BUILD_CONSTRAINT"], manifest.name)
 
     @patch(
         "scripts.workers.submission_worker.get_challenge_pip_constraints_file"
@@ -1551,6 +1555,112 @@ class ConfigureChallengePipEnvironmentTest(APITestCase):
             os.environ["PIP_BUILD_CONSTRAINT"],
             "/existing/build-constraints.txt",
         )
+
+    @patch(
+        "scripts.workers.submission_worker.get_challenge_pip_constraints_file"
+    )
+    def test_writes_derived_file_and_honors_overrides(self, mock_constraints):
+        # With a challenge directory, a derived constraints file is written
+        # there (numpy capped, others floored) honoring the override file, and
+        # both pip env vars point at the derived file rather than the manifest.
+        challenge_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, challenge_dir, ignore_errors=True)
+        manifest_path = join(challenge_dir, "manifest.txt")
+        with open(manifest_path, "w") as manifest:
+            manifest.write("numpy==1.26.4\nscipy==1.11.4\ntqdm==4.67.1\n")
+        mock_constraints.return_value = manifest_path
+        with open(
+            join(challenge_dir, "worker_constraint_overrides.txt"), "w"
+        ) as overrides:
+            overrides.write(
+                "# darts-devkit needs newer scipy/tqdm\nscipy\ntqdm\n"
+            )
+
+        returned = configure_challenge_pip_environment(challenge_dir)
+
+        self.assertTrue(returned.endswith("pip_constraints.effective.txt"))
+        self.assertEqual(os.environ["PIP_CONSTRAINT"], returned)
+        self.assertEqual(os.environ["PIP_BUILD_CONSTRAINT"], returned)
+        with open(returned) as handle:
+            body = handle.read()
+        # numpy stays capped; relaxed packages are dropped entirely.
+        self.assertIn("numpy>=1.26.4,<2", body)
+        self.assertNotIn("scipy", body)
+        self.assertNotIn("tqdm", body)
+
+
+class BuildChallengePipConstraintLinesTest(TestCase):
+    MANIFEST = (
+        "# header comment\n"
+        "matplotlib==3.8.4\n"
+        "numpy==1.26.4\n"
+        "\n"
+        "scipy==1.11.4\n"
+        "tqdm==4.67.1  # progress bars\n"
+    )
+
+    def _manifest(self):
+        handle = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".txt", delete=False
+        )
+        handle.write(self.MANIFEST)
+        handle.close()
+        self.addCleanup(os.remove, handle.name)
+        return handle.name
+
+    def test_numpy_capped_and_others_floored(self):
+        lines = build_challenge_pip_constraint_lines(self._manifest(), set())
+
+        self.assertIn("numpy>=1.26.4,<2", lines)
+        self.assertIn("scipy>=1.11.4", lines)
+        self.assertIn("tqdm>=4.67.1", lines)
+        self.assertIn("matplotlib>=3.8.4", lines)
+        # A floor (not an exact pin) is what lets darts-devkit pull
+        # tqdm>=4.67.3 / scipy>=1.13.1 instead of failing to resolve.
+        self.assertFalse(any("==" in line for line in lines))
+
+    def test_relaxed_packages_are_dropped(self):
+        lines = build_challenge_pip_constraint_lines(
+            self._manifest(), {"scipy", "tqdm"}
+        )
+
+        joined = "\n".join(lines)
+        self.assertIn("numpy>=1.26.4,<2", joined)
+        self.assertNotIn("scipy", joined)
+        self.assertNotIn("tqdm", joined)
+
+    def test_comments_and_blank_lines_ignored(self):
+        lines = build_challenge_pip_constraint_lines(self._manifest(), set())
+
+        self.assertEqual(len(lines), 4)
+
+
+class ReadChallengeConstraintOverridesTest(TestCase):
+    def test_none_directory_returns_empty(self):
+        self.assertEqual(read_challenge_constraint_overrides(None), set())
+
+    def test_missing_file_returns_empty(self):
+        empty_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, empty_dir, ignore_errors=True)
+        self.assertEqual(read_challenge_constraint_overrides(empty_dir), set())
+
+    def test_parses_names_specifiers_and_comments(self):
+        challenge_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, challenge_dir, ignore_errors=True)
+        with open(
+            join(challenge_dir, "worker_constraint_overrides.txt"), "w"
+        ) as handle:
+            handle.write(
+                "# relax the ones darts-devkit needs\n"
+                "scipy\n"
+                "tqdm>=4.67.3\n"
+                "scikit_learn\n"
+                "\n"
+            )
+
+        relaxed = read_challenge_constraint_overrides(challenge_dir)
+
+        self.assertEqual(relaxed, {"scipy", "tqdm", "scikit-learn"})
 
 
 class ExtractChallengeDataConstraintEnvTest(APITestCase):
@@ -1577,7 +1687,9 @@ class ExtractChallengeDataConstraintEnvTest(APITestCase):
     ):
         # Fail if the challenge module is imported before the pip environment
         # is configured (the install() helper runs at import time).
-        mock_configure.side_effect = mock_import.assert_not_called
+        mock_configure.side_effect = lambda *args, **kwargs: (
+            mock_import.assert_not_called()
+        )
 
         challenge = MagicMock()
         challenge.id = 356
@@ -1589,7 +1701,11 @@ class ExtractChallengeDataConstraintEnvTest(APITestCase):
 
         extract_challenge_data(challenge, [phase])
 
-        mock_configure.assert_called_once_with()
+        # Now called with the extracted challenge directory so the derived
+        # constraints (and any per-challenge override file) can be built.
+        mock_configure.assert_called_once()
+        (constraint_arg,) = mock_configure.call_args[0]
+        self.assertTrue(constraint_arg.endswith("challenge_356"))
         mock_import.assert_called_once()
 
 

--- a/tests/unit/worker/test_submission_worker.py
+++ b/tests/unit/worker/test_submission_worker.py
@@ -1627,7 +1627,8 @@ class ConfigureChallengePipEnvironmentTest(APITestCase):
         warnings = " ".join(
             str(call.args[0]) for call in mock_warning.call_args_list
         )
-        self.assertIn("still", warnings)
+        self.assertIn("exact worker manifest is in force", warnings)
+        self.assertIn("those pins are still enforced", warnings)
         self.assertNotIn("owns those versions", warnings)
 
 


### PR DESCRIPTION
## Problem

Challenge submission workers fail to load challenges whose dependencies need a **newer** version of any package in the worker's baked core stack.

The worker exports its exact-pinned manifest (`requirements/worker_py3_*.txt`) as `PIP_CONSTRAINT`/`PIP_BUILD_CONSTRAINT`, so every challenge pip path — the `requirements.txt` install **and** the `evaluation_script/__init__.py` `install()` helper — inherits hard `==` pins on the whole stack. A `==` constraint is both floor and ceiling, so a challenge cannot upgrade a pinned package even when doing so is safe.

Concrete failure (challenge 2718): it installs `darts-devkit==1.1.2`, which requires `tqdm>=4.67.3` and `scipy>=1.13.1`, against pins `tqdm==4.67.1` / `scipy==1.11.4`:

```
ERROR: Cannot install darts-devkit==1.1.2 because these package versions have conflicting dependencies.
darts-devkit 1.1.2 depends on tqdm>=4.67.3
The user requested (constraint) tqdm==4.67.1
```

→ `darts-devkit` never installs → `ModuleNotFoundError: No module named 'darts_devkit'` at import.

## Fix

Only **numpy** is genuinely ABI-critical: the baked scipy/scikit-learn/pandas/pycocotools are compiled against its 1.x C-ABI, so a numpy major bump breaks them. So rather than forcing the exact manifest onto challenges, the worker now **derives** a challenge-facing constraint from it:

- **numpy** keeps a hard ceiling — `numpy>=<baked>,<2`.
- **every other package** becomes a `>=` floor a challenge may upgrade past. A dependency that in turn needs numpy 2.x then fails cleanly at resolve time instead of breaking silently at import.

This unblocks challenge 2718 with **no host action** (the floors let `tqdm>=4.67.3` / `scipy>=1.13.1` resolve while numpy stays 1.26.4).

The exact manifest is untouched, so reproducible image builds (`uv pip install -r`) and the Dockerfile `PIP_CONSTRAINT` baseline are unaffected.

### Host escape hatch

For a version a floor still blocks, a challenge may ship a `worker_constraint_overrides.txt` in its evaluation-script zip listing package names to drop from the worker pins entirely (one per line, `#` comments allowed). Relaxing `numpy` is logged as risky (it can break the compiled stack unless the challenge reinstalls it).

## Changes

- `scripts/workers/submission_worker.py`: add `build_challenge_pip_constraint_lines` + `read_challenge_constraint_overrides`; rewrite `configure_challenge_pip_environment` to build/write the derived constraints after zip extraction and export them; feed the derived file to the `requirements.txt` install's `-c`.
- `requirements/worker_py3_{7,8,9}.txt`: correct header comments (exact pins are the baked image manifest; challenge installs get the derived floors).
- `docs/.../evaluation-scripts.md`: document custom dependencies + the override file for hosts.
- `tests/unit/worker/test_submission_worker.py`: derivation (numpy capped / others floored / overrides dropped), override parsing, end-to-end derived file + env export.

## Reviewer notes

- **Deploy:** this is a code change, not an image change — no worker image rebuild is required. The fix takes effect once a worker running this revision re-runs `load_challenge` for the challenge.
- If `darts-devkit` also needs numpy 2.x (not verified here), that challenge would additionally list `numpy` in `worker_constraint_overrides.txt` and take responsibility for the ABI.

## Verification

- `pytest tests/unit/worker/test_submission_worker.py tests/unit/worker/test_worker_pip_constraints.py` — 243 passed (py3.9, `settings.test`).
- `ruff check` clean; pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every challenge’s evaluation dependencies are constrained at install time; mis-derived constraints or overrides (especially numpy) could break worker imports, though fallbacks and numpy capping limit worst-case impact.
> 
> **Overview**
> Challenge evaluation workers no longer export the worker image’s **exact** `==` pins as `PIP_CONSTRAINT` for challenge installs, which blocked pip when a challenge needed a **newer** baked-stack package (e.g. `scipy` / `tqdm` above the image pin).
> 
> **`configure_challenge_pip_environment`** now builds **`pip_constraints.effective.txt`** from the worker manifest after the evaluation-script zip is extracted: **numpy** stays **`>=` baked, `<2`** for C-extension ABI safety; **other manifest packages** become **`>=` floors** so upgrades can resolve. Challenges can list packages in root **`worker_constraint_overrides.txt`** to drop worker pins entirely. **`PIP_CONSTRAINT`** / **`PIP_BUILD_CONSTRAINT`** (and `requirements.txt` **`-c`**) point at the derived file, with fallback to the exact manifest if the derived file cannot be written.
> 
> Host docs describe **`requirements.txt`**, derived constraints, and overrides; **`requirements/worker_py3_*.txt`** comments are updated to match. Unit tests cover derivation, override parsing, env export, and load order before import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46f041910ed8573f79b771b7e5ab63e2a2142634. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Evaluation scripts can include a root-level `requirements.txt` file for custom Python dependencies, which are installed before the script runs.
  - Challenge authors can selectively relax worker package constraints with a root-level `worker_constraint_overrides.txt` file.
  - Dependency constraints now allow compatible package upgrades while preserving NumPy major-version compatibility.

- **Documentation**
  - Added guidance covering custom dependencies, constraint behavior, package upgrade limits, override-file placement, and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->